### PR TITLE
feat(bot): miss analyzer integration

### DIFF
--- a/bathbot-client/src/lib.rs
+++ b/bathbot-client/src/lib.rs
@@ -8,6 +8,7 @@ mod client;
 mod discord;
 mod error;
 mod metrics;
+mod miss_analyzer;
 mod multipart;
 mod osu;
 mod site;

--- a/bathbot-client/src/miss_analyzer.rs
+++ b/bathbot-client/src/miss_analyzer.rs
@@ -54,13 +54,8 @@ impl Client {
         };
         let json = serde_json::to_vec(&body).unwrap();
 
-        let bytes = self
-            .make_json_post_request(url, Site::MissAnalyzer, json)
+        self.make_json_post_request(url, Site::MissAnalyzer, json)
             .await?;
-
-        let response = String::from_utf8_lossy(&bytes);
-
-        debug!("Miss analyzer response: {response}");
 
         Ok(())
     }

--- a/bathbot-client/src/miss_analyzer.rs
+++ b/bathbot-client/src/miss_analyzer.rs
@@ -1,0 +1,67 @@
+use eyre::{Result, WrapErr};
+use serde::Serialize;
+
+use crate::{site::Site, Client};
+
+impl Client {
+    pub async fn miss_analyzer_score_request(&self, guild_id: u64, score_id: u64) -> Result<bool> {
+        let url = "http://104.6.255.43:24342/api/scorerequest";
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body {
+            guild_id: u64,
+            score_id: u64,
+        }
+
+        let body = Body { guild_id, score_id };
+        let json = serde_json::to_vec(&body).unwrap();
+
+        let bytes = self
+            .make_json_post_request(url, Site::MissAnalyzer, json)
+            .await?;
+
+        serde_json::from_slice(&bytes).wrap_err_with(|| {
+            let body = String::from_utf8_lossy(&bytes);
+
+            format!("Failed to deserialize miss analyzer request: {body}")
+        })
+    }
+
+    pub async fn miss_analyzer_score_response(
+        &self,
+        guild_id: u64,
+        channel_id: u64,
+        message_id: u64,
+        score_id: u64,
+    ) -> Result<()> {
+        let url = "http://104.6.255.43:24342/api/scoreresponse";
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body {
+            guild_id: u64,
+            channel_id: u64,
+            message_id: u64,
+            score_id: u64,
+        }
+
+        let body = Body {
+            guild_id,
+            channel_id,
+            message_id,
+            score_id,
+        };
+        let json = serde_json::to_vec(&body).unwrap();
+
+        let bytes = self
+            .make_json_post_request(url, Site::MissAnalyzer, json)
+            .await?;
+
+        let response = String::from_utf8_lossy(&bytes);
+
+        debug!("Miss analyzer response: {response}");
+
+        Ok(())
+    }
+}

