### PR TITLE
restructure ScoreExt & improve personal best idx

### DIFF
--- a/bathbot-model/src/map_leaderboard.rs
+++ b/bathbot-model/src/map_leaderboard.rs
@@ -1,3 +1,4 @@
+use bathbot_util::{ScoreExt, ScoreHasEndedAt, ScoreHasMode};
 use rosu_v2::prelude::{CountryCode, GameMode, GameMods, Grade, RankStatus};
 use serde::{Deserialize, Deserializer};
 use time::OffsetDateTime;
@@ -110,6 +111,32 @@ impl<'de> Deserialize<'de> for ScraperScore {
             count_miss: helper.statistics.count_miss,
         })
     }
+}
+
+#[rustfmt::skip]
+impl ScoreExt for ScraperScore {
+    #[inline] fn count_miss(&self) -> u32 { self.count_miss }
+    #[inline] fn count_50(&self) -> u32 { self.count50 }
+    #[inline] fn count_100(&self) -> u32 { self.count100 }
+    #[inline] fn count_300(&self) -> u32 { self.count300 }
+    #[inline] fn count_geki(&self) -> u32 { self.count_geki }
+    #[inline] fn count_katu(&self) -> u32 { self.count_katu }
+    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
+    #[inline] fn mods(&self) -> GameMods { self.mods }
+    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
+    #[inline] fn score(&self) -> u32 { self.score }
+    #[inline] fn pp(&self) -> Option<f32> { self.pp }
+    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+}
+
+#[rustfmt::skip]
+impl ScoreHasMode for ScraperScore {
+    #[inline] fn mode(&self) -> GameMode { self.mode }
+}
+
+#[rustfmt::skip]
+impl ScoreHasEndedAt for ScraperScore {
+    #[inline] fn ended_at(&self) -> OffsetDateTime { self.date }
 }
 
 #[derive(Deserialize)]

--- a/bathbot-model/src/osu_stats.rs
+++ b/bathbot-model/src/osu_stats.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use bathbot_util::osu::ModSelection;
+use bathbot_util::{osu::ModSelection, ScoreExt, ScoreHasEndedAt};
 use rosu_v2::prelude::{GameMode, GameMods, Grade, RankStatus, Username};
 use serde::{de::Error, Deserialize, Deserializer};
 use time::OffsetDateTime;
@@ -76,6 +76,27 @@ pub struct OsuStatsScore {
     pub pp: Option<f32>,
     #[serde(rename = "beatmap")]
     pub map: OsuStatsMap,
+}
+
+#[rustfmt::skip]
+impl ScoreExt for OsuStatsScore {
+    #[inline] fn count_miss(&self) -> u32 { self.count_miss }
+    #[inline] fn count_50(&self) -> u32 { self.count50 }
+    #[inline] fn count_100(&self) -> u32 { self.count100 }
+    #[inline] fn count_300(&self) -> u32 { self.count300 }
+    #[inline] fn count_geki(&self) -> u32 { self.count_geki }
+    #[inline] fn count_katu(&self) -> u32 { self.count_katu }
+    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
+    #[inline] fn mods(&self) -> GameMods { self.mods }
+    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
+    #[inline] fn score(&self) -> u32 { self.score }
+    #[inline] fn pp(&self) -> Option<f32> { self.pp }
+    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+}
+
+#[rustfmt::skip]
+impl ScoreHasEndedAt for OsuStatsScore {
+    #[inline] fn ended_at(&self) -> OffsetDateTime { self.ended_at }
 }
 
 #[derive(Debug, Deserialize)]

--- a/bathbot-model/src/score_slim.rs
+++ b/bathbot-model/src/score_slim.rs
@@ -1,3 +1,4 @@
+use bathbot_util::{ScoreExt, ScoreHasEndedAt, ScoreHasMode};
 use rosu_v2::prelude::{GameMode, GameMods, Grade, Score, ScoreStatistics};
 use time::OffsetDateTime;
 
