### PR TITLE
feat(bot,psql): delete scores of restricted users

### DIFF
--- a/bathbot-psql/sqlx-data.json
+++ b/bathbot-psql/sqlx-data.json
@@ -1969,6 +1969,18 @@
     },
     "query": "\nSELECT \n  mapsets.mapset_id, \n  artist, \n  title, \n  rank_status, \n  ranked_date \nFROM \n  (\n    SELECT \n      mapset_id \n    FROM \n      osu_maps \n    WHERE \n      map_id = ANY($1)\n  ) AS maps \n  JOIN (\n    SELECT \n      * \n    FROM \n      osu_mapsets\n  ) AS mapsets ON maps.mapset_id = mapsets.mapset_id"
   },
+  "a52bab87e68e0afd8f671d0d97ea6299589d5f59107633ff056e9b373eac7f28": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "\nDELETE FROM \n  osu_scores \nWHERE \n  user_id = $1"
+  },
   "adfe9de02db6d8af635558f7c243b4c7c13093b460943160577157b01cb2c5d4": {
     "describe": {
       "columns": [

--- a/bathbot-psql/src/impls/osu/name.rs
+++ b/bathbot-psql/src/impls/osu/name.rs
@@ -119,7 +119,7 @@ WHERE
         query
             .execute(executor)
             .await
-            .wrap_err("failed to execute query")?;
+            .wrap_err("Failed to execute names query")?;
 
         Ok(())
     }

--- a/bathbot-psql/src/impls/osu/user.rs
+++ b/bathbot-psql/src/impls/osu/user.rs
@@ -802,11 +802,11 @@ SET
         Ok(())
     }
 
-    pub async fn delete_osu_user_stats(&self, user_id: u32) -> Result<()> {
+    pub async fn delete_osu_user_stats_and_scores(&self, user_id: u32) -> Result<()> {
         let mut conn = self
             .acquire()
             .await
-            .wrap_err("failed to acquire connection")?;
+            .wrap_err("Failed to acquire connection")?;
 
         let query = sqlx::query!(
             r#"
@@ -820,7 +820,7 @@ WHERE
         query
             .execute(&mut conn)
             .await
-            .wrap_err("failed to execute osu_user_stats query")?;
+            .wrap_err("Failed to execute osu_user_stats query")?;
 
         let query = sqlx::query!(
             r#"
@@ -834,8 +834,11 @@ WHERE
         query
             .execute(&mut conn)
             .await
-            .wrap_err("failed to execute osu_user_mode_stats query")?;
+            .wrap_err("Failed to execute osu_user_mode_stats query")?;
 
-        Self::delete_osu_username(&mut conn, user_id).await
+        Self::delete_osu_username(&mut conn, user_id).await?;
+        Self::delete_scores_by_user_id(&mut conn, user_id).await?;
+
+        Ok(())
     }
 }

--- a/bathbot/src/manager/osu_scores.rs
+++ b/bathbot/src/manager/osu_scores.rs
@@ -207,7 +207,7 @@ impl<'c> ScoreArgs<'c> {
             Err(OsuError::NotFound) => {
                 // Remove stats of unknown/restricted users so they don't appear in the
                 // leaderboard
-                if let Err(err) = ctx.osu_user().remove_stats(user_id).await {
+                if let Err(err) = ctx.osu_user().remove_stats_and_scores(user_id).await {
                     let wrap = "Failed to remove stats of unknown user";
                     warn!("{:?}", err.wrap_err(wrap));
                 }

--- a/bathbot/src/manager/osu_user.rs
+++ b/bathbot/src/manager/osu_user.rs
@@ -93,10 +93,10 @@ impl<'d> OsuUserManager<'d> {
             .wrap_err("Failed to upsert osu user")
     }
 
-    pub async fn remove_stats(self, user_id: u32) -> Result<()> {
+    pub async fn remove_stats_and_scores(self, user_id: u32) -> Result<()> {
         self.psql
-            .delete_osu_user_stats(user_id)
+            .delete_osu_user_stats_and_scores(user_id)
             .await
-            .wrap_err("Failed to delete osu user stats")
+            .wrap_err("Failed to delete osu user data")
     }
 }

--- a/bathbot/src/manager/redis/osu.rs
+++ b/bathbot/src/manager/redis/osu.rs
@@ -165,8 +165,8 @@ impl<'c> RedisManager<'c> {
             Err(OsuError::NotFound) => {
                 // Remove stats of unknown/restricted users so they don't appear in the
                 // leaderboard
-                if let Err(err) = self.ctx.osu_user().remove_stats(user_id).await {
-                    let wrap = "failed to remove stats of unknown user";
+                if let Err(err) = self.ctx.osu_user().remove_stats_and_scores(user_id).await {
+                    let wrap = "Failed to remove stats of unknown user";
                     warn!("{:?}", err.wrap_err(wrap));
                 }
 


### PR DESCRIPTION
closes #295 

Since the bot can't check whether a given user is restricted in `/scores server`, it can't filter out such scores. However, in addition to removing user stats of restricted users, scores will now also be removed whenever a user or their scores are requested and the bot notices they're restricted.