### PR TITLE
feat(bot): added reverse option to /scores commands

### DIFF
--- a/bathbot/src/commands/osu/scores/map.rs
+++ b/bathbot/src/commands/osu/scores/map.rs
@@ -1,18 +1,16 @@
-use std::{borrow::Cow, cmp::Reverse, collections::HashMap, fmt::Write, sync::Arc};
+use std::{borrow::Cow, fmt::Write, sync::Arc};
 
-use bathbot_psql::model::osu::DbScores;
 use bathbot_util::{
     constants::GENERAL_ISSUE,
     matcher,
     osu::{MapIdType, ModSelection},
-    IntHasher, MessageBuilder,
+    MessageBuilder,
 };
 use eyre::Result;
-use rosu_pp::beatmap::BeatmapAttributesBuilder;
-use rosu_v2::prelude::{GameMode, GameModsIntermode};
+use rosu_v2::prelude::GameMode;
 use twilight_interactions::command::AutocompleteValue;
 
-use super::{MapScores, ScoresOrder};
+use super::{process_scores, MapScores, ScoresOrder};
 use crate::{
     commands::osu::{
         compare::{slash_compare_score, ScoreOrder},
@@ -30,7 +28,7 @@ pub async fn map_scores(
 ) -> Result<()> {
     let Some(guild_id) = command.guild_id else {
         // TODO: use mode when /cs uses it
-        let MapScores { map, mode: _, sort, mods, index } = args;
+        let MapScores { map, mode: _, sort, mods, index, reverse:_ } = args;
 
         let sort = match sort {
             Some(ScoresOrder::Acc) => Some(ScoreOrder::Acc),
@@ -208,220 +206,13 @@ pub async fn map_scores(
 
     let sort = args.sort.unwrap_or_default();
     let content = msg_content(sort, mods.as_ref());
-
-    process_scores(&mut scores, sort);
+    process_scores(&mut scores, None, sort, args.reverse);
 
     MapScoresPagination::builder(scores, mode, sort, guild_icon)
         .content(content)
         .start_by_update()
         .start(ctx, (&mut command).into())
         .await
-}
-
-fn process_scores(scores: &mut DbScores<IntHasher>, sort: ScoresOrder) {
-    match sort {
-        ScoresOrder::Acc => scores.scores_mut().sort_unstable_by(|a, b| {
-            b.statistics
-                .accuracy(b.mode)
-                .total_cmp(&a.statistics.accuracy(a.mode))
-        }),
-        ScoresOrder::Ar => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let ars: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.ar))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_ar = BeatmapAttributesBuilder::default()
-                    .ar(ars[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .ar;
-
-                let b_ar = BeatmapAttributesBuilder::default()
-                    .ar(ars[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .ar;
-
-                b_ar.total_cmp(&a_ar)
-            })
-        }
-        ScoresOrder::Bpm => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let bpms: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.bpm))
-                .collect();
-
-            let mut clock_rates = HashMap::with_hasher(IntHasher);
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_clock_rate = *clock_rates
-                    .entry(a.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(a.mods).legacy_clock_rate());
-
-                let b_clock_rate = *clock_rates
-                    .entry(b.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(b.mods).legacy_clock_rate());
-
-                let a_bpm = bpms[&a.map_id] * a_clock_rate;
-                let b_bpm = bpms[&b.map_id] * b_clock_rate;
-
-                b_bpm.total_cmp(&a_bpm)
-            })
-        }
-        ScoresOrder::Combo => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.max_combo)),
-        ScoresOrder::Cs => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let css: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.cs))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_cs = BeatmapAttributesBuilder::default()
-                    .cs(css[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .cs;
-
-                let b_cs = BeatmapAttributesBuilder::default()
-                    .cs(css[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .cs;
-
-                b_cs.total_cmp(&a_cs)
-            })
-        }
-        ScoresOrder::Date => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.ended_at)),
-        ScoresOrder::Hp => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let hps: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.hp))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_ar = BeatmapAttributesBuilder::default()
-                    .hp(hps[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .hp;
-
-                let b_hp = BeatmapAttributesBuilder::default()
-                    .hp(hps[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .hp;
-
-                b_hp.total_cmp(&a_ar)
-            })
-        }
-        ScoresOrder::Length => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let seconds_drain: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.seconds_drain))
-                .collect();
-
-            let mut clock_rates = HashMap::with_hasher(IntHasher);
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_clock_rate = *clock_rates
-                    .entry(a.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(a.mods).legacy_clock_rate());
-
-                let b_clock_rate = *clock_rates
-                    .entry(b.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(b.mods).legacy_clock_rate());
-
-                let a_drain = seconds_drain[&a.map_id] as f32 / a_clock_rate;
-                let b_drain = seconds_drain[&b.map_id] as f32 / b_clock_rate;
-
-                b_drain.total_cmp(&a_drain)
-            })
-        }
-        ScoresOrder::Misses => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.statistics.count_miss)),
-        ScoresOrder::Od => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let ods: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.od))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_od = BeatmapAttributesBuilder::default()
-                    .od(ods[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .od;
-
-                let b_od = BeatmapAttributesBuilder::default()
-                    .od(ods[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .od;
-
-                b_od.total_cmp(&a_od)
-            })
-        }
-        ScoresOrder::Pp => {
-            scores.retain(|score, _, _, _| score.pp.is_some());
-
-            scores
-                .scores_mut()
-                .sort_unstable_by(|a, b| b.pp.unwrap().total_cmp(&a.pp.unwrap()))
-        }
-        ScoresOrder::RankedDate => {
-            scores.retain(|score, maps, mapsets, _| {
-                maps.get(&score.map_id)
-                    .and_then(|map| mapsets.get(&map.mapset_id))
-                    .and_then(|mapset| mapset.ranked_date)
-                    .is_some()
-            });
-
-            let ranked_dates: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .filter_map(|(map_id, map)| {
-                    scores
-                        .mapset(map.mapset_id)
-                        .and_then(|mapset| Some((*map_id, mapset.ranked_date?)))
-                })
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_ranked_date = ranked_dates[&a.map_id];
-                let b_ranked_date = ranked_dates[&b.map_id];
-
-                b_ranked_date.cmp(&a_ranked_date)
-            });
-        }
-        ScoresOrder::Score => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.score)),
-        ScoresOrder::Stars => {
-            scores.retain(|score, _, _, _| score.stars.is_some());
-
-            scores
-                .scores_mut()
-                .sort_unstable_by(|a, b| b.stars.unwrap().total_cmp(&a.stars.unwrap()))
-        }
-    }
 }
 
 fn msg_content(sort: ScoresOrder, mods: Option<&ModSelection>) -> String {

--- a/bathbot/src/commands/osu/scores/mod.rs
+++ b/bathbot/src/commands/osu/scores/mod.rs
@@ -1,7 +1,11 @@
-use std::sync::Arc;
+use std::{cmp::Reverse, collections::HashMap, sync::Arc};
 
 use bathbot_macros::{HasMods, HasName, SlashCommand};
+use bathbot_psql::model::osu::DbScores;
+use bathbot_util::IntHasher;
 use eyre::Result;
+use rosu_pp::beatmap::BeatmapAttributesBuilder;
+use rosu_v2::prelude::GameModsIntermode;
 use twilight_interactions::command::{CommandModel, CommandOption, CreateCommand, CreateOption};
 use twilight_model::id::{marker::UserMarker, Id};
 
@@ -51,6 +55,8 @@ pub struct ServerScores {
     country: Option<String>,
     /// Only show scores on maps of that mapper
     mapper: Option<String>,
+    /// Reverse the list
+    reverse: Option<bool>,
 }
 
 #[derive(Copy, Clone, CommandOption, CreateOption, Default)]
@@ -101,6 +107,8 @@ pub struct UserScores {
     mods: Option<String>,
     /// Only show scores on maps of that mapper
     mapper: Option<String>,
+    /// Reverse the list
+    reverse: Option<bool>,
     #[command(
         help = "Instead of specifying an osu! username with the `name` option, \
         you can use this option to choose a discord user.\n\
@@ -130,6 +138,8 @@ pub struct MapScores {
     /// While checking the channel history, I will choose the index-th map I can
     /// find
     index: Option<u32>,
+    /// Reverse the list
+    reverse: Option<bool>,
 }
 
 async fn slash_scores(ctx: Arc<Context>, mut command: InteractionCommand) -> Result<()> {
@@ -137,5 +147,227 @@ async fn slash_scores(ctx: Arc<Context>, mut command: InteractionCommand) -> Res
         Scores::Server(args) => server_scores(ctx, command, args).await,
         Scores::User(args) => user_scores(ctx, command, args).await,
         Scores::Map(args) => map_scores(ctx, command, args).await,
+    }
+}
+
+fn process_scores(
+    scores: &mut DbScores<IntHasher>,
+    creator_id: Option<u32>,
+    sort: ScoresOrder,
+    reverse: Option<bool>,
+) {
+    if let Some(creator_id) = creator_id {
+        scores.retain(|score, maps, _, _| match maps.get(&score.map_id) {
+            Some(map) => map.creator_id == creator_id,
+            None => false,
+        });
+    }
+
+    match sort {
+        ScoresOrder::Acc => scores.scores_mut().sort_unstable_by(|a, b| {
+            b.statistics
+                .accuracy(b.mode)
+                .total_cmp(&a.statistics.accuracy(a.mode))
+        }),
+        ScoresOrder::Ar => {
+            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
+
+            let ars: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .map(|(map_id, map)| (*map_id, map.ar))
+                .collect();
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_ar = BeatmapAttributesBuilder::default()
+                    .ar(ars[&a.map_id])
+                    .mods(a.mods)
+                    .build()
+                    .ar;
+
+                let b_ar = BeatmapAttributesBuilder::default()
+                    .ar(ars[&b.map_id])
+                    .mods(b.mods)
+                    .build()
+                    .ar;
+
+                b_ar.total_cmp(&a_ar)
+            })
+        }
+        ScoresOrder::Bpm => {
+            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
+
+            let bpms: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .map(|(map_id, map)| (*map_id, map.bpm))
+                .collect();
+
+            let mut clock_rates = HashMap::with_hasher(IntHasher);
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_clock_rate = *clock_rates
+                    .entry(a.mods)
+                    .or_insert_with(|| GameModsIntermode::from_bits(a.mods).legacy_clock_rate());
+
+                let b_clock_rate = *clock_rates
+                    .entry(b.mods)
+                    .or_insert_with(|| GameModsIntermode::from_bits(b.mods).legacy_clock_rate());
+
+                let a_bpm = bpms[&a.map_id] * a_clock_rate;
+                let b_bpm = bpms[&b.map_id] * b_clock_rate;
+
+                b_bpm.total_cmp(&a_bpm)
+            })
+        }
+        ScoresOrder::Combo => scores
+            .scores_mut()
+            .sort_unstable_by_key(|score| Reverse(score.max_combo)),
+        ScoresOrder::Cs => {
+            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
+
+            let css: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .map(|(map_id, map)| (*map_id, map.cs))
+                .collect();
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_cs = BeatmapAttributesBuilder::default()
+                    .cs(css[&a.map_id])
+                    .mods(a.mods)
+                    .build()
+                    .cs;
+
+                let b_cs = BeatmapAttributesBuilder::default()
+                    .cs(css[&b.map_id])
+                    .mods(b.mods)
+                    .build()
+                    .cs;
+
+                b_cs.total_cmp(&a_cs)
+            })
+        }
+        ScoresOrder::Date => scores
+            .scores_mut()
+            .sort_unstable_by_key(|score| Reverse(score.ended_at)),
+        ScoresOrder::Hp => {
+            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
+
+            let hps: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .map(|(map_id, map)| (*map_id, map.hp))
+                .collect();
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_ar = BeatmapAttributesBuilder::default()
+                    .hp(hps[&a.map_id])
+                    .mods(a.mods)
+                    .build()
+                    .hp;
+
+                let b_hp = BeatmapAttributesBuilder::default()
+                    .hp(hps[&b.map_id])
+                    .mods(b.mods)
+                    .build()
+                    .hp;
+
+                b_hp.total_cmp(&a_ar)
+            })
+        }
+        ScoresOrder::Length => {
+            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
+
+            let seconds_drain: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .map(|(map_id, map)| (*map_id, map.seconds_drain))
+                .collect();
+
+            let mut clock_rates = HashMap::with_hasher(IntHasher);
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_clock_rate = *clock_rates
+                    .entry(a.mods)
+                    .or_insert_with(|| GameModsIntermode::from_bits(a.mods).legacy_clock_rate());
+
+                let b_clock_rate = *clock_rates
+                    .entry(b.mods)
+                    .or_insert_with(|| GameModsIntermode::from_bits(b.mods).legacy_clock_rate());
+
+                let a_drain = seconds_drain[&a.map_id] as f32 / a_clock_rate;
+                let b_drain = seconds_drain[&b.map_id] as f32 / b_clock_rate;
+
+                b_drain.total_cmp(&a_drain)
+            })
+        }
+        ScoresOrder::Misses => scores
+            .scores_mut()
+            .sort_unstable_by_key(|score| Reverse(score.statistics.count_miss)),
+        ScoresOrder::Od => {
+            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
+
+            let ods: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .map(|(map_id, map)| (*map_id, map.od))
+                .collect();
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_od = BeatmapAttributesBuilder::default()
+                    .od(ods[&a.map_id])
+                    .mods(a.mods)
+                    .build()
+                    .od;
+
+                let b_od = BeatmapAttributesBuilder::default()
+                    .od(ods[&b.map_id])
+                    .mods(b.mods)
+                    .build()
+                    .od;
+
+                b_od.total_cmp(&a_od)
+            })
+        }
+        ScoresOrder::Pp => {
+            scores.retain(|score, _, _, _| score.pp.is_some());
+
+            scores
+                .scores_mut()
+                .sort_unstable_by(|a, b| b.pp.unwrap().total_cmp(&a.pp.unwrap()))
+        }
+        ScoresOrder::RankedDate => {
+            scores.retain(|score, maps, mapsets, _| {
+                maps.get(&score.map_id)
+                    .and_then(|map| mapsets.get(&map.mapset_id))
+                    .and_then(|mapset| mapset.ranked_date)
+                    .is_some()
+            });
+
+            let ranked_dates: HashMap<_, _, IntHasher> = scores
+                .maps()
+                .filter_map(|(map_id, map)| {
+                    scores
+                        .mapset(map.mapset_id)
+                        .and_then(|mapset| Some((*map_id, mapset.ranked_date?)))
+                })
+                .collect();
+
+            scores.scores_mut().sort_unstable_by(|a, b| {
+                let a_ranked_date = ranked_dates[&a.map_id];
+                let b_ranked_date = ranked_dates[&b.map_id];
+
+                b_ranked_date.cmp(&a_ranked_date)
+            });
+        }
+        ScoresOrder::Score => scores
+            .scores_mut()
+            .sort_unstable_by_key(|score| Reverse(score.score)),
+        ScoresOrder::Stars => {
+            scores.retain(|score, _, _, _| score.stars.is_some());
+
+            scores
+                .scores_mut()
+                .sort_unstable_by(|a, b| b.stars.unwrap().total_cmp(&a.stars.unwrap()))
+        }
+    }
+
+    if reverse == Some(true) {
+        scores.scores_mut().reverse();
     }
 }