@@ -34,4 +35,36 @@ impl ScoreSlim {
     pub fn total_hits(&self) -> u32 {
         self.statistics.total_hits(self.mode)
     }
+
+    /// Checks for equality compared to another score.
+    /// Note that it is already assumed that both scores come from the same user.
+    pub fn is_eq<S: ScoreHasEndedAt>(&self, score: &S) -> bool {
+        (self.ended_at.unix_timestamp() - score.ended_at().unix_timestamp()).abs() <= 2
+    }
+}
+
+#[rustfmt::skip]
+impl ScoreExt for ScoreSlim {
+    #[inline] fn count_miss(&self) -> u32 { self.statistics.count_miss }
+    #[inline] fn count_50(&self) -> u32 { self.statistics.count_50 }
+    #[inline] fn count_100(&self) -> u32 { self.statistics.count_100 }
+    #[inline] fn count_300(&self) -> u32 { self.statistics.count_300 }
+    #[inline] fn count_geki(&self) -> u32 { self.statistics.count_geki }
+    #[inline] fn count_katu(&self) -> u32 { self.statistics.count_katu }
+    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
+    #[inline] fn mods(&self) -> GameMods { self.mods }
+    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
+    #[inline] fn score(&self) -> u32 { self.score }
+    #[inline] fn pp(&self) -> Option<f32> { Some(self.pp) }
+    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+}
+
+#[rustfmt::skip]
+impl ScoreHasMode for ScoreSlim {
+    #[inline] fn mode(&self) -> GameMode { self.mode }
+}
+
+#[rustfmt::skip]
+impl ScoreHasEndedAt for ScoreSlim {
+    #[inline] fn ended_at(&self) -> OffsetDateTime { self.ended_at }
 }

--- a/bathbot-util/src/ext/mod.rs
+++ b/bathbot-util/src/ext/mod.rs
@@ -1,0 +1,3 @@
+mod score;
+
+pub use self::score::*;

--- a/bathbot-util/src/ext/score.rs
+++ b/bathbot-util/src/ext/score.rs
@@ -1,0 +1,121 @@
+use rosu_v2::prelude::{
+    BeatmapUserScore, GameMode, GameMods, Grade, MatchScore, Score, ScoreStatistics,
+};
+use time::OffsetDateTime;
+
+use crate::osu::calculate_grade;
+
+pub trait ScoreExt {
+    // Required to implement
+    fn count_miss(&self) -> u32;
+    fn count_50(&self) -> u32;
+    fn count_100(&self) -> u32;
+    fn count_300(&self) -> u32;
+    fn count_geki(&self) -> u32;
+    fn count_katu(&self) -> u32;
+    fn max_combo(&self) -> u32;
+    fn mods(&self) -> GameMods;
+    fn score(&self) -> u32;
+    fn pp(&self) -> Option<f32>;
+    fn accuracy(&self) -> f32;
+
+    // Optional to implement
+    #[inline]
+    fn grade(&self, mode: GameMode) -> Grade {
+        let stats = ScoreStatistics {
+            count_geki: self.count_geki(),
+            count_300: self.count_300(),
+            count_katu: self.count_katu(),
+            count_100: self.count_100(),
+            count_50: self.count_50(),
+            count_miss: self.count_miss(),
+        };
+
+        calculate_grade(mode, self.mods(), &stats)
+    }
+
+    #[inline]
+    fn total_hits(&self, mode: u8) -> u32 {
+        let mut amount = self.count_300() + self.count_100() + self.count_miss();
+
+        if mode != 1 {
+            // TKO
+            amount += self.count_50();
+
+            if mode != 0 {
+                // STD
+                amount += self.count_katu();
+
+                // CTB
+                amount += (mode != 2) as u32 * self.count_geki();
+            }
+        }
+
+        amount
+    }
+
+    #[inline]
+    fn is_fc(&self, mode: GameMode, max_combo: u32) -> bool {
+        match mode {
+            _ if self.count_miss() > 0 || self.grade(mode) == Grade::F => false,
+            // Allow 1 missed sliderend per 500 combo
+            GameMode::Osu => self.max_combo() >= (max_combo - (max_combo / 500).max(4)),
+            GameMode::Taiko | GameMode::Mania => true,
+            GameMode::Catch => self.max_combo() == max_combo,
+        }
+    }
+}
+
+#[rustfmt::skip]
+impl ScoreExt for Score {
+    #[inline] fn count_miss(&self) -> u32 { self.statistics.count_miss }
+    #[inline] fn count_50(&self) -> u32 { self.statistics.count_50 }
+    #[inline] fn count_100(&self) -> u32 { self.statistics.count_100 }
+    #[inline] fn count_300(&self) -> u32 { self.statistics.count_300 }
+    #[inline] fn count_geki(&self) -> u32 { self.statistics.count_geki }
+    #[inline] fn count_katu(&self) -> u32 { self.statistics.count_katu }
+    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
+    #[inline] fn mods(&self) -> GameMods { self.mods }
+    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
+    #[inline] fn score(&self) -> u32 { self.score }
+    #[inline] fn pp(&self) -> Option<f32> { self.pp }
+    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+}
+
+#[rustfmt::skip]
+impl ScoreExt for MatchScore {
+    #[inline] fn count_miss(&self) -> u32 { self.statistics.count_miss }
+    #[inline] fn count_50(&self) -> u32 { self.statistics.count_50 }
+    #[inline] fn count_100(&self) -> u32 { self.statistics.count_100 }
+    #[inline] fn count_300(&self) -> u32 { self.statistics.count_300 }
+    #[inline] fn count_geki(&self) -> u32 { self.statistics.count_geki }
+    #[inline] fn count_katu(&self) -> u32 { self.statistics.count_katu }
+    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
+    #[inline] fn mods(&self) -> GameMods { self.mods }
+    #[inline] fn score(&self) -> u32 { self.score }
+    #[inline] fn pp(&self) -> Option<f32> { None }
+    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+}
+
+pub trait ScoreHasMode {
+    fn mode(&self) -> GameMode;
+}
+
+#[rustfmt::skip]
+impl ScoreHasMode for Score {
+    #[inline] fn mode(&self) -> GameMode { self.mode }
+}
+
+pub trait ScoreHasEndedAt {
+    fn ended_at(&self) -> OffsetDateTime;
+}
+
+#[rustfmt::skip]
+impl ScoreHasEndedAt for Score {
+    #[inline] fn ended_at(&self) -> OffsetDateTime { self.ended_at }
+}
+
+#[rustfmt::skip]
+impl ScoreHasEndedAt for BeatmapUserScore {
+    #[inline] fn ended_at(&self) -> OffsetDateTime { self.score.ended_at }
+}

