### PR TITLE
Fix skin link formatting

### DIFF
--- a/bathbot/src/embeds/osu/profile.rs
+++ b/bathbot/src/embeds/osu/profile.rs
@@ -7,7 +7,7 @@ use bathbot_model::{
 use bathbot_util::{
     datetime::{HowLongAgoText, SecToMinSec, NAIVE_DATETIME_FORMAT},
     numbers::{round, WithComma},
-    AuthorBuilder, CowUtils, EmbedBuilder, FooterBuilder,
+    AuthorBuilder, EmbedBuilder, FooterBuilder,
 };
 use rkyv::{
     with::{DeserializeWith, Map},
@@ -82,7 +82,7 @@ impl ProfileEmbed {
         );
 
         if let Some(skin_url) = skin_url {
-            let skin_tooltip = skin_url.cow_replace("https://", "");
+            let skin_tooltip = skin_url.trim_start_matches("https://");
             let _ = write!(
                 description,
                 " • [**Link to skin**]({skin_url} \"{skin_tooltip}\")"

--- a/bathbot/src/embeds/osu/profile.rs
+++ b/bathbot/src/embeds/osu/profile.rs
@@ -7,7 +7,7 @@ use bathbot_model::{
 use bathbot_util::{
     datetime::{HowLongAgoText, SecToMinSec, NAIVE_DATETIME_FORMAT},
     numbers::{round, WithComma},
-    AuthorBuilder, EmbedBuilder, FooterBuilder,
+    AuthorBuilder, CowUtils, EmbedBuilder, FooterBuilder,
 };
 use rkyv::{
     with::{DeserializeWith, Map},
@@ -82,9 +82,10 @@ impl ProfileEmbed {
         );
 
         if let Some(skin_url) = skin_url {
+            let skin_tooltip = skin_url.cow_replace("https://", "");
             let _ = write!(
                 description,
-                " • [**Link to skin**]({skin_url} \"{skin_url}\")"
+                " • [**Link to skin**]({skin_url} \"{skin_tooltip}\")"
             );
         }
 

--- a/bathbot/src/embeds/utility/skins.rs
+++ b/bathbot/src/embeds/utility/skins.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use bathbot_macros::EmbedData;
 use bathbot_psql::model::configs::SkinEntry;
-use bathbot_util::{constants::OSU_BASE, CowUtils, FooterBuilder};
+use bathbot_util::{constants::OSU_BASE, FooterBuilder};
 
 use crate::pagination::Pages;
 
@@ -46,7 +46,7 @@ impl SkinsEmbed {
                 name_len = left_lengths.name,
                 user_id = left.user_id,
                 skin_url = left.skin_url,
-                skin_tooltip = left.skin_url.cow_replace("https://", ""),
+                skin_tooltip = left.skin_url.trim_start_matches("https://"),
             );
 
             if let Some(right) = right {
@@ -59,7 +59,7 @@ impl SkinsEmbed {
                     name_len = right_lengths.name,
                     user_id = right.user_id,
                     skin_url = right.skin_url,
-                    skin_tooltip = right.skin_url.cow_replace("https://", ""),
+                    skin_tooltip = right.skin_url.trim_start_matches("https://"),
                 );
             }
 

--- a/bathbot/src/embeds/utility/skins.rs
+++ b/bathbot/src/embeds/utility/skins.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use bathbot_macros::EmbedData;
 use bathbot_psql::model::configs::SkinEntry;
-use bathbot_util::{constants::OSU_BASE, FooterBuilder};
+use bathbot_util::{constants::OSU_BASE, CowUtils, FooterBuilder};
 
 use crate::pagination::Pages;
 
@@ -40,24 +40,26 @@ impl SkinsEmbed {
         for ((left, right), idx) in user_iter.zip(idx + 1..) {
             let _ = write!(
                 description,
-                "`#{idx:<idx_len$}` [`{name:<name_len$}`]({OSU_BASE}u/{user_id}) [`Skin`]({skin_url})",
+                "`#{idx:<idx_len$}` [`{name:<name_len$}`]({OSU_BASE}u/{user_id}) [`Skin`]({skin_url} \"{skin_tooltip}\")",
                 idx_len = left_lengths.idx,
                 name = left.username,
                 name_len = left_lengths.name,
                 user_id = left.user_id,
                 skin_url = left.skin_url,
+                skin_tooltip = left.skin_url.cow_replace("https://", ""),
             );
 
             if let Some(right) = right {
                 let _ = write!(
                     description,
-                    "|`#{idx:<idx_len$}` [`{name:<name_len$}`]({OSU_BASE}u/{user_id}) [`Skin`]({skin_url})",
+                    "|`#{idx:<idx_len$}` [`{name:<name_len$}`]({OSU_BASE}u/{user_id}) [`Skin`]({skin_url} \"{skin_tooltip}\")",
                     idx = idx + 10,
                     idx_len = right_lengths.idx,
                     name = right.username,
                     name_len = right_lengths.name,
                     user_id = right.user_id,
                     skin_url = right.skin_url,
+                    skin_tooltip = right.skin_url.cow_replace("https://", ""),
                 );
             }
 


### PR DESCRIPTION
I did some testing and it seems that Discord doesn't like having the `https://` in the link tooltips. 

I think showing the link like this without the `https://` is better than straight up removing the tooltip completely. Because of that, I also added the tooltip to the skin list command.