### PR TITLE
feat(bot): add top100 to osc

### DIFF
--- a/bathbot-model/src/osu_stats.rs
+++ b/bathbot-model/src/osu_stats.rs
@@ -320,7 +320,7 @@ impl Display for OsuStatsScoresOrder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct OsuStatsParams {
     pub username: Username,
     pub mode: GameMode,

--- a/bathbot-model/src/osu_stats.rs
+++ b/bathbot-model/src/osu_stats.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use bathbot_util::{osu::ModSelection, ScoreExt, ScoreHasEndedAt};
+use eyre::{Result, WrapErr};
 use rosu_v2::prelude::{GameMod, GameMode, GameMods, Grade, RankStatus, Username};
 use serde::{
     de::{
@@ -53,23 +54,52 @@ impl<'de> Deserialize<'de> for OsuStatsPlayer {
     }
 }
 
+/// Wrapper to avoid premature deserialization of the scores if only the count
+/// is needed
+pub struct OsuStatsScoresRaw {
+    mode: GameMode,
+    bytes: Vec<u8>,
+}
+
+impl OsuStatsScoresRaw {
+    pub fn new(mode: GameMode, bytes: Vec<u8>) -> Self {
+        Self { mode, bytes }
+    }
+
+    pub fn count(&self) -> Result<usize> {
+        let count_res = self
+            .bytes
+            .rsplit(|byte| *byte == b',')
+            .nth(2)
+            .map(|bytes| std::str::from_utf8(bytes).map(str::parse));
+
+        if let Some(Ok(Ok(count))) = count_res {
+            Ok(count)
+        } else {
+            let body = String::from_utf8_lossy(&self.bytes);
+
+            eyre::bail!("Failed to deserialize osustats global: {body}")
+        }
+    }
+
+    pub fn into_scores(self) -> Result<OsuStatsScores> {
+        let mut deserializer = serde_json::Deserializer::from_slice(&self.bytes);
+
+        self.deserialize(&mut deserializer).wrap_err_with(|| {
+            let body = String::from_utf8_lossy(&self.bytes);
+
+            format!("Failed to deserialize osustats global: {body}")
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct OsuStatsScores {
     pub scores: Vec<OsuStatsScore>,
     pub count: usize,
 }
 
-pub struct OsuStatsScoresSeed {
-    mode: GameMode,
-}
-
-impl OsuStatsScoresSeed {
-    pub fn new(mode: GameMode) -> Self {
-        Self { mode }
-    }
-}
-
-impl<'de> DeserializeSeed<'de> for OsuStatsScoresSeed {
+impl<'de> DeserializeSeed<'de> for &OsuStatsScoresRaw {
     type Value = OsuStatsScores;
 
     fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
@@ -77,7 +107,7 @@ impl<'de> DeserializeSeed<'de> for OsuStatsScoresSeed {
     }
 }
 
-impl<'de> Visitor<'de> for OsuStatsScoresSeed {
+impl<'de> Visitor<'de> for &OsuStatsScoresRaw {
     type Value = OsuStatsScores;
 
     fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/bathbot-model/src/osu_stats.rs
+++ b/bathbot-model/src/osu_stats.rs
@@ -78,7 +78,7 @@ impl OsuStatsScoresRaw {
         } else {
             let body = String::from_utf8_lossy(&self.bytes);
 
-            eyre::bail!("Failed to deserialize osustats global: {body}")
+            eyre::bail!("Failed to deserialize count of osustats: {body}")
         }
     }
 

--- a/bathbot/src/embeds/osu/osustats_counts.rs
+++ b/bathbot/src/embeds/osu/osustats_counts.rs
@@ -31,11 +31,8 @@ impl OsuStatsCountsEmbed {
         let mut description = String::with_capacity(64);
         description.push_str("```\n");
 
-        let has_top100 = counts.top100s.is_some();
-        let top_n_len = 2 + has_top100 as usize;
-
         for TopCount { top_n, count, rank } in counts {
-            let _ = write!(description, "Top {top_n:<top_n_len$}:  {count:>count_len$}");
+            let _ = write!(description, "Top {top_n:<3}:  {count:>count_len$}");
 
             if let Some(rank) = rank {
                 let _ = writeln!(description, "   #{rank}");

--- a/bathbot/src/util/osu.rs
+++ b/bathbot/src/util/osu.rs
@@ -135,9 +135,11 @@ impl TopCounts {
 
                     let next_next_fut = ctx.client().get_global_scores(&params_clone);
 
-                    let ((_, next_count_), (_, next_next_count_)) =
-                        tokio::try_join!(next_fut, next_next_fut)
-                            .wrap_err("Failed to get global scores count")?;
+                    let (next_raw, next_next_raw) = tokio::try_join!(next_fut, next_next_fut)
+                        .wrap_err("Failed to get global scores count")?;
+
+                    let next_count_ = next_raw.count()?;
+                    let next_next_count_ = next_next_raw.count()?;
 
                     next_count.write(WithComma::new(next_count_).to_string().into());
                     next_next_count.write(WithComma::new(next_next_count_).to_string().into());
@@ -145,10 +147,11 @@ impl TopCounts {
                     next_next_count_
                 }
                 None => {
-                    let (_, next_count_) = next_fut
+                    let next_raw = next_fut
                         .await
                         .wrap_err("Failed to get global scores count")?;
 
+                    let next_count_ = next_raw.count()?;
                     next_count.write(WithComma::new(next_count_).to_string().into());
 
                     next_count_


### PR DESCRIPTION
- Closes #261 
- Speeds osc up by requesting 2 ranks at a time concurrently
- Speeds osc up by only deserializing the count and not the scores

