### PR TITLE
replace plotters BitMapBackend with CairoBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,7 @@ dependencies = [
  "bb8-redis",
  "bitflags",
  "bytes",
+ "cairo-rs",
  "dotenvy",
  "enterpolation",
  "eyre",
@@ -266,6 +273,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "plotters",
  "plotters-backend",
+ "plotters-cairo",
  "priority-queue",
  "prometheus",
  "radix_trie",
@@ -391,6 +399,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "cairo-rs"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c76ee391b03d35510d9fa917357c7f1855bd9a6659c95a1b392e33f49b3369bc"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c55d429bef56ac9172d25fecb85dc8068307d17acd74b377866b7a1ef25d3c8"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +436,15 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+
+[[package]]
+name = "cfg-expr"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "cfg-if"
@@ -848,6 +889,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-intrusive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +972,62 @@ checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "glib"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a68131a662b04931e71891fb14aaf65ee4b44d08e8abc10f49e77418c86c64"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1330,6 +1438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1680,6 @@ dependencies = [
  "num-traits",
  "pathfinder_geometry",
  "plotters-backend",
- "plotters-bitmap",
  "ttf-parser",
  "wasm-bindgen",
  "web-sys",
@@ -1576,11 +1692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
-name = "plotters-bitmap"
+name = "plotters-cairo"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4a1f21490a6cf4a84c272ad20bd7844ed99a3178187a4c5ab7f2051295beef"
+checksum = "ad329f140235af4d41913a220f2c9ab5da42d0d09132435fd3d981ad647325db"
 dependencies = [
+ "cairo-rs",
  "plotters-backend",
 ]
 
@@ -1610,6 +1727,40 @@ checksum = "d7685ca4cc0b3ad748c22ce6803e23b55b9206ef7715b965ebeaf41639238fdc"
 dependencies = [
  "autocfg",
  "indexmap",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2315,6 +2466,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "system-deps"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2630,32 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -2853,6 +3043,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/bathbot/Cargo.toml
+++ b/bathbot/Cargo.toml
@@ -14,6 +14,7 @@ bathbot-util = { path = "../bathbot-util" }
 bb8-redis = { version = "0.12" }
 bitflags = { version = "1.0" }
 bytes = { version = "1.0" }
+cairo-rs = { version = "0.15", features = ["png"] }
 dotenvy = { version = "0.15" }
 enterpolation = { version = "0.2", default-features = false, features = ["std", "linear"] }
 eyre = { version = "0.6" }
@@ -28,8 +29,9 @@ leaky-bucket-lite = { version = "0.5", features = ["parking_lot"] }
 nom = { version = "7.1.3" }
 once_cell = { version = "1.0" }
 parking_lot = { version = "0.12", default-features = false }
-plotters = { version = "0.3", default-features = false, features = ["bitmap_backend", "image", "line_series", "area_series", "histogram", "point_series"] }
+plotters = { version = "0.3", default-features = false, features = ["ttf", "image", "all_series", "all_elements", "full_palette"] }
 plotters-backend = { version = "0.3" }
+plotters-cairo = { version = "0.3" }
 priority-queue = { version = "1.0", optional = true }
 prometheus = { version = "0.13" }
 radix_trie = { version = "0.2" }

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::CountryCode;
@@ -7,6 +7,10 @@ use bathbot_util::{
     EmbedBuilder, MessageBuilder,
 };
 use eyre::{Report, Result, WrapErr};
+use image::{DynamicImage, GenericImageView};
+use plotters::element::{Drawable, PointCollection};
+use plotters_backend::{BackendCoord, DrawingBackend, DrawingErrorKind};
+use plotters_cairo::CairoBackend;
 use rosu_v2::{
     prelude::{GameMode, OsuError},
     request::UserId,
@@ -351,7 +355,6 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
 
 const W: u32 = 1350;
 const H: u32 = 711;
-const LEN: usize = (W * H) as usize;
 
 async fn top_graph(
     ctx: &Context,
@@ -439,4 +442,49 @@ async fn top_graph(
     };
 
     Ok(Some((user, bytes)))
+}
+
+pub struct BitmapElement<C> {
+    img: Vec<u8>,
+    size: (u32, u32),
+    pos: C,
+}
+
+impl<C> BitmapElement<C> {
+    /// Be sure the image has been resized beforehand
+    pub fn new(img: DynamicImage, pos: C) -> Self {
+        let size = img.dimensions();
+
+        Self {
+            img: img.into_rgb8().into_raw(),
+            size,
+            pos,
+        }
+    }
+}
+
+impl<'a, C> PointCollection<'a, C> for &'a BitmapElement<C> {
+    type Point = &'a C;
+    type IntoIter = iter::Once<&'a C>;
+
+    #[inline]
+    fn point_iter(self) -> Self::IntoIter {
+        iter::once(&self.pos)
+    }
+}
+
+impl<'a, C> Drawable<CairoBackend<'a>> for BitmapElement<C> {
+    #[inline]
+    fn draw<I: Iterator<Item = BackendCoord>>(
+        &self,
+        mut points: I,
+        backend: &mut CairoBackend<'a>,
+        _: (u32, u32),
+    ) -> Result<(), DrawingErrorKind<<CairoBackend<'_> as DrawingBackend>::ErrorType>> {
+        if let Some((x, y)) = points.next() {
+            return backend.blit_bitmap((x, y), self.size, self.img.as_ref());
+        }
+
+        Ok(())
+    }
 }

--- a/bathbot/src/commands/osu/graphs/playcount_replays.rs
+++ b/bathbot/src/commands/osu/graphs/playcount_replays.rs
@@ -233,7 +233,7 @@ fn draw(ctx: &CairoContext, params: ProfileGraphParams<'_>, badges: &[Bytes]) ->
     let mut canvas = create_root(ctx, w, h)?;
 
     if !badges.is_empty() {
-        canvas = draw_badges(&badges, canvas, w, h)?;
+        canvas = draw_badges(badges, canvas, w, h)?;
     }
 
     if flags.playcount() && flags.replays() {

--- a/bathbot/src/commands/osu/graphs/rank.rs
+++ b/bathbot/src/commands/osu/graphs/rank.rs
@@ -4,19 +4,20 @@ use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
     numbers::WithComma,
 };
+use cairo::{Context as CairoContext, Format, ImageSurface};
 use eyre::{Report, Result, WrapErr};
-use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use plotters::{
-    prelude::{BitMapBackend, ChartBuilder, Circle, IntoDrawingArea, SeriesLabelPosition},
+    prelude::{ChartBuilder, Circle, IntoDrawingArea, SeriesLabelPosition},
     series::AreaSeries,
     style::{Color, RGBColor, ShapeStyle, BLACK, GREEN, RED, WHITE},
 };
 use plotters_backend::FontStyle;
+use plotters_cairo::CairoBackend;
 use rosu_v2::{prelude::OsuError, request::UserId};
 
 use crate::{
     commands::osu::{
-        graphs::{H, LEN, W},
+        graphs::{H, W},
         user_not_found,
     },
     core::{commands::CommandOrigin, Context},
@@ -49,8 +50,6 @@ pub async fn rank_graph(
     };
 
     fn draw_graph(user: &RedisData<User>) -> Result<Option<Vec<u8>>> {
-        let mut buf = vec![0; LEN * 3];
-
         let history = match user {
             RedisData::Original(user) if user.rank_history.is_empty() => return Ok(None),
             RedisData::Original(user) => user.rank_history.as_slice(),
@@ -93,8 +92,16 @@ pub async fn rank_graph(
 
         let (min, max) = (-(max as i32), -(min as i32));
 
+        let surface = ImageSurface::create(Format::ARgb32, W as i32, H as i32)
+            .wrap_err("failed to create surface")?;
+
         {
-            let root = BitMapBackend::with_buffer(&mut buf, (W, H)).into_drawing_area();
+            let ctx = CairoContext::new(&surface).wrap_err("failed to create cairo context")?;
+
+            let root = CairoBackend::new(&ctx, (W, H))
+                .wrap_err("failed to create backend")?
+                .into_drawing_area();
+
             let background = RGBColor(19, 43, 33);
             root.fill(&background)
                 .wrap_err("failed to fill background")?;
@@ -173,12 +180,11 @@ pub async fn rank_graph(
         }
 
         // Encode buf to png
-        let mut png_bytes: Vec<u8> = Vec::with_capacity(LEN);
-        let png_encoder = PngEncoder::new(&mut png_bytes);
+        let mut png_bytes: Vec<u8> = Vec::with_capacity((2 * W * H) as usize);
 
-        png_encoder
-            .write_image(&buf, W, H, ColorType::Rgb8)
-            .wrap_err("failed to encode image")?;
+        surface
+            .write_to_png(&mut png_bytes)
+            .wrap_err("failed to write to png")?;
 
         Ok(Some(png_bytes))
     }

--- a/bathbot/src/commands/osu/graphs/top_index.rs
+++ b/bathbot/src/commands/osu/graphs/top_index.rs
@@ -1,11 +1,12 @@
+use cairo::{Context as CairoContext, Format, ImageSurface};
 use eyre::{Result, WrapErr};
-use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use plotters::{
-    prelude::{BitMapBackend, ChartBuilder, EmptyElement, IntoDrawingArea, SeriesLabelPosition},
+    prelude::{ChartBuilder, EmptyElement, IntoDrawingArea, SeriesLabelPosition},
     series::AreaSeries,
     style::{Color, RGBColor, WHITE},
 };
 use plotters_backend::FontStyle;
+use plotters_cairo::CairoBackend;
 use rosu_v2::prelude::Score;
 
 use super::{H, W};
@@ -17,11 +18,16 @@ pub async fn top_graph_index(caption: String, scores: &[Score]) -> Result<Vec<u8
     let min = scores.last().and_then(|s| s.pp).unwrap_or(0.0);
     let min_adj = (min - 5.0).max(0.0);
 
-    let len = (W * H) as usize;
-    let mut buf = vec![0; len * 3];
+    let surface = ImageSurface::create(Format::ARgb32, W as i32, H as i32)
+        .wrap_err("failed to create surface")?;
 
     {
-        let root = BitMapBackend::with_buffer(&mut buf, (W, H)).into_drawing_area();
+        let ctx = CairoContext::new(&surface).wrap_err("failed to create cairo context")?;
+
+        let root = CairoBackend::new(&ctx, (W, H))
+            .wrap_err("failed to create backend")?
+            .into_drawing_area();
+
         let background = RGBColor(19, 43, 33);
         root.fill(&background)
             .wrap_err("failed to fill background")?;
@@ -84,12 +90,11 @@ pub async fn top_graph_index(caption: String, scores: &[Score]) -> Result<Vec<u8
     }
 
     // Encode buf to png
-    let mut png_bytes: Vec<u8> = Vec::with_capacity(len);
-    let png_encoder = PngEncoder::new(&mut png_bytes);
+    let mut png_bytes: Vec<u8> = Vec::with_capacity((2 * W * H) as usize);
 
-    png_encoder
-        .write_image(&buf, W, H, ColorType::Rgb8)
-        .wrap_err("failed to encode image")?;
+    surface
+        .write_to_png(&mut png_bytes)
+        .wrap_err("failed to write to png")?;
 
     Ok(png_bytes)
 }

--- a/bathbot/src/commands/osu/graphs/top_time.rs
+++ b/bathbot/src/commands/osu/graphs/top_time.rs
@@ -1,16 +1,17 @@
 use std::fmt::Write;
 
+use cairo::{Context as CairoContext, Format, ImageSurface};
 use eyre::{Result, WrapErr};
-use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use plotters::{
     prelude::{
-        BitMapBackend, ChartBuilder, Circle, EmptyElement, IntoDrawingArea, IntoSegmentedCoord,
-        Rectangle, SegmentValue, SeriesLabelPosition,
+        ChartBuilder, Circle, EmptyElement, IntoDrawingArea, IntoSegmentedCoord, Rectangle,
+        SegmentValue, SeriesLabelPosition,
     },
     series::PointSeries,
     style::{Color, RGBColor, WHITE},
 };
 use plotters_backend::FontStyle;
+use plotters_cairo::CairoBackend;
 use rosu_v2::prelude::Score;
 use time::{OffsetDateTime, UtcOffset};
 
@@ -49,11 +50,16 @@ pub async fn top_graph_time(
 
     let max_hours = hours.iter().max().map_or(0, |count| *count as u32);
 
-    let len = (W * H) as usize;
-    let mut buf = vec![0; len * 3];
+    let surface = ImageSurface::create(Format::ARgb32, W as i32, H as i32)
+        .wrap_err("failed to create surface")?;
 
     {
-        let root = BitMapBackend::with_buffer(&mut buf, (W, H)).into_drawing_area();
+        let ctx = CairoContext::new(&surface).wrap_err("failed to create cairo context")?;
+
+        let root = CairoBackend::new(&ctx, (W, H))
+            .wrap_err("failed to create backend")?
+            .into_drawing_area();
+
         let background = RGBColor(19, 43, 33);
         root.fill(&background)
             .wrap_err("failed to fill background")?;
@@ -185,12 +191,11 @@ pub async fn top_graph_time(
     }
 
     // Encode buf to png
-    let mut png_bytes: Vec<u8> = Vec::with_capacity(len);
-    let png_encoder = PngEncoder::new(&mut png_bytes);
+    let mut png_bytes: Vec<u8> = Vec::with_capacity((2 * W * H) as usize);
 
-    png_encoder
-        .write_image(&buf, W, H, ColorType::Rgb8)
-        .wrap_err("failed to encode image")?;
+    surface
+        .write_to_png(&mut png_bytes)
+        .wrap_err("failed to write to png")?;
 
     Ok(png_bytes)
 }

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -5,9 +5,10 @@ use bathbot_util::{
     constants::{GENERAL_ISSUE, HUISMETBENEN_ISSUE, OSU_API_ISSUE},
     matcher, MessageBuilder,
 };
+use cairo::{Context as CairoContext, Format, ImageSurface};
 use eyre::{Report, Result, WrapErr};
-use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use plotters::prelude::*;
+use plotters_cairo::CairoBackend;
 use rosu_v2::{
     prelude::{GameMode, OsuError},
     request::UserId,
@@ -193,17 +194,22 @@ pub fn graphs(
     w: u32,
     h: u32,
 ) -> Result<Vec<u8>> {
-    let len = (w * h * 3) as usize; // PIXEL_SIZE = 3
-    let mut buf = vec![0; len];
-
     let style: fn(RGBColor) -> ShapeStyle = |color| ShapeStyle {
         color: color.to_rgba(),
         filled: false,
         stroke_width: 1,
     };
 
+    let surface = ImageSurface::create(Format::ARgb32, w as i32, h as i32)
+        .wrap_err("failed to create surface")?;
+
     {
-        let root = BitMapBackend::with_buffer(&mut buf, (w, h)).into_drawing_area();
+        let ctx = CairoContext::new(&surface).wrap_err("failed to create cairo context")?;
+
+        let root = CairoBackend::new(&ctx, (w, h))
+            .wrap_err("failed to create backend")?
+            .into_drawing_area();
+
         let background = RGBColor(19, 43, 33);
         root.fill(&background)
             .wrap_err("failed to fill background")?;
@@ -310,12 +316,11 @@ pub fn graphs(
     }
 
     // Encode buf to png
-    let mut png_bytes: Vec<u8> = Vec::with_capacity(len);
-    let png_encoder = PngEncoder::new(&mut png_bytes);
+    let mut png_bytes: Vec<u8> = Vec::with_capacity((2 * w * h) as usize);
 
-    png_encoder
-        .write_image(&buf, w, h, ColorType::Rgb8)
-        .wrap_err("failed to encode image")?;
+    surface
+        .write_to_png(&mut png_bytes)
+        .wrap_err("failed to write to png")?;
 
     Ok(png_bytes)
 }

--- a/bathbot/src/commands/osu/snipe/sniped.rs
+++ b/bathbot/src/commands/osu/snipe/sniped.rs
@@ -7,8 +7,8 @@ use bathbot_util::{
     datetime::DATE_FORMAT,
     matcher, MessageBuilder,
 };
+use cairo::{Context as CairoContext, Format, ImageSurface};
 use eyre::{Report, Result, WrapErr};
-use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use itertools::Itertools;
 use plotters::{
     coord::{
@@ -18,6 +18,7 @@ use plotters::{
     },
     prelude::*,
 };
+use plotters_cairo::CairoBackend;
 use rosu_v2::{prelude::OsuError, request::UserId};
 use time::{Date, Duration, OffsetDateTime};
 use twilight_model::guild::Permissions;
@@ -177,11 +178,16 @@ pub fn graphs(
         return Ok(None);
     }
 
-    let len = (w * h) as usize;
-    let mut buf = vec![0; len * 3];
+    let surface = ImageSurface::create(Format::ARgb32, w as i32, h as i32)
+        .wrap_err("failed to create surface")?;
 
     {
-        let root = BitMapBackend::with_buffer(&mut buf, (w, h)).into_drawing_area();
+        let ctx = CairoContext::new(&surface).wrap_err("failed to create cairo context")?;
+
+        let root = CairoBackend::new(&ctx, (w, h))
+            .wrap_err("failed to create backend")?
+            .into_drawing_area();
+
         let background = RGBColor(19, 43, 33);
         root.fill(&background)
             .wrap_err("failed to fill background")?;
@@ -199,12 +205,11 @@ pub fn graphs(
     }
 
     // Encode buf to png
-    let mut png_bytes: Vec<u8> = Vec::with_capacity(len);
-    let png_encoder = PngEncoder::new(&mut png_bytes);
+    let mut png_bytes: Vec<u8> = Vec::with_capacity((2 * w * h) as usize);
 
-    png_encoder
-        .write_image(&buf, w, h, ColorType::Rgb8)
-        .wrap_err("failed to encode image")?;
+    surface
+        .write_to_png(&mut png_bytes)
+        .wrap_err("failed to write to png")?;
 
     Ok(Some(png_bytes))
 }


### PR DESCRIPTION
[Cairo](https://github.com/gtk-rs/gtk-rs-core) performs much cleaner image processing than the simple bitmap backend.
So far only the usage of the backend is added; features that come with it remain to be implemented.