### PR TITLE
Adjusted rb message content if index is specified for clarification (Issue #407)

### DIFF
--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -1363,9 +1363,7 @@ fn write_content(name: &str, args: &TopArgs<'_>, amount: usize) -> Option<String
     } else {
         let genitive = if name.ends_with('s') { "" } else { "s" };
         let reverse = if args.reverse { "reversed " } else { "" };
-        let ordinal_suffix = if args.index.filter(|n| *n == 1).is_some() { 
-            "st" 
-        } else if args.index.filter(|n| *n == 2).is_some() { 
+        let ordinal_suffix = if args.index.filter(|n| *n == 2).is_some() { 
             "nd" 
         } else if args.index.filter(|n| *n == 3).is_some() { 
             "rd" 
@@ -1389,13 +1387,19 @@ fn write_content(name: &str, args: &TopArgs<'_>, amount: usize) -> Option<String
             TopScoreOrder::Combo => {
                 format!("`{name}`'{genitive} top100 sorted by {reverse}combo:")
             }
-            TopScoreOder::Date if (args.reverse && args.index.filter(|n| *n > 0).is_some()) => {
+            TopScoreOder::Date if (args.reverse && args.index.filter(|n| *n == 1).is_some()) => {
+                format!("Oldest score in `{name}`'{genitive} top100:")
+            }
+            TopScoreOder::Date if (args.reverse && args.index.filter(|n| *n > 1).is_some()) => {
                 format!("{index_string}{ordinal_suffix} oldest score in `{name}`'{genitive} top100:", index_string = args.index.unwrap())
             }
             TopScoreOrder::Date if args.reverse => {
                 format!("Oldest scores in `{name}`'{genitive} top100:")
             }
-            TopScoreOder::Date if args.index.filter(|n| *n > 0).is_some() => {
+            TopScoreOder::Date if args.index.filter(|n| *n == 1).is_some() => {
+                format!("Most recent score in `{name}`'{genitive} top100:")
+            }
+            TopScoreOder::Date if args.index.filter(|n| *n > 1).is_some() => {
                 format!("{index_string}{ordinal_suffix} most recent score in `{name}`'{genitive} top100:", index_string = args.index.unwrap())
             }
             TopScoreOrder::Date => {

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -1363,6 +1363,15 @@ fn write_content(name: &str, args: &TopArgs<'_>, amount: usize) -> Option<String
     } else {
         let genitive = if name.ends_with('s') { "" } else { "s" };
         let reverse = if args.reverse { "reversed " } else { "" };
+        let ordinal_suffix = if args.index.filter(|n| *n == 1).is_some() { 
+            "st" 
+        } else if args.index.filter(|n| *n == 2).is_some() { 
+            "nd" 
+        } else if args.index.filter(|n| *n == 3).is_some() { 
+            "rd" 
+        } else { 
+            "th" 
+        };
 
         let content = match args.sort_by {
             TopScoreOrder::Farm if args.reverse => {
@@ -1380,8 +1389,14 @@ fn write_content(name: &str, args: &TopArgs<'_>, amount: usize) -> Option<String
             TopScoreOrder::Combo => {
                 format!("`{name}`'{genitive} top100 sorted by {reverse}combo:")
             }
+            TopScoreOder::Date if (args.reverse && args.index.filter(|n| *n > 0).is_some()) => {
+                format!("{index_string}{ordinal_suffix} oldest score in `{name}`'{genitive} top100:", index_string = args.index.unwrap())
+            }
             TopScoreOrder::Date if args.reverse => {
                 format!("Oldest scores in `{name}`'{genitive} top100:")
+            }
+            TopScoreOder::Date if args.index.filter(|n| *n > 0).is_some() => {
+                format!("{index_string}{ordinal_suffix} most recent score in `{name}`'{genitive} top100:", index_string = args.index.unwrap())
             }
             TopScoreOrder::Date => {
                 format!("Most recent scores in `{name}`'{genitive} top100:")


### PR DESCRIPTION
Solves issue #407 
Before:
  <rb1 &nbsp; ```Most recent scores in Ricar_old's top100:```
  <rb2 &nbsp; ```Most recent scores in Ricar_old's top100:```
  <rb3 &nbsp; ```Most recent scores in Ricar_old's top100:```
  <rb57 ```Most recent scores in Ricar_old's top100:```

After:
  <rb1 &nbsp; ```Most recent score in Ricar_old's top100:```
  <rb2 &nbsp; ```2nd most recent score in Ricar_old's top100:```
  <rb3 &nbsp; ```3rd most recent score in Ricar_old's top100:```
  <rb57 ```57th most recent score in Ricar_old's top100:```

Added to reverse argument too with "oldest".