### PR TITLE
check permissions more thoroughly depending on what's needed

### DIFF
--- a/bathbot/src/commands/fun/bg_game/hint.rs
+++ b/bathbot/src/commands/fun/bg_game/hint.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bathbot_util::{constants::GENERAL_ISSUE, MessageBuilder};
 use eyre::Result;
-use twilight_model::channel::Message;
+use twilight_model::{channel::Message, guild::Permissions};
 
 use crate::{
     core::{buckets::BucketName, commands::checks::check_ratelimit},
@@ -11,7 +11,11 @@ use crate::{
     Context,
 };
 
-pub async fn hint(ctx: Arc<Context>, msg: &Message) -> Result<()> {
+pub async fn hint(
+    ctx: Arc<Context>,
+    msg: &Message,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let ratelimit = check_ratelimit(&ctx, msg.author.id, BucketName::BgHint).await;
 
     if let Some(cooldown) = ratelimit {
@@ -27,7 +31,7 @@ pub async fn hint(ctx: Arc<Context>, msg: &Message) -> Result<()> {
         Some(GameState::Running { game }) => match game.hint().await {
             Ok(hint) => {
                 let builder = MessageBuilder::new().content(hint);
-                msg.create_message(&ctx, &builder).await?;
+                msg.create_message(&ctx, &builder, permissions).await?;
             }
             Err(err) => {
                 let _ = msg.error(&ctx, GENERAL_ISSUE).await;

--- a/bathbot/src/commands/fun/higherlower_game.rs
+++ b/bathbot/src/commands/fun/higherlower_game.rs
@@ -6,7 +6,7 @@ use std::{
 use bathbot_macros::SlashCommand;
 use bathbot_model::{HlVersion, RankingEntries, RankingEntry, RankingKind};
 use bathbot_util::{constants::GENERAL_ISSUE, IntHasher, MessageBuilder};
-use eyre::{Result, WrapErr};
+use eyre::{ContextCompat, Result, WrapErr};
 use rosu_v2::prelude::GameMode;
 use twilight_interactions::command::{CommandModel, CreateCommand};
 use twilight_model::id::Id;
@@ -78,7 +78,8 @@ async fn slash_higherlower(ctx: Arc<Context>, mut command: InteractionCommand) -
         let builder = MessageBuilder::new().components(components);
 
         (game.msg, game.channel)
-            .update(&ctx, &builder)
+            .update(&ctx, &builder, command.permissions)
+            .wrap_err("lacking permission to update message")?
             .await
             .wrap_err("failed to remove components of previous game")?;
     }

--- a/bathbot/src/commands/osu/compare/common.rs
+++ b/bathbot/src/commands/osu/compare/common.rs
@@ -13,6 +13,7 @@ use rosu_v2::{
     OsuResult,
 };
 use time::OffsetDateTime;
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::{
@@ -37,10 +38,15 @@ use super::{CompareTop, AT_LEAST_ONE};
 #[usage("[name1] [name2]")]
 #[example("badewanne3 \"nathan on osu\"")]
 #[group(Osu)]
-async fn prefix_common(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_common(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = CompareTop::args(None, args);
 
-    top(ctx, msg.into(), args).await
+    top(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 #[command]
@@ -50,10 +56,15 @@ async fn prefix_common(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Resu
 #[example("badewanne3 \"nathan on osu\"")]
 #[alias("commonm")]
 #[group(Mania)]
-async fn prefix_commonmania(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_commonmania(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = CompareTop::args(Some(GameModeOption::Mania), args);
 
-    top(ctx, msg.into(), args).await
+    top(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 #[command]
@@ -63,10 +74,15 @@ async fn prefix_commonmania(ctx: Arc<Context>, msg: &Message, args: Args<'_>) ->
 #[example("badewanne3 \"nathan on osu\"")]
 #[alias("commont")]
 #[group(Taiko)]
-async fn prefix_commontaiko(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_commontaiko(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = CompareTop::args(Some(GameModeOption::Taiko), args);
 
-    top(ctx, msg.into(), args).await
+    top(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 #[command]
@@ -76,10 +92,15 @@ async fn prefix_commontaiko(ctx: Arc<Context>, msg: &Message, args: Args<'_>) ->
 #[example("badewanne3 \"nathan on osu\"")]
 #[aliases("commonc", "commoncatch")]
 #[group(Catch)]
-async fn prefix_commonctb(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_commonctb(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = CompareTop::args(Some(GameModeOption::Catch), args);
 
-    top(ctx, msg.into(), args).await
+    top(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 async fn extract_user_id(ctx: &Context, args: &mut CompareTop<'_>) -> UserExtraction {
@@ -253,9 +274,8 @@ pub(super) async fn top(
 
     // Create the combined profile pictures
     let urls = iter::once(user1.avatar_url()).chain(iter::once(user2.avatar_url()));
-    let thumbnail_result = get_combined_thumbnail(&ctx, urls, 2, None).await;
 
-    let thumbnail = match thumbnail_result {
+    let thumbnail = match get_combined_thumbnail(&ctx, urls, 2, None).await {
         Ok(thumbnail) => Some(thumbnail),
         Err(err) => {
             warn!("{:?}", err.wrap_err("Failed to combine avatars"));

--- a/bathbot/src/commands/osu/compare/profile.rs
+++ b/bathbot/src/commands/osu/compare/profile.rs
@@ -18,6 +18,7 @@ use rosu_v2::{
     prelude::{GameMode, GameMods, OsuError, Score, UserStatistics},
     request::UserId,
 };
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::{
@@ -186,10 +187,15 @@ pub(super) async fn profile(
 #[example("badewanne3 5joshi")]
 #[aliases("pc", "profilecompareosu", "pco")]
 #[group(Osu)]
-async fn prefix_profilecompare(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_profilecompare(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = CompareProfile::args(None, args);
 
-    profile(ctx, msg.into(), args).await
+    profile(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 #[command]
@@ -208,10 +214,11 @@ async fn prefix_profilecomparemania(
     ctx: Arc<Context>,
     msg: &Message,
     args: Args<'_>,
+    permissions: Option<Permissions>,
 ) -> Result<()> {
     let args = CompareProfile::args(Some(GameModeOption::Mania), args);
 
-    profile(ctx, msg.into(), args).await
+    profile(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 #[command]
@@ -230,10 +237,11 @@ async fn prefix_profilecomparetaiko(
     ctx: Arc<Context>,
     msg: &Message,
     args: Args<'_>,
+    permissions: Option<Permissions>,
 ) -> Result<()> {
     let args = CompareProfile::args(Some(GameModeOption::Taiko), args);
 
-    profile(ctx, msg.into(), args).await
+    profile(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 #[command]
@@ -248,10 +256,15 @@ async fn prefix_profilecomparetaiko(
 #[example("badewanne3 5joshi")]
 #[aliases("pcc", "profilecomparecatch")]
 #[group(Catch)]
-async fn prefix_profilecomparectb(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_profilecomparectb(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = CompareProfile::args(Some(GameModeOption::Catch), args);
 
-    profile(ctx, msg.into(), args).await
+    profile(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 pub struct CompareResult {
     pub mode: GameMode,

--- a/bathbot/src/commands/osu/map.rs
+++ b/bathbot/src/commands/osu/map.rs
@@ -261,9 +261,7 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
 
     let map_id = if let Some(id) = map {
         id
-    } else if orig.permissions().map_or(true, |permissions| {
-        permissions.contains(Permissions::READ_MESSAGE_HISTORY)
-    }) {
+    } else if orig.can_read_history() {
         let msgs = match ctx.retrieve_channel_history(orig.channel_id()).await {
             Ok(msgs) => msgs,
             Err(err) => {
@@ -285,7 +283,7 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
         }
     } else {
         let content =
-            "No beatmap specified and lacking permission to search the channel history for maps. \
+            "No beatmap specified and lacking permission to search the channel history for maps.\n\
             Try specifying a map(set) either by url to the map, \
             or just by map(set) id, or give me the \"Read Message History\" permission.";
 

--- a/bathbot/src/commands/osu/map.rs
+++ b/bathbot/src/commands/osu/map.rs
@@ -19,7 +19,10 @@ use plotters_backend::{BackendColor, BackendCoord, BackendStyle, DrawingErrorKin
 use rosu_pp::{BeatmapExt, Strains};
 use rosu_v2::prelude::{GameMode, GameMods, OsuError};
 use twilight_interactions::command::{CommandModel, CreateCommand};
-use twilight_model::channel::{message::MessageType, Message};
+use twilight_model::{
+    channel::{message::MessageType, Message},
+    guild::Permissions,
+};
 
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
@@ -210,9 +213,14 @@ impl<'a> TryFrom<Map<'a>> for MapArgs<'a> {
 #[examples("2240404 +hddt", "https://osu.ppy.sh/beatmapsets/902425 +hr")]
 #[aliases("m", "beatmap", "maps", "beatmaps", "mapinfo")]
 #[group(AllModes)]
-async fn prefix_map(ctx: Arc<Context>, msg: &Message, args: Args<'_>) -> Result<()> {
+async fn prefix_map(
+    ctx: Arc<Context>,
+    msg: &Message,
+    args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     match MapArgs::args(msg, args) {
-        Ok(args) => map(ctx, msg.into(), args).await,
+        Ok(args) => map(ctx, CommandOrigin::from_msg(msg, permissions), args).await,
         Err(content) => {
             msg.error(&ctx, content).await?;
 
@@ -253,7 +261,9 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
 
     let map_id = if let Some(id) = map {
         id
-    } else {
+    } else if orig.permissions().map_or(true, |permissions| {
+        permissions.contains(Permissions::READ_MESSAGE_HISTORY)
+    }) {
         let msgs = match ctx.retrieve_channel_history(orig.channel_id()).await {
             Ok(msgs) => msgs,
             Err(err) => {
@@ -273,6 +283,13 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
                 return orig.error(&ctx, content).await;
             }
         }
+    } else {
+        let content =
+            "No beatmap specified and lacking permission to search the channel history for maps. \
+            Try specifying a map(set) either by url to the map, \
+            or just by map(set) id, or give me the \"Read Message History\" permission.";
+
+        return orig.error(&ctx, content).await;
     };
 
     let mods = match mods {

--- a/bathbot/src/commands/osu/match_compare.rs
+++ b/bathbot/src/commands/osu/match_compare.rs
@@ -170,7 +170,7 @@ async fn matchcompare(
                     interval.tick().await;
                     command
                         .channel_id
-                        .create_message(&ctx, &embed.into())
+                        .create_message(&ctx, &embed.into(), command.permissions)
                         .await?;
                 }
             }

--- a/bathbot/src/commands/osu/match_live.rs
+++ b/bathbot/src/commands/osu/match_live.rs
@@ -161,6 +161,12 @@ async fn matchlive(
             return orig.error(&ctx, THREADS_UNAVAILABLE).await;
         }
 
+        if !orig.can_create_thread() {
+            let content = "I'm lacking the permission to create public threads";
+
+            return orig.error(&ctx, content).await;
+        }
+
         let kind = ChannelType::GuildPublicThread;
         let archive_dur = AutoArchiveDuration::Day;
         let thread_name = format!("Live tracking match id {match_id}");

--- a/bathbot/src/commands/osu/medals/stats.rs
+++ b/bathbot/src/commands/osu/medals/stats.rs
@@ -16,6 +16,7 @@ use rosu_v2::{
     request::UserId,
 };
 use time::OffsetDateTime;
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::osu::{require_link, user_not_found},
@@ -34,7 +35,12 @@ use super::MedalStats;
 #[examples("badewanne3", r#""im a fancy lad""#)]
 #[alias("ms")]
 #[group(AllModes)]
-async fn prefix_medalstats(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> Result<()> {
+async fn prefix_medalstats(
+    ctx: Arc<Context>,
+    msg: &Message,
+    mut args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = match args.next() {
         Some(arg) => match matcher::get_mention_user(arg) {
             Some(id) => MedalStats {
@@ -49,7 +55,7 @@ async fn prefix_medalstats(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>)
         None => MedalStats::default(),
     };
 
-    stats(ctx, msg.into(), args).await
+    stats(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 pub(super) async fn stats(

--- a/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
@@ -10,6 +10,7 @@ use eyre::{Report, Result, WrapErr};
 use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use plotters::prelude::*;
 use rosu_v2::{prelude::OsuError, request::UserId};
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::osu::user_not_found,
@@ -38,12 +39,13 @@ async fn prefix_countrysnipestats(
     ctx: Arc<Context>,
     msg: &Message,
     mut args: Args<'_>,
+    permissions: Option<Permissions>,
 ) -> Result<()> {
     let args = SnipeCountryStats {
         country: args.next().map(Cow::from),
     };
 
-    country_stats(ctx, msg.into(), args).await
+    country_stats(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 pub(super) async fn country_stats(

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -13,6 +13,7 @@ use rosu_v2::{
     request::UserId,
 };
 use time::Date;
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::osu::require_link,
@@ -40,6 +41,7 @@ async fn prefix_playersnipestats(
     ctx: Arc<Context>,
     msg: &Message,
     mut args: Args<'_>,
+    permissions: Option<Permissions>,
 ) -> Result<()> {
     let args = match args.next() {
         Some(arg) => match matcher::get_mention_user(arg) {
@@ -55,7 +57,7 @@ async fn prefix_playersnipestats(
         None => SnipePlayerStats::default(),
     };
 
-    player_stats(ctx, msg.into(), args).await
+    player_stats(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 pub(super) async fn player_stats(

--- a/bathbot/src/commands/osu/snipe/sniped.rs
+++ b/bathbot/src/commands/osu/snipe/sniped.rs
@@ -20,6 +20,7 @@ use plotters::{
 };
 use rosu_v2::{prelude::OsuError, request::UserId};
 use time::{Date, Duration, OffsetDateTime};
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::osu::require_link,
@@ -42,7 +43,12 @@ use super::SnipePlayerSniped;
 #[example("badewanne3")]
 #[alias("snipes")]
 #[group(Osu)]
-async fn prefix_sniped(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> Result<()> {
+async fn prefix_sniped(
+    ctx: Arc<Context>,
+    msg: &Message,
+    mut args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let args = match args.next() {
         Some(arg) => match matcher::get_mention_user(arg) {
             Some(id) => SnipePlayerSniped {
@@ -57,7 +63,7 @@ async fn prefix_sniped(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> 
         None => SnipePlayerSniped::default(),
     };
 
-    player_sniped(ctx, msg.into(), args).await
+    player_sniped(ctx, CommandOrigin::from_msg(msg, permissions), args).await
 }
 
 pub(super) async fn player_sniped(

--- a/bathbot/src/commands/utility/prefix.rs
+++ b/bathbot/src/commands/utility/prefix.rs
@@ -2,6 +2,7 @@ use bathbot_macros::command;
 use bathbot_psql::model::configs::{GuildConfig, Prefix, Prefixes, DEFAULT_PREFIX};
 use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
 use eyre::Result;
+use twilight_model::guild::Permissions;
 
 use crate::{core::commands::checks::check_authority, util::ChannelExt, Context};
 
@@ -23,7 +24,12 @@ use std::{cmp::Ordering, fmt::Write, sync::Arc};
 #[alias("prefixes")]
 #[flags(ONLY_GUILDS, SKIP_DEFER)] // authority check is done manually
 #[group(Utility)]
-async fn prefix_prefix(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> Result<()> {
+async fn prefix_prefix(
+    ctx: Arc<Context>,
+    msg: &Message,
+    mut args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let guild_id = msg.guild_id.unwrap();
 
     let Some(action) = args.next() else {
@@ -33,7 +39,7 @@ async fn prefix_prefix(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> 
         ctx.guild_config().peek(guild_id, f).await;
 
         let builder = MessageBuilder::new().embed(content);
-        msg.create_message(&ctx, &builder).await?;
+        msg.create_message(&ctx, &builder, permissions).await?;
 
         return Ok(());
     };
@@ -135,7 +141,7 @@ async fn prefix_prefix(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> 
             ctx.guild_config().peek(guild_id, f).await;
 
             let builder = MessageBuilder::new().embed(content);
-            msg.create_message(&ctx, &builder).await?;
+            msg.create_message(&ctx, &builder, permissions).await?;
 
             Ok(())
         }

--- a/bathbot/src/commands/utility/roll.rs
+++ b/bathbot/src/commands/utility/roll.rs
@@ -5,6 +5,7 @@ use bathbot_util::MessageBuilder;
 use eyre::Result;
 use rand::Rng;
 use twilight_interactions::command::{CommandModel, CreateCommand};
+use twilight_model::guild::Permissions;
 
 use crate::{
     core::{commands::CommandOrigin, Context},
@@ -39,7 +40,12 @@ async fn slash_roll(ctx: Arc<Context>, mut command: InteractionCommand) -> Resul
 #[usage("[upper limit]")]
 #[flags(SKIP_DEFER)]
 #[group(Utility)]
-async fn prefix_roll(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> Result<()> {
+async fn prefix_roll(
+    ctx: Arc<Context>,
+    msg: &Message,
+    mut args: Args<'_>,
+    permissions: Option<Permissions>,
+) -> Result<()> {
     let limit = match args.num {
         Some(n) => n,
         None => match args.next().map(|arg| arg.parse()) {
@@ -48,7 +54,7 @@ async fn prefix_roll(ctx: Arc<Context>, msg: &Message, mut args: Args<'_>) -> Re
         },
     };
 
-    roll(ctx, msg.into(), limit).await
+    roll(ctx, CommandOrigin::from_msg(msg, permissions), limit).await
 }
 
 async fn roll(ctx: Arc<Context>, orig: CommandOrigin<'_>, limit: u64) -> Result<()> {

--- a/bathbot/src/core/commands/origin.rs
+++ b/bathbot/src/core/commands/origin.rs
@@ -3,6 +3,7 @@ use eyre::{Result, WrapErr};
 use twilight_http::Response;
 use twilight_model::{
     channel::Message,
+    guild::Permissions,
     id::{
         marker::{ChannelMarker, GuildMarker, UserMarker},
         Id,
@@ -17,29 +18,41 @@ use crate::{
 };
 
 pub enum CommandOrigin<'d> {
-    Message { msg: &'d Message },
-    Interaction { command: &'d mut InteractionCommand },
+    Message {
+        msg: &'d Message,
+        permissions: Option<Permissions>,
+    },
+    Interaction {
+        command: &'d mut InteractionCommand,
+    },
 }
 
 impl CommandOrigin<'_> {
     pub fn user_id(&self) -> Result<Id<UserMarker>> {
         match self {
-            CommandOrigin::Message { msg } => Ok(msg.author.id),
+            CommandOrigin::Message { msg, .. } => Ok(msg.author.id),
             CommandOrigin::Interaction { command } => command.user_id(),
         }
     }
 
     pub fn channel_id(&self) -> Id<ChannelMarker> {
         match self {
-            CommandOrigin::Message { msg } => msg.channel_id,
+            CommandOrigin::Message { msg, .. } => msg.channel_id,
             CommandOrigin::Interaction { command } => command.channel_id,
         }
     }
 
     pub fn guild_id(&self) -> Option<Id<GuildMarker>> {
         match self {
-            CommandOrigin::Message { msg } => msg.guild_id,
+            CommandOrigin::Message { msg, .. } => msg.guild_id,
             CommandOrigin::Interaction { command } => command.guild_id,
+        }
+    }
+
+    pub fn permissions(&self) -> Option<Permissions> {
+        match self {
+            CommandOrigin::Message { permissions, .. } => *permissions,
+            CommandOrigin::Interaction { command } => command.permissions,
         }
     }
 
@@ -50,7 +63,7 @@ impl CommandOrigin<'_> {
     /// In case of an interaction, the response will **not** be ephemeral.
     pub async fn callback(&self, ctx: &Context, builder: MessageBuilder<'_>) -> Result<()> {
         match self {
-            Self::Message { msg } => msg
+            Self::Message { msg, .. } => msg
                 .create_message(ctx, &builder)
                 .await
                 .map(|_| ())
@@ -72,7 +85,7 @@ impl CommandOrigin<'_> {
         builder: MessageBuilder<'_>,
     ) -> Result<Response<Message>> {
         match self {
-            Self::Message { msg } => msg
+            Self::Message { msg, .. } => msg
                 .create_message(ctx, &builder)
                 .await
                 .wrap_err("failed to create message for response callback"),
@@ -102,7 +115,7 @@ impl CommandOrigin<'_> {
         ephemeral: bool,
     ) -> Result<()> {
         match self {
-            Self::Message { msg } => msg
+            Self::Message { msg, .. } => msg
                 .create_message(ctx, &builder)
                 .await
                 .map(|_| ())
@@ -127,7 +140,7 @@ impl CommandOrigin<'_> {
         builder: &MessageBuilder<'_>,
     ) -> Result<Response<Message>> {
         match self {
-            Self::Message { msg } => msg
+            Self::Message { msg, .. } => msg
                 .create_message(ctx, builder)
                 .await
                 .wrap_err("failed to create message as response"),
@@ -149,7 +162,7 @@ impl CommandOrigin<'_> {
         builder: &MessageBuilder<'_>,
     ) -> Result<Response<Message>> {
         match self {
-            Self::Message { msg } => msg
+            Self::Message { msg, .. } => msg
                 .update(ctx, builder)
                 .await
                 .wrap_err("failed to update message"),
@@ -165,7 +178,7 @@ impl CommandOrigin<'_> {
     /// In case of an interaction, be sure you already called back beforehand.
     pub async fn error(&self, ctx: &Context, content: impl Into<String>) -> Result<()> {
         match self {
-            Self::Message { msg } => msg
+            Self::Message { msg, .. } => msg
                 .error(ctx, content)
                 .await
                 .map(|_| ())
@@ -184,7 +197,7 @@ impl CommandOrigin<'_> {
     /// The response will not be ephemeral.
     pub async fn error_callback(&self, ctx: &Context, content: impl Into<String>) -> Result<()> {
         match self {
-            CommandOrigin::Message { msg } => msg
+            CommandOrigin::Message { msg, .. } => msg
                 .error(ctx, content)
                 .await
                 .map(|_| ())
@@ -198,9 +211,12 @@ impl CommandOrigin<'_> {
     }
 }
 
-impl<'d> From<&'d mut InteractionCommand> for CommandOrigin<'d> {
-    #[inline]
-    fn from(command: &'d mut InteractionCommand) -> Self {
+impl<'d> CommandOrigin<'d> {
+    pub fn from_msg(msg: &'d Message, permissions: Option<Permissions>) -> Self {
+        Self::Message { msg, permissions }
+    }
+
+    pub fn from_interaction(command: &'d mut InteractionCommand) -> Self {
         Self::Interaction { command }
     }
 }
@@ -208,6 +224,13 @@ impl<'d> From<&'d mut InteractionCommand> for CommandOrigin<'d> {
 impl<'d> From<&'d Message> for CommandOrigin<'d> {
     #[inline]
     fn from(msg: &'d Message) -> Self {
-        Self::Message { msg }
+        Self::from_msg(msg, None)
+    }
+}
+
+impl<'d> From<&'d mut InteractionCommand> for CommandOrigin<'d> {
+    #[inline]
+    fn from(command: &'d mut InteractionCommand) -> Self {
+        Self::from_interaction(command)
     }
 }

--- a/bathbot/src/core/commands/prefix/command.rs
+++ b/bathbot/src/core/commands/prefix/command.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use twilight_model::channel::Message;
+use twilight_model::{channel::Message, guild::Permissions};
 
 use crate::core::{buckets::BucketName, commands::flags::CommandFlags, Context};
 
@@ -15,7 +15,8 @@ pub struct PrefixCommand {
     pub bucket: Option<BucketName>,
     pub flags: CommandFlags,
     pub group: PrefixCommandGroup,
-    pub exec: for<'f> fn(Arc<Context>, &'f Message, Args<'f>) -> CommandResult<'f>,
+    pub exec:
+        for<'f> fn(Arc<Context>, &'f Message, Args<'f>, Option<Permissions>) -> CommandResult<'f>,
 }
 
 impl PrefixCommand {

--- a/bathbot/src/core/events/message/mod.rs
+++ b/bathbot/src/core/events/message/mod.rs
@@ -92,14 +92,18 @@ async fn process_command<'m>(
     let channel = msg.channel_id;
 
     // Does bot have sufficient permissions to send response in a guild?
-    if let Some(guild) = msg.guild_id {
+    let permissions = if let Some(guild) = msg.guild_id {
         let user = ctx.cache.current_user(|user| user.id)?;
         let permissions = ctx.cache.get_channel_permissions(user, channel, guild);
 
         if !permissions.contains(Permissions::SEND_MESSAGES) {
             return Ok(ProcessResult::NoSendPermission);
         }
-    }
+
+        Some(permissions)
+    } else {
+        None
+    };
 
     // Ratelimited?
     let ratelimit = ctx
@@ -155,7 +159,7 @@ async fn process_command<'m>(
     }
 
     // Call command function
-    (cmd.exec)(ctx, msg, args).await?;
+    (cmd.exec)(ctx, msg, args, permissions).await?;
 
     Ok(ProcessResult::Success)
 }

--- a/bathbot/src/games/bg/game_wrapper.rs
+++ b/bathbot/src/games/bg/game_wrapper.rs
@@ -59,7 +59,7 @@ impl GameWrapper {
                     .content("Here's the next one:")
                     .attachment("bg_img.png", mem::take(&mut img));
 
-                if let Err(err) = channel.create_message(&ctx, &builder).await {
+                if let Err(err) = channel.create_message(&ctx, &builder, None).await {
                     let report = Report::new(err).wrap_err("Failed to send initial bg game msg");
                     warn!("{report:?}");
                 }

--- a/bathbot/src/games/hl/kind.rs
+++ b/bathbot/src/games/hl/kind.rs
@@ -340,7 +340,7 @@ impl GameStateKind {
 
         let mut message = BotConfig::get()
             .hl_channel
-            .create_message(ctx, &builder)
+            .create_message(ctx, &builder, None)
             .await?
             .model()
             .await

--- a/bathbot/src/pagination/components.rs
+++ b/bathbot/src/pagination/components.rs
@@ -65,6 +65,7 @@ where
     if defer_components {
         component
             .update(&ctx, &builder?)
+            .wrap_err("lacking permission to update message")?
             .await
             .wrap_err("failed to update")?;
     } else {
@@ -222,6 +223,7 @@ pub async fn handle_sim_version(ctx: Arc<Context>, component: InteractionCompone
     if defer_components {
         component
             .update(&ctx, &builder?)
+            .wrap_err("lacking permission to update message")?
             .await
             .wrap_err("failed to update")?;
     } else {
@@ -289,6 +291,7 @@ async fn respond_modal(
     if defer {
         modal
             .update(ctx, &builder?)
+            .wrap_err("lacking permission to update message")?
             .await
             .wrap_err("failed to update")?;
     } else {

--- a/bathbot/src/pagination/mod.rs
+++ b/bathbot/src/pagination/mod.rs
@@ -279,9 +279,11 @@ impl Pagination {
                         if pagination_active && msg_available {
                             let builder = MessageBuilder::new().components(Vec::new());
 
-                            if let Err(err) = (msg, channel).update(&ctx, &builder).await {
-                                let report = Report::new(err).wrap_err("failed to remove components");
-                                warn!("{report:?}");
+                            if let Some(update_fut) = (msg, channel).update(&ctx, &builder, None) {
+                                if let Err(err) = update_fut.await {
+                                    let err = Report::new(err).wrap_err("failed to remove components");
+                                    warn!("{err:?}");
+                                }
                             }
                         }
 

--- a/bathbot/src/util/ext/component.rs
+++ b/bathbot/src/util/ext/component.rs
@@ -22,7 +22,11 @@ pub trait ComponentExt {
     /// After having already ackowledged the component either via
     /// [`ComponentExt::callback`] or [`ComponentExt::defer`],
     /// use this to update the message.
-    fn update(&self, ctx: &Context, builder: &MessageBuilder<'_>) -> ResponseFuture<Message>;
+    fn update(
+        &self,
+        ctx: &Context,
+        builder: &MessageBuilder<'_>,
+    ) -> Option<ResponseFuture<Message>>;
 
     /// Acknowledge a component by responding with a modal.
     fn modal(&self, ctx: &Context, modal: ModalBuilder) -> ResponseFuture<EmptyBody>;
@@ -71,8 +75,12 @@ impl ComponentExt for InteractionComponent {
     }
 
     #[inline]
-    fn update(&self, ctx: &Context, builder: &MessageBuilder<'_>) -> ResponseFuture<Message> {
-        self.message.update(ctx, builder)
+    fn update(
+        &self,
+        ctx: &Context,
+        builder: &MessageBuilder<'_>,
+    ) -> Option<ResponseFuture<Message>> {
+        self.message.update(ctx, builder, self.permissions)
     }
 
     #[inline]

--- a/bathbot/src/util/ext/modal.rs
+++ b/bathbot/src/util/ext/modal.rs
@@ -22,7 +22,11 @@ pub trait ModalExt {
     /// use this to update the message.
     ///
     /// Note: Can only be used if `ModalSubmitInteraction::message` is `Some`.
-    fn update(&self, ctx: &Context, builder: &MessageBuilder<'_>) -> ResponseFuture<Message>;
+    fn update(
+        &self,
+        ctx: &Context,
+        builder: &MessageBuilder<'_>,
+    ) -> Option<ResponseFuture<Message>>;
 }
 
 impl ModalExt for InteractionModal {
@@ -67,10 +71,14 @@ impl ModalExt for InteractionModal {
     }
 
     #[inline]
-    fn update(&self, ctx: &Context, builder: &MessageBuilder<'_>) -> ResponseFuture<Message> {
+    fn update(
+        &self,
+        ctx: &Context,
+        builder: &MessageBuilder<'_>,
+    ) -> Option<ResponseFuture<Message>> {
         self.message
             .as_ref()
             .expect("no message in modal")
-            .update(ctx, builder)
+            .update(ctx, builder, self.permissions)
     }
 }


### PR DESCRIPTION
Putting permission checks in place for
- `ATTACH_FILES`
- `READ_MESSAGE_HISTORY`
- `CREATE_PUBLIC_THREADS`
- `VIEW_CHANNEL` (to update messages)