--- a/bathbot-util/src/lib.rs
+++ b/bathbot-util/src/lib.rs
@@ -4,6 +4,7 @@ extern crate eyre;
 mod builder;
 mod cow;
 mod exp_backoff;
+mod ext;
 mod hasher;
 mod html_to_png;
 mod matrix;
@@ -20,6 +21,7 @@ pub use self::{
     builder::{modal, AuthorBuilder, EmbedBuilder, FooterBuilder, MessageBuilder},
     cow::CowUtils,
     exp_backoff::ExponentialBackoff,
+    ext::*,
     hasher::{IntHash, IntHasher},
     html_to_png::HtmlToPng,
     matrix::Matrix,

--- a/bathbot/src/commands/osu/match_compare.rs
+++ b/bathbot/src/commands/osu/match_compare.rs
@@ -1,7 +1,9 @@
 use std::{borrow::Cow, fmt::Write, mem, sync::Arc, time::Duration};
 
 use bathbot_macros::SlashCommand;
-use bathbot_util::{constants::OSU_API_ISSUE, matcher, CowUtils, IntHasher, MessageBuilder};
+use bathbot_util::{
+    constants::OSU_API_ISSUE, matcher, CowUtils, IntHasher, MessageBuilder, ScoreExt,
+};
 use eyre::{Report, Result};
 use hashbrown::HashMap;
 use rosu_v2::prelude::{
@@ -16,7 +18,7 @@ use crate::{
     core::Context,
     embeds::{EmbedData, MatchCompareMapEmbed, MatchCompareSummaryEmbed},
     pagination::MatchComparePagination,
-    util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt, ScoreExt},
+    util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
 };
 
 use super::retrieve_previous;

--- a/bathbot/src/embeds/osu/match_live.rs
+++ b/bathbot/src/embeds/osu/match_live.rs
@@ -12,7 +12,7 @@ use bathbot_util::{
     constants::{DESCRIPTION_SIZE, OSU_BASE},
     datetime::SecToMinSec,
     numbers::{round, WithComma},
-    CowUtils, EmbedBuilder, FooterBuilder,
+    CowUtils, EmbedBuilder, FooterBuilder, ScoreExt,
 };
 use rosu_v2::prelude::{
     GameMode, Grade, MatchEvent, MatchGame, MatchScore, OsuMatch, ScoringType, TeamType,
@@ -21,7 +21,7 @@ use rosu_v2::prelude::{
 use smallvec::SmallVec;
 use twilight_model::channel::embed::Embed;
 
-use crate::util::{osu::grade_emote, Emote, ScoreExt};
+use crate::util::{osu::grade_emote, Emote};
 
 const DESCRIPTION_BUFFER: usize = 45;
 

--- a/bathbot/src/embeds/osu/recent_list.rs
+++ b/bathbot/src/embeds/osu/recent_list.rs
@@ -18,7 +18,7 @@ use crate::{
         OsuMap, PpManager,
     },
     pagination::Pages,
-    util::{osu::grade_completion_mods, ScoreExt},
+    util::{osu::grade_completion_mods, ScoreHasState},
 };
 
 use super::{ComboFormatter, KeyFormatter, PpFormatter};

--- a/bathbot/src/embeds/osu/scores.rs
+++ b/bathbot/src/embeds/osu/scores.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
     constants::{AVATAR_URL, MAP_THUMB_URL, OSU_BASE},
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
-    AuthorBuilder, CowUtils, FooterBuilder,
+    AuthorBuilder, CowUtils, FooterBuilder, ScoreExt,
 };
 use rosu_v2::prelude::{GameMode, Score};
 
@@ -18,7 +18,7 @@ use crate::{
         OsuMap,
     },
     pagination::Pages,
-    util::{Emote, ScoreExt},
+    util::Emote,
 };
 
 use super::HitResultFormatter;
