### PR TITLE
feat(bot): check video descriptions for map id

### DIFF
--- a/bathbot/src/core/context/messages.rs
+++ b/bathbot/src/core/context/messages.rs
@@ -92,6 +92,17 @@ impl Context {
         }
 
         for embed in embeds {
+            // check the description for youtube video's & co
+            if let Some(map_id) = embed
+                .description
+                .as_deref()
+                .filter(|_| embed.kind == "video")
+                .and_then(matcher::get_osu_map_id)
+            {
+                return Some(MapIdType::Map(map_id));
+            }
+
+            // if it's an ordr url, try to request the map id for it
             let video_url_opt = embed
                 .url
                 .as_ref()
@@ -100,6 +111,7 @@ impl Context {
             let Some(video_url) = video_url_opt else {
                 continue;
             };
+
             let Some(ordr) = self.ordr() else { continue };
 
             let render_opt = ordr


### PR DESCRIPTION
Tries to find the map id in the description of embed videos. This is only a best-effort approach since youtube description and such are commonly truncated if they're too long so finding the map id this way won't always work.

More reliable alternatives would be to either
- request the youtube page and try to scrape the map id out of the description
- add a youtube api dependency and request the description through it

Both of which are very annoying to deal with.

Closes #520 