### PR TITLE
Display precise acc on hover in profile command

### DIFF
--- a/bathbot/src/commands/osu/profile/mod.rs
+++ b/bathbot/src/commands/osu/profile/mod.rs
@@ -18,6 +18,7 @@ use super::{require_link, user_not_found};
 use crate::{
     commands::GameModeOption,
     core::commands::{prefix::Args, CommandOrigin},
+    embeds::MessageOrigin,
     manager::redis::osu::UserArgs,
     pagination::ProfilePagination,
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
@@ -237,7 +238,8 @@ async fn profile(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Profile<'_>) 
 
     let tz = no_user_specified.then_some(config.timezone).flatten();
     let profile_data = ProfileData::new(user, discord_id, tz);
-    let builder = ProfilePagination::builder(kind, profile_data);
+    let origin = MessageOrigin::new(orig.guild_id(), orig.channel_id());
+    let builder = ProfilePagination::builder(kind, profile_data, origin);
 
     builder
         .profile_components()

--- a/bathbot/src/pagination/profile.rs
+++ b/bathbot/src/pagination/profile.rs
@@ -4,17 +4,18 @@ use super::{Pages, PaginationBuilder, PaginationKind};
 use crate::{
     commands::osu::{ProfileData, ProfileKind},
     core::Context,
-    embeds::{EmbedData, ProfileEmbed},
+    embeds::{EmbedData, MessageOrigin, ProfileEmbed},
 };
 
 // Not using #[pagination(...)] since it requires special initialization
 pub struct ProfilePagination {
     kind: ProfileKind,
     data: ProfileData,
+    origin: MessageOrigin,
 }
 
 impl ProfilePagination {
-    pub fn builder(curr_kind: ProfileKind, data: ProfileData) -> PaginationBuilder {
+    pub fn builder(curr_kind: ProfileKind, data: ProfileData, origin: MessageOrigin) -> PaginationBuilder {
         // initialization doesn't really matter since the index is always set manually
         // anyway
         let mut pages = Pages::new(1, usize::MAX);
@@ -23,6 +24,7 @@ impl ProfilePagination {
         let pagination = Self {
             kind: curr_kind,
             data,
+            origin,
         };
 
         let kind = PaginationKind::Profile(Box::new(pagination));
@@ -41,7 +43,7 @@ impl ProfilePagination {
             _ => unreachable!(),
         };
 
-        ProfileEmbed::new(ctx, self.kind, &mut self.data)
+        ProfileEmbed::new(ctx, self.kind, &mut self.data, self.origin)
             .await
             .build()
     }


### PR DESCRIPTION
Closes #55 

Personally feel like the link actually looks kinda weird on the profile embed. An alternative could be to show the rounded one in the compact embed and show the precise acc in the User Stats embed.