--- a/bathbot-client/src/osu.rs
+++ b/bathbot-client/src/osu.rs
@@ -179,7 +179,9 @@ impl Client {
         let url = "https://osekai.net/medals/api/medals.php";
         let form = Multipart::new().push_text("strSearch", "");
 
-        let bytes = self.make_post_request(url, Site::Osekai, form).await?;
+        let bytes = self
+            .make_multipart_post_request(url, Site::Osekai, form)
+            .await?;
 
         let medals: OsekaiMedals = serde_json::from_slice(&bytes).wrap_err_with(|| {
             let body = String::from_utf8_lossy(&bytes);
@@ -194,7 +196,9 @@ impl Client {
         let url = "https://osekai.net/medals/api/beatmaps.php";
         let form = Multipart::new().push_text("strSearch", medal_name);
 
-        let bytes = self.make_post_request(url, Site::Osekai, form).await?;
+        let bytes = self
+            .make_multipart_post_request(url, Site::Osekai, form)
+            .await?;
 
         let maps: OsekaiMaps = serde_json::from_slice(&bytes).wrap_err_with(|| {
             let body = String::from_utf8_lossy(&bytes);
@@ -212,7 +216,9 @@ impl Client {
             .push_text("strMedalID", medal_id)
             .push_text("bGetComments", "true");
 
-        let bytes = self.make_post_request(url, Site::Osekai, form).await?;
+        let bytes = self
+            .make_multipart_post_request(url, Site::Osekai, form)
+            .await?;
 
         let comments: OsekaiComments = serde_json::from_slice(&bytes).wrap_err_with(|| {
             let body = String::from_utf8_lossy(&bytes);
@@ -228,7 +234,9 @@ impl Client {
         let url = "https://osekai.net/rankings/api/api.php";
         let form = Multipart::new().push_text("App", R::FORM);
 
-        let bytes = self.make_post_request(url, Site::Osekai, form).await?;
+        let bytes = self
+            .make_multipart_post_request(url, Site::Osekai, form)
+            .await?;
 
         serde_json::from_slice::<OsekaiRankingEntries<R>>(&bytes)
             .map(Vec::from)
@@ -404,7 +412,7 @@ impl Client {
         }
 
         let url = "https://osustats.ppy.sh/api/getScoreRanking";
-        let post_fut = self.make_post_request(url, Site::OsuStats, form);
+        let post_fut = self.make_multipart_post_request(url, Site::OsuStats, form);
 
         let bytes = match timeout(Duration::from_secs(4), post_fut).await {
             Ok(Ok(bytes)) => bytes,
@@ -444,7 +452,7 @@ impl Client {
         }
 
         let url = "https://osustats.ppy.sh/api/getScores";
-        let post_fut = self.make_post_request(url, Site::OsuStats, form);
+        let post_fut = self.make_multipart_post_request(url, Site::OsuStats, form);
 
         let bytes = match timeout(Duration::from_secs(4), post_fut).await {
             Ok(Ok(bytes)) => bytes,

--- a/bathbot-client/src/site.rs
+++ b/bathbot-client/src/site.rs
@@ -3,6 +3,7 @@
 pub enum Site {
     DiscordAttachment,
     Huismetbenen,
+    MissAnalyzer,
     Osekai,
     OsuAvatar,
     OsuBadge,
@@ -20,6 +21,7 @@ impl Site {
         match self {
             Self::DiscordAttachment => "DiscordAttachment",
             Self::Huismetbenen => "Huismetbenen",
+            Self::MissAnalyzer => "MissAnalyzer",
             Self::Osekai => "Osekai",
             Self::OsuAvatar => "OsuAvatar",
             Self::OsuBadge => "OsuBadge",

--- a/bathbot-util/src/constants.rs
+++ b/bathbot-util/src/constants.rs
@@ -1,3 +1,5 @@
+use twilight_model::id::{marker::UserMarker, Id};
+
 // Colors
 pub const DARK_GREEN: u32 = 0x1F8B4C;
 pub const RED: u32 = 0xE74C3C;
@@ -42,3 +44,4 @@ pub const BATHBOT_WORKSHOP: &str = "https://discord.gg/n9fFstG";
 pub const BATHBOT_GITHUB: &str = "https://github.com/MaxOhn/Bathbot";
 pub const BATHBOT_ROADMAP: &str = "https://github.com/users/MaxOhn/projects/3";
 pub const KOFI: &str = "https://ko-fi.com/bathbot";
+pub const MISS_ANALYZER_ID: Id<UserMarker> = Id::new(752035690237394944);

--- a/bathbot/src/commands/osu/mod.rs
+++ b/bathbot/src/commands/osu/mod.rs
@@ -71,7 +71,13 @@ use bathbot_util::osu::ModSelection;
 use eyre::{Report, Result, WrapErr};
 use rosu_v2::request::UserId;
 use twilight_interactions::command::{CommandOption, CreateOption};
-use twilight_model::id::{marker::UserMarker, Id};
+use twilight_model::{
+    channel::message::{
+        component::{ActionRow, Button, ButtonStyle},
+        Component,
+    },
+    id::{marker::UserMarker, Id},
+};
 
 #[cfg(feature = "server")]
 pub use self::link::*;
@@ -84,7 +90,7 @@ pub use self::{
     osustats::*, pinned::*, popular::*, pp::*, profile::*, rank::*, ranking::*, ratios::*,
     recent::*, scores::*, serverleaderboard::*, simulate::*, snipe::*, top::*, whatif::*,
 };
-use crate::{core::commands::CommandOrigin, Context};
+use crate::{core::commands::CommandOrigin, util::Emote, Context};
 
 mod attributes;
 mod avatar;
@@ -321,4 +327,19 @@ enum UserExtraction {
     Err(Report),
     Content(String),
     None,
+}
+
+pub fn miss_analyzer_components() -> Vec<Component> {
+    let miss_analyzer = Button {
+        custom_id: Some("miss_analyzer".to_owned()),
+        disabled: false,
+        emoji: Some(Emote::Miss.reaction_type()),
+        label: Some("Miss analyzer".to_owned()),
+        style: ButtonStyle::Secondary,
+        url: None,
+    };
+
+    let components = vec![Component::Button(miss_analyzer)];
+
+    vec![Component::ActionRow(ActionRow { components })]
 }

--- a/bathbot/src/core/events/interaction/component.rs
+++ b/bathbot/src/core/events/interaction/component.rs
@@ -45,6 +45,7 @@ pub async fn handle_component(ctx: Arc<Context>, mut component: InteractionCompo
             handle_sim_version(ctx, component).await
         }
         "sim_attrs" => handle_sim_attrs_button(ctx, component).await,
+        "miss_analyzer" => handle_miss_analyzer_button(ctx, component).await,
         _ => return error!(name, "Unknown message component"),
     };
 

--- a/bathbot/src/pagination/miss_analyzer.rs
+++ b/bathbot/src/pagination/miss_analyzer.rs
@@ -1,0 +1,36 @@
+use eyre::{Report, Result};
+use twilight_model::channel::message::Embed;
+
+use super::{Pages, PaginationBuilder, PaginationKind};
+
+pub struct MissAnalyzerPagination {
+    pub score_id: u64,
+    initial_embed: Option<Embed>,
+    pub edited_embed: Option<Embed>,
+    pub content: Option<String>,
+}
+
+impl MissAnalyzerPagination {
+    pub fn builder(
+        score_id: u64,
+        initial_embed: Embed,
+        edited_embed: Option<Embed>,
+        content: Option<String>,
+    ) -> PaginationBuilder {
+        let kind = Self {
+            score_id,
+            initial_embed: Some(initial_embed),
+            edited_embed,
+            content,
+        };
+        let pages = Pages::new(1, 3); // pagination only starts when there's more than one page
+
+        PaginationBuilder::new(PaginationKind::MissAnalyzer(kind), pages)
+    }
+
+    pub fn build_page(&mut self) -> Result<Embed> {
+        self.initial_embed
+            .take()
+            .ok_or_else(|| Report::msg("Already used miss analyzer embed"))
+    }
+}

--- a/bathbot/src/pagination/miss_analyzer.rs
+++ b/bathbot/src/pagination/miss_analyzer.rs
@@ -25,7 +25,7 @@ impl MissAnalyzerPagination {
         };
         let pages = Pages::new(1, 3); // pagination only starts when there's more than one page
 
-        PaginationBuilder::new(PaginationKind::MissAnalyzer(kind), pages)
+        PaginationBuilder::new(PaginationKind::MissAnalyzer(Box::new(kind)), pages)
     }
 
     pub fn build_page(&mut self) -> Result<Embed> {

--- a/bathbot/src/pagination/mod.rs
+++ b/bathbot/src/pagination/mod.rs
@@ -175,14 +175,14 @@ impl PaginationKind {
                     builder = builder.content(content);
                 }
 
-                if let Some(update_fut) = (msg, channel).update(&ctx, &builder, None) {
+                if let Some(update_fut) = (msg, channel).update(ctx, &builder, None) {
                     update_fut.await.wrap_err("Failed to minimize embed")?;
                 }
             }
         } else {
             let builder = MessageBuilder::new().components(Vec::new());
 
-            if let Some(update_fut) = (msg, channel).update(&ctx, &builder, None) {
+            if let Some(update_fut) = (msg, channel).update(ctx, &builder, None) {
                 update_fut.await.wrap_err("Failed to remove components")?;
             }
         }

--- a/bathbot/src/pagination/mod.rs
+++ b/bathbot/src/pagination/mod.rs
@@ -87,7 +87,7 @@ pub enum PaginationKind {
     MedalsCommon(Box<MedalsCommonPagination>),
     MedalsList(Box<MedalsListPagination>),
     MedalsMissing(Box<MedalsMissingPagination>),
-    MissAnalyzer(MissAnalyzerPagination),
+    MissAnalyzer(Box<MissAnalyzerPagination>),
     MostPlayed(Box<MostPlayedPagination>),
     MostPlayedCommon(Box<MostPlayedCommonPagination>),
     NoChoke(Box<NoChokePagination>),


### PR DESCRIPTION
Makes the `/rs` command interact with [Miss Analyzer](https://github.com/ThereGoesMySanity/osuMissAnalyzer).
Adds a button to notify Miss Analyzer.