### PR TITLE
fix(bot): avoid using /thumb endpoint

### DIFF
--- a/bathbot-util/src/constants.rs
+++ b/bathbot-util/src/constants.rs
@@ -10,6 +10,7 @@ pub const FIELD_VALUE_SIZE: usize = 1024;
 
 // osu!
 pub const OSU_BASE: &str = "https://osu.ppy.sh/";
+/// FIXME: Endpoint is sometimes wrong so avoid using it, see issue #426
 pub const MAP_THUMB_URL: &str = "https://b.ppy.sh/thumb/";
 pub const AVATAR_URL: &str = "https://a.ppy.sh/";
 pub const HUISMETBENEN: &str = "https://api.huismetbenen.nl/";

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -6,7 +6,7 @@ use std::{
 use bathbot_macros::PaginationBuilder;
 use bathbot_model::{rosu_v2::user::User, ScoreSlim};
 use bathbot_util::{
-    constants::{AVATAR_URL, MAP_THUMB_URL, OSU_BASE},
+    constants::{AVATAR_URL, OSU_BASE},
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
     CowUtils, EmbedBuilder, FooterBuilder, MessageOrigin, ScoreExt,
@@ -204,14 +204,13 @@ impl IActiveMessage for CompareScoresPagination {
             let _ = write!(title_text, "[{}K] ", self.map.cs() as u32);
         }
 
-        let thumbnail = format!("{MAP_THUMB_URL}{}l.jpg", self.map.mapset_id());
         let url = format!("{OSU_BASE}b/{}", self.map.map_id());
 
         let embed = EmbedBuilder::new()
             .author(self.user.author_builder())
             .description(description)
             .footer(footer)
-            .thumbnail(thumbnail)
+            .thumbnail(self.map.thumbnail())
             .title(title_text)
             .url(url);
 

--- a/bathbot/src/active/impls/leaderboard.rs
+++ b/bathbot/src/active/impls/leaderboard.rs
@@ -7,7 +7,7 @@ use std::{
 use bathbot_macros::PaginationBuilder;
 use bathbot_model::ScraperScore;
 use bathbot_util::{
-    constants::{AVATAR_URL, MAP_THUMB_URL, OSU_BASE},
+    constants::{AVATAR_URL, OSU_BASE},
     datetime::HowLongAgoDynamic,
     numbers::WithComma,
     AuthorBuilder, CowUtils, EmbedBuilder, FooterBuilder, IntHasher,
@@ -187,13 +187,11 @@ impl LeaderboardPagination {
         );
         let footer = FooterBuilder::new(footer_text).icon_url(footer_icon);
 
-        let thumbnail = format!("{MAP_THUMB_URL}{}l.jpg", self.map.mapset_id());
-
         let embed = EmbedBuilder::new()
             .author(author)
             .description(description)
             .footer(footer)
-            .thumbnail(thumbnail);
+            .thumbnail(self.map.thumbnail());
 
         Ok(BuildPage::new(embed, true).content(self.content.clone()))
     }

--- a/bathbot/src/active/impls/scores/map.rs
+++ b/bathbot/src/active/impls/scores/map.rs
@@ -71,6 +71,7 @@ impl IActiveMessage for ScoresMapPagination {
                 "https://cdn.discordapp.com/icons/{id}/{icon}.{ext}",
                 ext = if icon.animated { "gif" } else { "webp" }
             ),
+            // FIXME: MAP_THUMB_URL endpoint is sometimes wrong, see issue #426
             None => format!("{MAP_THUMB_URL}{mapset_id}l.jpg"),
         };
 

--- a/bathbot/src/commands/osu/compare/score.rs
+++ b/bathbot/src/commands/osu/compare/score.rs
@@ -8,7 +8,7 @@ use bathbot_macros::{command, HasMods, HasName, SlashCommand};
 use bathbot_model::{rosu_v2::user::User, ScoreSlim};
 use bathbot_psql::model::osu::{ArchivedMapVersion, MapVersion};
 use bathbot_util::{
-    constants::{AVATAR_URL, GENERAL_ISSUE, MAP_THUMB_URL, OSU_API_ISSUE, OSU_BASE},
+    constants::{AVATAR_URL, GENERAL_ISSUE, OSU_API_ISSUE, OSU_BASE},
     matcher,
     osu::{MapIdType, ModSelection},
     CowUtils, EmbedBuilder, FooterBuilder, MessageBuilder, MessageOrigin,
@@ -958,7 +958,7 @@ fn no_scores_embed(
         .author(user.author_builder())
         .description(description)
         .footer(footer)
-        .thumbnail(format!("{MAP_THUMB_URL}{}l.jpg", map.mapset_id()))
+        .thumbnail(map.thumbnail())
         .title(title)
         .url(format!("{OSU_BASE}b/{}", map.map_id()))
 }

--- a/bathbot/src/embeds/osu/fix_score.rs
+++ b/bathbot/src/embeds/osu/fix_score.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, convert::identity, fmt::Write};
 use bathbot_macros::EmbedData;
 use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
-    constants::{MAP_THUMB_URL, OSU_BASE},
+    constants::OSU_BASE,
     numbers::{round, WithComma},
     osu::{ExtractablePp, PpListUtil},
     AuthorBuilder, CowUtils,
@@ -31,7 +31,7 @@ impl FixScoreEmbed {
 
         let author = user.author_builder();
         let url = format!("{OSU_BASE}b/{}", map.map_id());
-        let thumbnail = format!("{MAP_THUMB_URL}{}l.jpg", map.mapset_id());
+        let thumbnail = map.thumbnail().to_owned();
 
         let title = format!(
             "{} - {} [{}]",


### PR DESCRIPTION
Only `/scores map` might still make use of the endpoint since the proper thumbnail url is not available at that point.

Closes #426 