@@ -273,7 +273,7 @@ impl<T: Display> Display for OptionFormat<T> {
 
 struct MissFormat<'s> {
     mode: GameMode,
-    score: &'s dyn ScoreExt,
+    score: &'s ScoreSlim,
     max_combo: u32,
 }
 
@@ -290,7 +290,7 @@ impl<'s> MissFormat<'s> {
 impl Display for MissFormat<'_> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let miss = self.score.count_miss();
+        let miss = self.score.statistics.count_miss;
 
         if miss > 0 || !self.score.is_fc(self.mode, self.max_combo) {
             write!(f, "{miss}{}", Emote::Miss.text())

--- a/bathbot/src/util/ext/mod.rs
+++ b/bathbot/src/util/ext/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
-    authored::Authored, channel::ChannelExt,
-    component::ComponentExt, interaction_command::InteractionCommandExt, map::BeatmapExt,
-    message::MessageExt, modal::*, score::ScoreExt,
+    authored::Authored, channel::ChannelExt, component::ComponentExt,
+    interaction_command::InteractionCommandExt, map::BeatmapExt, message::MessageExt, modal::*,
+    score::ScoreHasState,
 };
 
 mod authored;

--- a/bathbot/src/util/ext/score.rs
+++ b/bathbot/src/util/ext/score.rs
@@ -1,164 +1,48 @@
-use bathbot_model::{OsuStatsScore, ScoreSlim, ScraperScore};
-use bathbot_util::osu::calculate_grade;
+use bathbot_model::ScoreSlim;
 use rosu_pp::ScoreState;
-use rosu_v2::prelude::{GameMode, GameMods, Grade, MatchScore, Score, ScoreStatistics};
+use rosu_v2::prelude::Score;
 
-pub trait ScoreExt: Send + Sync {
-    // Required to implement
-    fn count_miss(&self) -> u32;
-    fn count_50(&self) -> u32;
-    fn count_100(&self) -> u32;
-    fn count_300(&self) -> u32;
-    fn count_geki(&self) -> u32;
-    fn count_katu(&self) -> u32;
+pub trait ScoreHasState {
     fn max_combo(&self) -> u32;
-    fn mods(&self) -> GameMods;
-    fn score(&self) -> u32;
-    fn pp(&self) -> Option<f32>;
-    fn accuracy(&self) -> f32;
-    fn mode(&self) -> Option<GameMode>;
-
-    // Optional to implement
-    #[inline]
-    fn grade(&self, mode: GameMode) -> Grade {
-        let stats = ScoreStatistics {
-            count_geki: self.count_geki(),
-            count_300: self.count_300(),
-            count_katu: self.count_katu(),
-            count_100: self.count_100(),
-            count_50: self.count_50(),
-            count_miss: self.count_miss(),
-        };
-
-        calculate_grade(mode, self.mods(), &stats)
-    }
-
-    #[inline]
-    fn total_hits(&self, mode: u8) -> u32 {
-        let mut amount = self.count_300() + self.count_100() + self.count_miss();
-
-        if mode != 1 {
-            // TKO
-            amount += self.count_50();
-
-            if mode != 0 {
-                // STD
-                amount += self.count_katu();
-
-                // CTB
-                amount += (mode != 2) as u32 * self.count_geki();
-            }
-        }
-
-        amount
-    }
-
-    #[inline]
-    fn is_fc(&self, mode: GameMode, max_combo: u32) -> bool {
-        match mode {
-            _ if self.count_miss() > 0 || self.grade(mode) == Grade::F => false,
-            // Allow 1 missed sliderend per 500 combo
-            GameMode::Osu => self.max_combo() >= (max_combo - (max_combo / 500).max(4)),
-            GameMode::Taiko | GameMode::Mania => true,
-            GameMode::Catch => self.max_combo() == max_combo,
-        }
-    }
+    fn n_miss(&self) -> u32;
+    fn n_geki(&self) -> u32;
+    fn n300(&self) -> u32;
+    fn n_katu(&self) -> u32;
+    fn n100(&self) -> u32;
+    fn n50(&self) -> u32;
 
     #[inline]
     fn state(&self) -> ScoreState {
         ScoreState {
             max_combo: self.max_combo() as usize,
-            n_misses: self.count_miss() as usize,
-            n_geki: self.count_geki() as usize,
-            n300: self.count_300() as usize,
-            n_katu: self.count_katu() as usize,
-            n100: self.count_100() as usize,
-            n50: self.count_50() as usize,
+            n_misses: self.n_miss() as usize,
+            n_geki: self.n_geki() as usize,
+            n300: self.n300() as usize,
+            n_katu: self.n_katu() as usize,
+            n100: self.n100() as usize,
+            n50: self.n50() as usize,
         }
     }
 }
 
 #[rustfmt::skip]
-impl ScoreExt for Score {
-    #[inline] fn count_miss(&self) -> u32 { self.statistics.count_miss }
-    #[inline] fn count_50(&self) -> u32 { self.statistics.count_50 }
-    #[inline] fn count_100(&self) -> u32 { self.statistics.count_100 }
-    #[inline] fn count_300(&self) -> u32 { self.statistics.count_300 }
-    #[inline] fn count_geki(&self) -> u32 { self.statistics.count_geki }
-    #[inline] fn count_katu(&self) -> u32 { self.statistics.count_katu }
-    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
-    #[inline] fn mods(&self) -> GameMods { self.mods }
-    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
-    #[inline] fn score(&self) -> u32 { self.score }
-    #[inline] fn pp(&self) -> Option<f32> { self.pp }
-    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
-    #[inline] fn mode(&self) -> Option<GameMode> { Some(self.mode) }
+impl ScoreHasState for Score {
+    fn max_combo(&self) -> u32 { self.max_combo }
+    fn n_miss(&self) -> u32 { self.statistics.count_miss }
+    fn n_geki(&self) -> u32 { self.statistics.count_geki }
+    fn n300(&self) -> u32 { self.statistics.count_300 }
+    fn n_katu(&self) -> u32 { self.statistics.count_katu }
+    fn n100(&self) -> u32 { self.statistics.count_100 }
+    fn n50(&self) -> u32 { self.statistics.count_50 }
 }
 
 #[rustfmt::skip]
-impl ScoreExt for ScoreSlim {
-    #[inline] fn count_miss(&self) -> u32 { self.statistics.count_miss }
-    #[inline] fn count_50(&self) -> u32 { self.statistics.count_50 }
-    #[inline] fn count_100(&self) -> u32 { self.statistics.count_100 }
-    #[inline] fn count_300(&self) -> u32 { self.statistics.count_300 }
-    #[inline] fn count_geki(&self) -> u32 { self.statistics.count_geki }
-    #[inline] fn count_katu(&self) -> u32 { self.statistics.count_katu }
-    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
-    #[inline] fn mods(&self) -> GameMods { self.mods }
-    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
-    #[inline] fn score(&self) -> u32 { self.score }
-    #[inline] fn pp(&self) -> Option<f32> { Some(self.pp) }
-    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
-    #[inline] fn mode(&self) -> Option<GameMode> { Some(self.mode) }
-}
-
-#[rustfmt::skip]
-impl ScoreExt for OsuStatsScore {
-    #[inline] fn count_miss(&self) -> u32 { self.count_miss }
-    #[inline] fn count_50(&self) -> u32 { self.count50 }
-    #[inline] fn count_100(&self) -> u32 { self.count100 }
-    #[inline] fn count_300(&self) -> u32 { self.count300 }
-    #[inline] fn count_geki(&self) -> u32 { self.count_geki }
-    #[inline] fn count_katu(&self) -> u32 { self.count_katu }
-    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
-    #[inline] fn mods(&self) -> GameMods { self.mods }
-    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
-    #[inline] fn score(&self) -> u32 { self.score }
-    #[inline] fn pp(&self) -> Option<f32> { self.pp }
-    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
-    // self.map.mode is the map's original mode, not converted
-    #[inline] fn mode(&self) -> Option<GameMode> { None }
-}
-
-#[rustfmt::skip]
-impl ScoreExt for ScraperScore {
-    #[inline] fn count_miss(&self) -> u32 { self.count_miss }
-    #[inline] fn count_50(&self) -> u32 { self.count50 }
-    #[inline] fn count_100(&self) -> u32 { self.count100 }
-    #[inline] fn count_300(&self) -> u32 { self.count300 }
-    #[inline] fn count_geki(&self) -> u32 { self.count_geki }
-    #[inline] fn count_katu(&self) -> u32 { self.count_katu }
-    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
-    #[inline] fn mods(&self) -> GameMods { self.mods }
-    #[inline] fn grade(&self, _: GameMode) -> Grade { self.grade }
-    #[inline] fn score(&self) -> u32 { self.score }
-    #[inline] fn pp(&self) -> Option<f32> { self.pp }
-    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
-    #[inline] fn mode(&self) -> Option<GameMode> { Some(self.mode) }
-}
-
-#[rustfmt::skip]
-impl ScoreExt for MatchScore {
-    #[inline] fn count_miss(&self) -> u32 { self.statistics.count_miss }
-    #[inline] fn count_50(&self) -> u32 { self.statistics.count_50 }
-    #[inline] fn count_100(&self) -> u32 { self.statistics.count_100 }
-    #[inline] fn count_300(&self) -> u32 { self.statistics.count_300 }
-    #[inline] fn count_geki(&self) -> u32 { self.statistics.count_geki }
-    #[inline] fn count_katu(&self) -> u32 { self.statistics.count_katu }
-    #[inline] fn max_combo(&self) -> u32 { self.max_combo }
-    #[inline] fn mods(&self) -> GameMods { self.mods }
-    #[inline] fn score(&self) -> u32 { self.score }
-    #[inline] fn pp(&self) -> Option<f32> { None }
-    #[inline] fn accuracy(&self) -> f32 { self.accuracy }
-    #[inline] fn mode(&self) -> Option<GameMode> { None }
+impl ScoreHasState for ScoreSlim {
+    fn max_combo(&self) -> u32 { self.max_combo }
+    fn n_miss(&self) -> u32 { self.statistics.count_miss }
+    fn n_geki(&self) -> u32 { self.statistics.count_geki }
+    fn n300(&self) -> u32 { self.statistics.count_300 }
+    fn n_katu(&self) -> u32 { self.statistics.count_katu }
+    fn n100(&self) -> u32 { self.statistics.count_100 }
+    fn n50(&self) -> u32 { self.statistics.count_50 }
 }

--- a/bathbot/src/util/osu.rs
+++ b/bathbot/src/util/osu.rs
@@ -757,7 +757,7 @@ impl PersonalBestIndex {
                 old = old_idx + 1
             )),
             PersonalBestIndex::Presumably { idx } => {
-                Some(format!("Personal Best #{} (maybe)", idx + 1))
+                Some(format!("Personal Best #{} (?)", idx + 1))
             }
             PersonalBestIndex::IfRanked { idx } => {
                 Some(format!("Personal Best #{} (if ranked)", idx + 1))

--- a/bathbot/src/util/osu.rs
+++ b/bathbot/src/util/osu.rs
@@ -1,6 +1,8 @@
 use std::{
     array::IntoIter,
     borrow::Cow,
+    cmp::Ordering,
+    convert::identity,
     fmt::{Display, Formatter, Result as FmtResult},
     io::Cursor,
     mem::MaybeUninit,
@@ -10,6 +12,7 @@ use bathbot_model::{OsuStatsParams, RespektiveTopCount, ScoreSlim};
 use bathbot_util::{
     datetime::SecToMinSec,
     numbers::{round, WithComma},
+    ScoreExt,
 };
 use eyre::{Result, WrapErr};
 use futures::{stream::FuturesOrdered, StreamExt};
@@ -20,7 +23,7 @@ use rosu_pp::{
     beatmap::BeatmapAttributesBuilder, CatchPP, DifficultyAttributes, GameMode as Mode, OsuPP,
     TaikoPP,
 };
-use rosu_v2::prelude::{GameMode, GameMods, Grade, ScoreStatistics};
+use rosu_v2::prelude::{GameMode, GameMods, Grade, RankStatus, Score, ScoreStatistics};
 use time::OffsetDateTime;
 
 use crate::{
@@ -32,8 +35,6 @@ use crate::{
     },
     util::Emote,
 };
-
-use super::ScoreExt;
 
 pub fn grade_emote(grade: Grade) -> &'static str {
     BotConfig::get().grade(grade)
@@ -680,5 +681,88 @@ impl Display for MapInfo<'_> {
             round(attrs.hp as f32),
             round(self.stars),
         )
+    }
+}
+
+/// Note that all contained indices start at 0.
+pub enum PersonalBestIndex {
+    /// Found the score in the top100
+    FoundScore { idx: usize },
+    /// There was a score on the same map with more pp in the top100
+    FoundBetter { idx: usize },
+    /// Found another score on the same map and the
+    /// same mods that has more score but less pp
+    ScoreV1d { would_be_idx: usize, old_idx: usize },
+    /// Score is ranked and has enough pp to be in but wasn't found
+    Presumably { idx: usize },
+    /// Score is not ranked but has enough pp to be in the top100
+    IfRanked { idx: usize },
+    /// Score does not have enough pp to be in the top100
+    NotTop100,
+}
+
+impl PersonalBestIndex {
+    pub fn new(score: &ScoreSlim, map_id: u32, status: RankStatus, top100: &[Score]) -> Self {
+        // Note that the index is determined through float
+        // comparisons which could result in issues
+        let idx = top100
+            .binary_search_by(|probe| {
+                probe
+                    .pp
+                    .and_then(|pp| score.pp.partial_cmp(&pp))
+                    .unwrap_or(Ordering::Less)
+            })
+            .unwrap_or_else(identity);
+
+        if idx == 100 {
+            return Self::NotTop100;
+        } else if score.is_eq(&top100[idx]) {
+            // If multiple scores have the exact same pp as the given
+            // score then `idx` might not belong to the given score.
+            // Chances are pretty slim though so this should be fine.
+            return Self::FoundScore { idx };
+        } else if !matches!(status, RankStatus::Ranked) {
+            return Self::IfRanked { idx };
+        }
+
+        let (better, worse) = top100.split_at(idx);
+
+        // A case that's not covered is when there is a score
+        // with more pp on the same map with the same mods that has
+        // less score than the current score. Sounds really fringe though.
+        if let Some(idx) = better.iter().position(|top| top.map_id == map_id) {
+            Self::FoundBetter { idx }
+        } else if let Some(i) = worse.iter().position(|top| {
+            top.map_id == map_id && top.mods == score.mods && top.score > score.score
+        }) {
+            Self::ScoreV1d {
+                would_be_idx: idx,
+                old_idx: idx + i,
+            }
+        } else {
+            Self::Presumably { idx }
+        }
+    }
+
+    pub fn into_embed_description(self) -> Option<String> {
+        match self {
+            PersonalBestIndex::FoundScore { idx } => Some(format!("Personal Best #{}", idx + 1)),
+            PersonalBestIndex::FoundBetter { .. } => None,
+            PersonalBestIndex::ScoreV1d {
+                would_be_idx,
+                old_idx,
+            } => Some(format!(
+                "Personal Best #{idx} (v1'd by #{old})",
+                idx = would_be_idx + 1,
+                old = old_idx + 1
+            )),
+            PersonalBestIndex::Presumably { idx } => {
+                Some(format!("Personal Best #{} (maybe)", idx + 1))
+            }
+            PersonalBestIndex::IfRanked { idx } => {
+                Some(format!("Personal Best #{} (if ranked)", idx + 1))
+            }
+            PersonalBestIndex::NotTop100 => None,
+        }
     }
 }


### PR DESCRIPTION
Should fix #173 and implement #185 and #186.

Also splits up `ScoreExt` into sub-traits and moved them to `bathbot-util` / `bathbot-model`.