--- a/bathbot/src/commands/osu/scores/server.rs
+++ b/bathbot/src/commands/osu/scores/server.rs
@@ -1,20 +1,18 @@
-use std::{borrow::Cow, cmp::Reverse, collections::HashMap, fmt::Write, sync::Arc};
+use std::{borrow::Cow, fmt::Write, sync::Arc};
 
 use bathbot_model::CountryCode;
-use bathbot_psql::model::osu::DbScores;
 use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
     osu::ModSelection,
-    CowUtils, IntHasher,
+    CowUtils,
 };
 use eyre::{Report, Result};
-use rosu_pp::beatmap::BeatmapAttributesBuilder;
 use rosu_v2::{
-    prelude::{GameMode, GameModsIntermode, OsuError},
+    prelude::{GameMode, OsuError},
     request::UserId,
 };
 
-use super::{ScoresOrder, ServerScores};
+use super::{process_scores, ServerScores};
 use crate::{
     commands::osu::{user_not_found, HasMods, ModsResult},
     core::Context,
@@ -130,227 +128,13 @@ pub async fn server_scores(
     );
 
     let sort = args.sort.unwrap_or_default();
-
-    process_scores(&mut scores, creator_id, sort);
+    process_scores(&mut scores, creator_id, sort, args.reverse);
 
     ServerScoresPagination::builder(scores, mode, sort, guild_icon)
         .content(content)
         .start_by_update()
         .start(ctx, (&mut command).into())
         .await
-}
-
-fn process_scores(scores: &mut DbScores<IntHasher>, creator_id: Option<u32>, sort: ScoresOrder) {
-    if let Some(creator_id) = creator_id {
-        scores.retain(|score, maps, _, _| match maps.get(&score.map_id) {
-            Some(map) => map.creator_id == creator_id,
-            None => false,
-        });
-    }
-
-    match sort {
-        ScoresOrder::Acc => scores.scores_mut().sort_unstable_by(|a, b| {
-            b.statistics
-                .accuracy(b.mode)
-                .total_cmp(&a.statistics.accuracy(a.mode))
-        }),
-        ScoresOrder::Ar => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let ars: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.ar))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_ar = BeatmapAttributesBuilder::default()
-                    .ar(ars[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .ar;
-
-                let b_ar = BeatmapAttributesBuilder::default()
-                    .ar(ars[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .ar;
-
-                b_ar.total_cmp(&a_ar)
-            })
-        }
-        ScoresOrder::Bpm => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let bpms: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.bpm))
-                .collect();
-
-            let mut clock_rates = HashMap::with_hasher(IntHasher);
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_clock_rate = *clock_rates
-                    .entry(a.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(a.mods).legacy_clock_rate());
-
-                let b_clock_rate = *clock_rates
-                    .entry(b.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(b.mods).legacy_clock_rate());
-
-                let a_bpm = bpms[&a.map_id] * a_clock_rate;
-                let b_bpm = bpms[&b.map_id] * b_clock_rate;
-
-                b_bpm.total_cmp(&a_bpm)
-            })
-        }
-        ScoresOrder::Combo => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.max_combo)),
-        ScoresOrder::Cs => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let css: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.cs))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_cs = BeatmapAttributesBuilder::default()
-                    .cs(css[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .cs;
-
-                let b_cs = BeatmapAttributesBuilder::default()
-                    .cs(css[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .cs;
-
-                b_cs.total_cmp(&a_cs)
-            })
-        }
-        ScoresOrder::Date => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.ended_at)),
-        ScoresOrder::Hp => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let hps: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.hp))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_ar = BeatmapAttributesBuilder::default()
-                    .hp(hps[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .hp;
-
-                let b_hp = BeatmapAttributesBuilder::default()
-                    .hp(hps[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .hp;
-
-                b_hp.total_cmp(&a_ar)
-            })
-        }
-        ScoresOrder::Length => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let seconds_drain: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.seconds_drain))
-                .collect();
-
-            let mut clock_rates = HashMap::with_hasher(IntHasher);
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_clock_rate = *clock_rates
-                    .entry(a.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(a.mods).legacy_clock_rate());
-
-                let b_clock_rate = *clock_rates
-                    .entry(b.mods)
-                    .or_insert_with(|| GameModsIntermode::from_bits(b.mods).legacy_clock_rate());
-
-                let a_drain = seconds_drain[&a.map_id] as f32 / a_clock_rate;
-                let b_drain = seconds_drain[&b.map_id] as f32 / b_clock_rate;
-
-                b_drain.total_cmp(&a_drain)
-            })
-        }
-        ScoresOrder::Misses => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.statistics.count_miss)),
-        ScoresOrder::Od => {
-            scores.retain(|score, maps, _, _| maps.get(&score.map_id).is_some());
-
-            let ods: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .map(|(map_id, map)| (*map_id, map.od))
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_od = BeatmapAttributesBuilder::default()
-                    .od(ods[&a.map_id])
-                    .mods(a.mods)
-                    .build()
-                    .od;
-
-                let b_od = BeatmapAttributesBuilder::default()
-                    .od(ods[&b.map_id])
-                    .mods(b.mods)
-                    .build()
-                    .od;
-
-                b_od.total_cmp(&a_od)
-            })
-        }
-        ScoresOrder::Pp => {
-            scores.retain(|score, _, _, _| score.pp.is_some());
-
-            scores
-                .scores_mut()
-                .sort_unstable_by(|a, b| b.pp.unwrap().total_cmp(&a.pp.unwrap()))
-        }
-        ScoresOrder::RankedDate => {
-            scores.retain(|score, maps, mapsets, _| {
-                maps.get(&score.map_id)
-                    .and_then(|map| mapsets.get(&map.mapset_id))
-                    .and_then(|mapset| mapset.ranked_date)
-                    .is_some()
-            });
-
-            let ranked_dates: HashMap<_, _, IntHasher> = scores
-                .maps()
-                .filter_map(|(map_id, map)| {
-                    scores
-                        .mapset(map.mapset_id)
-                        .and_then(|mapset| Some((*map_id, mapset.ranked_date?)))
-                })
-                .collect();
-
-            scores.scores_mut().sort_unstable_by(|a, b| {
-                let a_ranked_date = ranked_dates[&a.map_id];
-                let b_ranked_date = ranked_dates[&b.map_id];
-
-                b_ranked_date.cmp(&a_ranked_date)
-            });
-        }
-        ScoresOrder::Score => scores
-            .scores_mut()
-            .sort_unstable_by_key(|score| Reverse(score.score)),
-        ScoresOrder::Stars => {
-            scores.retain(|score, _, _, _| score.stars.is_some());
-
-            scores
-                .scores_mut()
-                .sort_unstable_by(|a, b| b.stars.unwrap().total_cmp(&a.stars.unwrap()))
-        }
-    }
 }
 
 fn msg_content(mods: Option<&ModSelection>, mapper: Option<&str>, country: Option<&str>) -> String {


### PR DESCRIPTION
Also refactored `process_scores` to the parent module.

closes #291 