### PR TITLE
feat(bot): add render button to single score tops

### DIFF
--- a/bathbot-psql/sqlx-data.json
+++ b/bathbot-psql/sqlx-data.json
@@ -907,6 +907,26 @@
     },
     "query": "\nINSERT INTO tracked_osu_users (user_id, gamemode, channels) \nVALUES \n  ($1, $2, $3) ON CONFLICT (user_id, gamemode) DO \nUPDATE \nSET \n  last_update = NOW() RETURNING channels"
   },
+  "107c2ad205ff181f354f375cf3ff545c36d841ae39bbddb2795453ed530ef13b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "checksum",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "\nSELECT \n  checksum \nFROM \n  osu_maps \nWHERE \n  map_id = $1"
+  },
   "14dc3fec9ff696d82c4a4e4d3b73807c62d95550b4dade6650487b28d0427e4d": {
     "describe": {
       "columns": [],

--- a/bathbot-psql/src/impls/osu/map.rs
+++ b/bathbot-psql/src/impls/osu/map.rs
@@ -407,6 +407,25 @@ WHERE
         query.fetch_all(self).await.wrap_err("failed to fetch all")
     }
 
+    pub async fn select_beatmap_checksum(&self, map_id: u32) -> Result<Option<Box<str>>> {
+        let query = sqlx::query!(
+            r#"
+SELECT 
+  checksum 
+FROM 
+  osu_maps 
+WHERE 
+  map_id = $1"#,
+            map_id as i32
+        );
+
+        query
+            .fetch_optional(self)
+            .await
+            .map(|opt| opt.map(|row| row.checksum.into_boxed_str()))
+            .wrap_err("Failed to fetch optional")
+    }
+
     pub async fn insert_beatmap_file(&self, map_id: u32, path: impl AsRef<str>) -> Result<()> {
         let query = sqlx::query!(
             r#"

--- a/bathbot/src/active/impls/edit_on_timeout/recent_score.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/recent_score.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, mem};
+use std::fmt::Write;
 
 use bathbot_model::rosu_v2::user::User;
 use bathbot_model::ScoreSlim;
@@ -13,7 +13,7 @@ use bathbot_util::{
 };
 use rosu_v2::prelude::{BeatmapUserScore, GameMode, Score};
 
-use super::{EditOnTimeout, EditOnTimeoutKind};
+use super::{ButtonData, EditOnTimeout, EditOnTimeoutKind};
 #[cfg(feature = "twitch")]
 use crate::commands::osu::RecentTwitchStream;
 use crate::{
@@ -26,9 +26,7 @@ use crate::{
 };
 
 pub struct RecentScoreEdit {
-    score_id: Option<u64>,
-    with_miss_analyzer_button: bool,
-    replay_score: Option<OwnedReplayScore>,
+    pub(super) button_data: ButtonData,
 }
 
 impl RecentScoreEdit {
@@ -127,9 +125,11 @@ impl RecentScoreEdit {
         let max_pp = Some(*max_pp);
 
         let kind = Self {
-            score_id,
-            with_miss_analyzer_button,
-            replay_score,
+            button_data: ButtonData {
+                score_id,
+                with_miss_analyzer_button,
+                replay_score,
+            },
         };
 
         match size {
@@ -428,24 +428,6 @@ impl RecentScoreEdit {
             .timestamp(score.ended_at)
             .title(title)
             .url(url)
-    }
-
-    pub fn with_miss_analyzer(&self) -> bool {
-        self.with_miss_analyzer_button
-    }
-
-    pub fn take_miss_analyzer(&mut self) -> Option<u64> {
-        let with_miss_analyzer = mem::replace(&mut self.with_miss_analyzer_button, false);
-
-        self.score_id.filter(|_| with_miss_analyzer)
-    }
-
-    pub fn with_render(&self) -> bool {
-        self.replay_score.is_some()
-    }
-
-    pub fn borrow_mut_render(&mut self) -> (Option<u64>, &mut Option<OwnedReplayScore>) {
-        (self.score_id, &mut self.replay_score)
     }
 }
 

--- a/bathbot/src/active/impls/top.rs
+++ b/bathbot/src/active/impls/top.rs
@@ -106,6 +106,7 @@ impl TopPagination {
                 stars,
                 max_pp: _,
                 max_combo,
+                replay: _,
             } = entry;
 
             let _ = writeln!(
@@ -140,6 +141,7 @@ impl TopPagination {
                 max_pp: _,
                 max_combo: _,
                 stars: _,
+                replay: _,
             } = entry;
 
             let stats = &score.statistics;
@@ -182,6 +184,7 @@ impl TopPagination {
                 max_pp,
                 max_combo,
                 stars,
+                replay: _,
             } = entry;
 
             let _ = writeln!(
@@ -235,6 +238,7 @@ impl TopPagination {
             max_pp,
             max_combo,
             stars,
+            replay: _,
         } = entry;
 
         let if_fc = IfFc::new(&ctx, score, map).await;

--- a/bathbot/src/commands/osu/leaderboard.rs
+++ b/bathbot/src/commands/osu/leaderboard.rs
@@ -231,7 +231,7 @@ async fn leaderboard(
 
     let scores_fut = ctx
         .osu_scores()
-        .map_leaderboard(map_id, map.mode(), mods.clone());
+        .map_leaderboard(map_id, map.mode(), mods.clone(), 100);
 
     let user_fut = get_user_score(&ctx, osu_id_res, map_id, map.mode(), mods.clone());
 

--- a/bathbot/src/commands/osu/mapper.rs
+++ b/bathbot/src/commands/osu/mapper.rs
@@ -401,6 +401,7 @@ async fn process_scores(
 
         let entry = TopEntry {
             original_idx: i,
+            replay: score.replay,
             score: ScoreSlim::new(score, pp),
             map,
             max_pp,

--- a/bathbot/src/commands/osu/pinned.rs
+++ b/bathbot/src/commands/osu/pinned.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bathbot_macros::{HasMods, HasName, SlashCommand};
-use bathbot_model::{rosu_v2::user::User, ScoreSlim};
+use bathbot_model::ScoreSlim;
 use bathbot_psql::model::configs::{GuildConfig, ListSize, MinimizedPp, ScoreSize};
 use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
@@ -23,7 +23,10 @@ use rosu_v2::{
     request::UserId,
 };
 use twilight_interactions::command::{CommandModel, CreateCommand};
-use twilight_model::id::{marker::UserMarker, Id};
+use twilight_model::{
+    guild::Permissions,
+    id::{marker::UserMarker, Id},
+};
 
 use super::{require_link, user_not_found, HasMods, ModsResult, ScoreOrder, TopEntry};
 use crate::{
@@ -33,14 +36,17 @@ use crate::{
     },
     commands::GameModeOption,
     core::commands::CommandOrigin,
-    manager::redis::{
-        osu::{UserArgs, UserArgsSlim},
-        RedisData,
+    manager::{
+        redis::{
+            osu::{UserArgs, UserArgsSlim},
+            RedisData,
+        },
+        OwnedReplayScore,
     },
     util::{
         interaction::InteractionCommand,
         query::{FilterCriteria, Searchable},
-        InteractionCommandExt,
+        CheckPermissions, InteractionCommandExt,
     },
     Context,
 };
@@ -127,14 +133,18 @@ async fn pinned(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pinned) -> Res
         .or(config.mode)
         .unwrap_or(GameMode::Osu);
 
-    let (guild_score_size, guild_list_size, guild_minimized_pp) = match orig.guild_id() {
+    let GuildValues {
+        minimized_pp: guild_minimized_pp,
+        score_size: guild_score_size,
+        list_size: guild_list_size,
+        render_button: guild_render_button,
+    } = match orig.guild_id() {
         Some(guild_id) => {
-            let f =
-                |config: &GuildConfig| (config.score_size, config.list_size, config.minimized_pp);
-
-            ctx.guild_config().peek(guild_id, f).await
+            ctx.guild_config()
+                .peek(guild_id, |config| GuildValues::from(config))
+                .await
         }
-        None => (None, None, None),
+        None => GuildValues::default(),
     };
 
     let list_size = args
@@ -221,7 +231,7 @@ async fn pinned(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pinned) -> Res
 
     let username = user.username();
 
-    if let [score] = &entries[..] {
+    if let [entry] = &entries[..] {
         let score_size = config.score_size.or(guild_score_size).unwrap_or_default();
 
         let minimized_pp = config
@@ -231,7 +241,90 @@ async fn pinned(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pinned) -> Res
 
         let content = write_content(username, &args, 1, mods);
 
-        single_embed(ctx, orig, user, score, score_size, minimized_pp, content).await
+        let user_id = user.user_id();
+
+        let mut with_render = match (guild_render_button, config.render_button) {
+            (None | Some(true), None) => true,
+            (None | Some(true), Some(with_render)) => with_render,
+            (Some(false), _) => false,
+        };
+
+        with_render &= mode == GameMode::Osu
+            && entry.replay == Some(true)
+            && orig.has_permission_to(Permissions::SEND_MESSAGES);
+
+        let replay_score = if with_render {
+            match ctx.osu_map().checksum(entry.map.map_id()).await {
+                Ok(Some(checksum)) => {
+                    Some(OwnedReplayScore::from_top_entry(entry, username, checksum))
+                }
+                Ok(None) => None,
+                Err(err) => {
+                    warn!(?err);
+
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // Get indices of score in user top100 and map top50
+        let (personal_idx, global_idx) = match entry.map.status() {
+            Ranked | Loved | Qualified | Approved => {
+                let user_args = UserArgsSlim::user_id(user_id).mode(entry.score.mode);
+                let best_fut = ctx.osu_scores().top().limit(100).exec(user_args);
+
+                let global_fut = ctx.osu_scores().map_leaderboard(
+                    entry.map.map_id(),
+                    entry.score.mode,
+                    None,
+                    50,
+                );
+                let (best_res, global_res) = tokio::join!(best_fut, global_fut);
+
+                let personal_idx = match best_res {
+                    Ok(scores) => scores.iter().position(|s| entry.score.is_eq(s)),
+                    Err(err) => {
+                        warn!(?err, "Failed to get top scores");
+
+                        None
+                    }
+                };
+
+                let global_idx = match global_res {
+                    Ok(scores) => scores
+                        .iter()
+                        .position(|s| s.user_id == user_id && entry.score.is_eq(s)),
+                    Err(err) => {
+                        warn!(?err, "Failed to get global scores");
+
+                        None
+                    }
+                };
+
+                (personal_idx, global_idx)
+            }
+            _ => (None, None),
+        };
+
+        let active_msg_fut = TopScoreEdit::create(
+            &ctx,
+            &user,
+            entry,
+            personal_idx,
+            global_idx,
+            minimized_pp,
+            entry.score.score_id,
+            replay_score,
+            score_size,
+            content,
+        );
+
+        ActiveMessages::builder(active_msg_fut.await)
+            .start_by_update(true)
+            .begin(ctx, orig)
+            .await
     } else {
         let content = write_content(username, &args, entries.len(), mods);
         let sort_by = args.sort.unwrap_or(ScoreOrder::Pp).into(); // TopOrder::Pp does not show anything
@@ -310,6 +403,7 @@ async fn process_scores(
             None => calc.score(&score).performance().await.pp() as f32,
         };
 
+        let replay = score.replay;
         let score = ScoreSlim::new(score, pp);
 
         if size_single {
@@ -326,6 +420,7 @@ async fn process_scores(
             max_pp,
             stars,
             max_combo,
+            replay,
         };
 
         entries.push(entry);
@@ -389,68 +484,6 @@ async fn process_scores(
     }
 
     Ok(entries)
-}
-
-async fn single_embed(
-    ctx: Arc<Context>,
-    orig: CommandOrigin<'_>,
-    user: RedisData<User>,
-    entry: &TopEntry,
-    score_size: ScoreSize,
-    minimized_pp: MinimizedPp,
-    content: Option<String>,
-) -> Result<()> {
-    let user_id = user.user_id();
-
-    // Get indices of score in user top100 and map top50
-    let (personal_idx, global_idx) = match entry.map.status() {
-        Ranked | Loved | Qualified | Approved => {
-            let user_args = UserArgsSlim::user_id(user_id).mode(entry.score.mode);
-            let best_fut = ctx.osu_scores().top().limit(100).exec(user_args);
-
-            let global_fut = ctx.osu().beatmap_scores(entry.map.map_id()).limit(50);
-            let (best_res, global_res) = tokio::join!(best_fut, global_fut);
-
-            let personal_idx = match best_res {
-                Ok(scores) => scores.iter().position(|s| entry.score.is_eq(s)),
-                Err(err) => {
-                    warn!(?err, "Failed to get top scores");
-
-                    None
-                }
-            };
-
-            let global_idx = match global_res {
-                Ok(scores) => scores
-                    .iter()
-                    .position(|s| s.user_id == user_id && entry.score.is_eq(s)),
-                Err(err) => {
-                    warn!(?err, "Failed to get global scores");
-
-                    None
-                }
-            };
-
-            (personal_idx, global_idx)
-        }
-        _ => (None, None),
-    };
-
-    let active_msg_fut = TopScoreEdit::create(
-        &ctx,
-        &user,
-        entry,
-        personal_idx,
-        global_idx,
-        minimized_pp,
-        score_size,
-        content,
-    );
-
-    ActiveMessages::builder(active_msg_fut.await)
-        .start_by_update(true)
-        .begin(ctx, orig)
-        .await
 }
 
 fn write_content(
@@ -534,4 +567,23 @@ fn content_with_condition(args: &Pinned, amount: usize, mods: Option<ModSelectio
     let _ = write!(content, "\nFound {amount} matching pinned score{plural}:");
 
     content
+}
+
+#[derive(Default)]
+struct GuildValues {
+    minimized_pp: Option<MinimizedPp>,
+    score_size: Option<ScoreSize>,
+    list_size: Option<ListSize>,
+    render_button: Option<bool>,
+}
+
+impl From<&GuildConfig> for GuildValues {
+    fn from(config: &GuildConfig) -> Self {
+        Self {
+            minimized_pp: config.minimized_pp,
+            score_size: config.score_size,
+            list_size: config.list_size,
+            render_button: config.render_button,
+        }
+    }
 }

--- a/bathbot/src/commands/osu/recent/leaderboard.rs
+++ b/bathbot/src/commands/osu/recent/leaderboard.rs
@@ -254,7 +254,9 @@ pub(super) async fn leaderboard(
         Some(ModSelection::Include(m)) | Some(ModSelection::Exact(m)) => Some(m),
     };
 
-    let scores_fut = ctx.osu_scores().map_leaderboard(map_id, mode, mods.clone());
+    let scores_fut = ctx
+        .osu_scores()
+        .map_leaderboard(map_id, mode, mods.clone(), 100);
     let map_fut = ctx.osu_map().map(map_id, checksum.as_deref());
     let user_score_fut = get_user_score(&ctx, map_id, config.osu, mode, mods.clone());
 

--- a/bathbot/src/manager/osu_map.rs
+++ b/bathbot/src/manager/osu_map.rs
@@ -258,6 +258,13 @@ impl<'d> MapManager<'d> {
             .map_err(MapError::Report)
     }
 
+    pub async fn checksum(self, map_id: u32) -> eyre::Result<Option<Box<str>>> {
+        self.psql
+            .select_beatmap_checksum(map_id)
+            .await
+            .wrap_err("Failed to get map checksum")
+    }
+
     pub async fn store(self, mapset: &Beatmapset) -> eyre::Result<()> {
         self.psql
             .upsert_beatmapset(mapset)

--- a/bathbot/src/manager/osu_scores.rs
+++ b/bathbot/src/manager/osu_scores.rs
@@ -100,8 +100,14 @@ impl<'c> ScoresManager<'c> {
         map_id: u32,
         mode: GameMode,
         mods: Option<GameModsIntermode>,
+        limit: u32,
     ) -> Result<Vec<Score>> {
-        let mut req = self.ctx.osu().beatmap_scores(map_id).limit(100).mode(mode);
+        let mut req = self
+            .ctx
+            .osu()
+            .beatmap_scores(map_id)
+            .limit(limit)
+            .mode(mode);
 
         if let Some(mods) = mods {
             req = req.mods(mods);

--- a/bathbot/src/manager/replay.rs
+++ b/bathbot/src/manager/replay.rs
@@ -9,7 +9,7 @@ use rosu_v2::prelude::{GameMode, Score, ScoreStatistics};
 use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
 use twilight_model::id::{marker::UserMarker, Id};
 
-use crate::core::BotConfig;
+use crate::{commands::osu::TopEntry, core::BotConfig};
 
 #[derive(Copy, Clone)]
 pub struct ReplayManager<'d> {
@@ -468,6 +468,26 @@ pub struct OwnedReplayScore {
     max_combo: u16,
     perfect: bool,
     mods: u32,
+}
+
+impl OwnedReplayScore {
+    pub fn from_top_entry(
+        entry: &TopEntry,
+        username: impl Into<Box<str>>,
+        map_checksum: impl Into<Box<str>>,
+    ) -> Self {
+        Self {
+            mode: entry.score.mode,
+            ended_at: entry.score.ended_at,
+            map_checksum: Some(map_checksum.into()),
+            username: username.into(),
+            statistics: entry.score.statistics.clone(),
+            score: entry.score.score,
+            max_combo: entry.score.max_combo as u16,
+            perfect: entry.max_combo == entry.score.max_combo,
+            mods: entry.score.mods.bits(),
+        }
+    }
 }
 
 impl From<&Score> for OwnedReplayScore {


### PR DESCRIPTION
Adds the `Render` button to single-score top & pinned embeds.

I decided against adding the miss analyzer button on those since it would require an additional request each time and users should rather use Miss Analyzer directly for scores  like that.