### PR TITLE
Added support for “', '” (Issue #381)

### DIFF
--- a/bathbot/src/core/commands/prefix/args.rs
+++ b/bathbot/src/core/commands/prefix/args.rs
@@ -57,6 +57,7 @@ impl<'m> Args<'m> {
             quote_delimited('“', '“'),
             quote_delimited('«', '»'),
             quote_delimited('„', '“'),
+            quote_delimited('“', '”'),
             simple,
         );
 


### PR DESCRIPTION
Added support for “ ” as quotes for argument parsing.
Solves issue #381 