### PR TITLE
refactor(util): dont use regex for tourney badge filtering

### DIFF
--- a/bathbot-util/src/lib.rs
+++ b/bathbot-util/src/lib.rs
@@ -10,6 +10,7 @@ mod html_to_png;
 mod macros;
 mod matrix;
 mod msg_origin;
+mod tourney_badges;
 
 pub mod constants;
 pub mod datetime;
@@ -27,4 +28,5 @@ pub use self::{
     html_to_png::HtmlToPng,
     matrix::Matrix,
     msg_origin::MessageOrigin,
+    tourney_badges::TourneyBadges,
 };

--- a/bathbot-util/src/matcher.rs
+++ b/bathbot-util/src/matcher.rs
@@ -146,10 +146,6 @@ pub fn is_hit_results(msg: &str) -> bool {
     HIT_RESULTS_MATCHER.get().is_match(msg)
 }
 
-pub fn tourney_badge(description: &str) -> bool {
-    !IGNORE_BADGE_MATCHER.get().is_match_at(description, 0)
-}
-
 pub fn highlight_funny_numeral(content: &str) -> Cow<'_, str> {
     SEVEN_TWO_SEVEN.get().replace_all(content, "__${num}__")
 }
@@ -197,8 +193,6 @@ define_regex! {
     HIT_RESULTS_MATCHER: r".*\{(\d+/){2,}\d+}.*";
 
     EMOJI_MATCHER: r"<(a?):([^:\n]+):(\d+)>";
-
-    IGNORE_BADGE_MATCHER: r"^(?i:contrib|nomination|assessment|global|moderation|beatmap|spotlight|map|pending|aspire|elite|monthly|exemplary|outstanding|longstanding|idol[^@]+)|(?i:(?:fan| |^)art contest)";
 
     SEVEN_TWO_SEVEN: "(?P<num>7[.,]?2[.,]?7)";
 

--- a/bathbot-util/src/tourney_badges.rs
+++ b/bathbot-util/src/tourney_badges.rs
@@ -1,0 +1,92 @@
+pub struct TourneyBadges;
+
+impl TourneyBadges {
+    pub fn count<I, S>(badges: I) -> usize
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        fn filter_badge(badge: &str, buf: &mut String) -> bool {
+            buf.clear();
+
+            let iter = badge.bytes().map(|byte| byte.to_ascii_lowercase());
+
+            // SAFETY: from `str::make_ascii_lowercase`:
+            // "changing ASCII letters only does not invalidate UTF-8."
+            unsafe { buf.as_mut_vec() }.extend(iter);
+
+            TourneyBadges::is_tourney_badge(&*buf)
+        }
+
+        let mut lowercase = String::new();
+
+        badges
+            .into_iter()
+            .filter(|badge| filter_badge(badge.as_ref(), &mut lowercase))
+            .count()
+    }
+
+    fn is_tourney_badge(badge: &str) -> bool {
+        !(badge.contains("fanart contest")
+            || badge.contains(" art contest")
+            || badge.starts_with("art contest")
+            || badge.starts_with("aspire")
+            || badge.starts_with("assessment")
+            || badge.starts_with("beatmap")
+            || badge.starts_with("contrib")
+            || badge.starts_with("centurion mapper")
+            || badge.starts_with("elite")
+            || badge.starts_with("exemplary")
+            || badge.starts_with("global")
+            || (badge.starts_with("idol") && !badge.starts_with("idol@"))
+            || badge.starts_with("global")
+            || badge.starts_with("longstanding")
+            || (badge.starts_with("map") && !badge.starts_with("maple"))
+            || badge.starts_with("moderation")
+            || badge.starts_with("monthly")
+            || badge.starts_with("nominat")
+            || badge.starts_with("outstanding")
+            || badge.starts_with("pending")
+            || badge.starts_with("spotlight"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TourneyBadges;
+
+    #[test]
+    fn false_negatives() {
+        let badges = [
+            "Maple Cup 2015 Winner",            // /u/2155578
+            "Belgian osu! Cup 2020",            // /u/7078544
+            "osu! World Cup #3 Winning Team",   // /u/124493
+            "iDOL@NSTER 2019 osu!mania Winner", // /u/8798383
+        ];
+
+        assert_eq!(TourneyBadges::count(badges), badges.len());
+    }
+
+    #[test]
+    fn false_positives() {
+        let badges = [
+            "Elite Mapper 2011",                                               // /u/106
+            "Pending Cup #3 Mapping Contest Winner",                           // /u/3076909
+            "Mappers' Guild first level contributor",                          // /u/3181083
+            "Centurion Mapper (100+ Beatmaps Ranked)",                         // /u/896613
+            "Nominated 200+ beatmaps as a Beatmap Nominator",                  // /u/3181083
+            "Outstanding contribution to the Mentorship Project",              // /u/4945926
+            "New Beginnings Art Contest Finalist (#1, 2203 votes)",            // /u/13103233
+            "Beatmap Spotlights: Spring 2023 - osu!mania (Diamond 1)",         // temporary badge
+            "Halloween 2022 Fanart Contest Finalist, (#1, 3749 votes)",        // /u/13103233
+            "Longstanding commitment to World Cup Organisation (3 years)",     // /u/2155578
+            "Exemplary performance as a Beatmap Nominator during 2021 (osu!)", // /u/3181083
+            "Mapper's Choice Awards 2021: Top 3 in \
+            the user/beatmap category Hitsounding", // /u/2155578
+            "Aspire V Community Pick Grand Award: \
+            Innovative Storyboarding (osu!) Runner Up and Song Title Runner Up", // /u/2330619
+        ];
+
+        assert_eq!(TourneyBadges::count(&badges), 0);
+    }
+}

--- a/bathbot/src/commands/osu/bws.rs
+++ b/bathbot/src/commands/osu/bws.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, mem, sync::Arc};
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
-    matcher, MessageBuilder,
+    matcher, MessageBuilder, TourneyBadges,
 };
 use eyre::{Report, Result};
 use rosu_v2::{prelude::OsuError, request::UserId};
@@ -174,17 +174,17 @@ async fn bws(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Bws<'_>) -> Resul
         }
     };
 
-    let badges_curr = match &user {
-        RedisData::Original(user) => user
-            .badges
-            .iter()
-            .filter(|badge| matcher::tourney_badge(&badge.description))
-            .count(),
-        RedisData::Archive(user) => user
-            .badges
-            .iter()
-            .filter(|badge| matcher::tourney_badge(badge.description.as_ref()))
-            .count(),
+    let badges_curr = match user {
+        RedisData::Original(ref user) => {
+            let badges = user.badges.iter().map(|badge| &badge.description);
+
+            TourneyBadges::count(badges)
+        }
+        RedisData::Archive(ref user) => {
+            let badges = user.badges.iter().map(|badge| &badge.description);
+
+            TourneyBadges::count(badges)
+        }
     };
 
     let (badges_min, badges_max) = match badges {


### PR DESCRIPTION
Closes #464

Also considers some more mapping badges.