### PR TITLE
dont include full path in stored map filenames

### DIFF
--- a/bathbot-psql/src/model/osu/map.rs
+++ b/bathbot-psql/src/model/osu/map.rs
@@ -17,7 +17,7 @@ pub struct DbBeatmap {
 }
 
 #[derive(Debug)]
-pub enum DbMapPath {
+pub enum DbMapFilename {
     Present(String),
     ChecksumMismatch,
     Missing,


### PR DESCRIPTION
Executed `UPDATE osu_map_files SET map_filepath=REPLACE(map_filepath, '<MAP_PATH>', '');` and adjusted the code to accommodate prefixing the returned filenames with the `MAP_PATH`.