### PR TITLE
specify archived when retrieving twitch VODs

### DIFF
--- a/bathbot-client/src/twitch.rs
+++ b/bathbot-client/src/twitch.rs
@@ -183,6 +183,7 @@ impl Client {
             ("user_id", Cow::Owned(user_id.to_string())),
             ("first", "1".into()),
             ("sort", "time".into()),
+            ("type", "archive".into()),
         ];
 
         let bytes = self


### PR DESCRIPTION
fixes #41 