### PR TITLE
fix(bot): update component by token instead of msg

### DIFF
--- a/bathbot/src/active/impls/render/cached.rs
+++ b/bathbot/src/active/impls/render/cached.rs
@@ -122,10 +122,7 @@ impl CachedRender {
                     Err(err) => {
                         let embed = EmbedBuilder::new().color_red().description(OSU_API_ISSUE);
                         let builder = MessageBuilder::new().embed(embed);
-
-                        if let Some(update_fut) = component.update(&ctx, builder) {
-                            let _ = update_fut.await;
-                        }
+                        let _ = component.update(&ctx, builder).await;
 
                         return Err(Report::new(err).wrap_err("Failed to get score"));
                     }
@@ -135,20 +132,14 @@ impl CachedRender {
                     let content = "Failed to prepare the replay";
                     let embed = EmbedBuilder::new().color_red().description(content);
                     let builder = MessageBuilder::new().embed(embed);
-
-                    if let Some(update_fut) = component.update(&ctx, builder) {
-                        update_fut.await?;
-                    }
+                    component.update(&ctx, builder).await?;
 
                     return Ok(());
                 };
 
                 // Just a status update, no need to propagate an error
                 status.set(RenderStatusInner::PreparingReplay);
-
-                if let Some(update_fut) = component.update(&ctx, status.as_message()) {
-                    let _ = update_fut.await;
-                }
+                let _ = component.update(&ctx, status.as_message()).await;
 
                 let replay_manager = ctx.replay();
                 let replay_fut = replay_manager.get_replay(score.score_id, &replay_score);
@@ -166,23 +157,14 @@ impl CachedRender {
                     .description("Looks like the replay for that score is not available");
 
                 let builder = MessageBuilder::new().embed(embed);
+                component.update(&ctx, builder).await?;
 
-                match component.update(&ctx, builder) {
-                    Some(update_fut) => {
-                        update_fut.await?;
-
-                        return Ok(());
-                    }
-                    None => bail!("Lacking permission to update cached render component"),
-                }
+                return Ok(());
             }
             Err(err) => {
                 let embed = EmbedBuilder::new().color_red().description(GENERAL_ISSUE);
                 let builder = MessageBuilder::new().embed(embed);
-
-                if let Some(update_fut) = component.update(&ctx, builder) {
-                    let _ = update_fut.await;
-                }
+                let _ = component.update(&ctx, builder).await;
 
                 return Err(err.wrap_err("Failed to get replay"));
             }
@@ -193,10 +175,7 @@ impl CachedRender {
             Err(err) => {
                 let embed = EmbedBuilder::new().color_red().description(GENERAL_ISSUE);
                 let builder = MessageBuilder::new().embed(embed);
-
-                if let Some(update_fut) = component.update(&ctx, builder) {
-                    let _ = update_fut.await;
-                }
+                let _ = component.update(&ctx, builder).await;
 
                 return Err(err);
             }
@@ -204,10 +183,7 @@ impl CachedRender {
 
         // Just a status update, no need to propagate an error
         status.set(RenderStatusInner::CommissioningRender);
-
-        if let Some(update_fut) = component.update(&ctx, status.as_message()) {
-            let _ = update_fut.await;
-        }
+        let _ = component.update(&ctx, status.as_message()).await;
 
         let allow_custom_skins = match component.guild_id {
             Some(guild_id) => {
@@ -232,10 +208,7 @@ impl CachedRender {
             Err(err) => {
                 let embed = EmbedBuilder::new().color_red().description(ORDR_ISSUE);
                 let builder = MessageBuilder::new().embed(embed);
-
-                if let Some(update_fut) = component.update(&ctx, builder) {
-                    let _ = update_fut.await;
-                }
+                let _ = component.update(&ctx, builder).await;
 
                 return Err(Report::new(err).wrap_err("Failed to commission render"));
             }

--- a/bathbot/src/active/mod.rs
+++ b/bathbot/src/active/mod.rs
@@ -235,16 +235,12 @@ impl ActiveMessages {
                 }
 
                 if build.defer {
-                    if let Some(fut) = modal.update(&ctx, builder) {
-                        if let Err(err) = fut.await {
-                            return error!(
-                                name = %modal.data.custom_id,
-                                ?err,
-                                "Failed to update modal",
-                            );
-                        }
-                    } else {
-                        return warn!("Lacking permission to update message through modal");
+                    if let Err(err) = modal.update(&ctx, builder).await {
+                        return error!(
+                            name = %modal.data.custom_id,
+                            ?err,
+                            "Failed to update modal",
+                        );
                     }
                 } else if let Err(err) = modal.callback(&ctx, builder).await {
                     return error!(

--- a/bathbot/src/active/mod.rs
+++ b/bathbot/src/active/mod.rs
@@ -161,16 +161,12 @@ impl ActiveMessages {
                     }
 
                     if build.defer {
-                        if let Some(fut) = component.update(&ctx, builder) {
-                            if let Err(err) = fut.await {
-                                return error!(
-                                    name = %component.data.custom_id,
-                                    ?err,
-                                    "Failed to update component",
-                                );
-                            }
-                        } else {
-                            return warn!("Lacking permission to update message through component");
+                        if let Err(err) = component.update(&ctx, builder).await {
+                            return error!(
+                                name = %component.data.custom_id,
+                                ?err,
+                                "Failed to update component",
+                            );
                         }
                     } else if let Err(err) = component.callback(&ctx, builder).await {
                         return error!(

--- a/bathbot/src/util/ext/component.rs
+++ b/bathbot/src/util/ext/component.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, future::IntoFuture};
+use std::{borrow::Cow, future::IntoFuture, slice};
 
 use bathbot_util::{modal::ModalBuilder, MessageBuilder};
 use twilight_http::response::{marker::EmptyBody, ResponseFuture};
@@ -8,7 +8,6 @@ use twilight_model::{
     http::interaction::{InteractionResponse, InteractionResponseData, InteractionResponseType},
 };
 
-use super::MessageExt;
 use crate::{core::Context, util::interaction::InteractionComponent};
 
 pub trait ComponentExt {
@@ -21,8 +20,7 @@ pub trait ComponentExt {
     /// After having already ackowledged the component either via
     /// [`ComponentExt::callback`] or [`ComponentExt::defer`],
     /// use this to update the message.
-    fn update(&self, ctx: &Context, builder: MessageBuilder<'_>)
-        -> Option<ResponseFuture<Message>>;
+    fn update(&self, ctx: &Context, builder: MessageBuilder<'_>) -> ResponseFuture<Message>;
 
     /// Acknowledge a component by responding with a modal.
     fn modal(&self, ctx: &Context, modal: ModalBuilder) -> ResponseFuture<EmptyBody>;
@@ -71,12 +69,37 @@ impl ComponentExt for InteractionComponent {
     }
 
     #[inline]
-    fn update(
-        &self,
-        ctx: &Context,
-        builder: MessageBuilder<'_>,
-    ) -> Option<ResponseFuture<Message>> {
-        self.message.update(ctx, builder, self.permissions)
+    fn update(&self, ctx: &Context, builder: MessageBuilder<'_>) -> ResponseFuture<Message> {
+        let client = ctx.interaction();
+
+        let mut req = client.update_response(&self.token);
+
+        if let Some(ref content) = builder.content {
+            req = req
+                .content(Some(content.as_ref()))
+                .expect("invalid content");
+        }
+
+        let embed = builder.embed.build();
+        req = req.embeds(embed.as_option_slice()).expect("invalid embed");
+
+        if let Some(ref components) = builder.components {
+            req = req
+                .components(Some(components))
+                .expect("invalid components");
+        }
+
+        if let Some(attachment) = builder.attachment.as_ref().filter(|_| {
+            self.permissions.map_or(true, |permissions| {
+                permissions.contains(Permissions::ATTACH_FILES)
+            })
+        }) {
+            req = req
+                .attachments(slice::from_ref(attachment))
+                .expect("invalid attachments");
+        }
+
+        req.into_future()
     }
 
     #[inline]

--- a/bathbot/src/util/ext/interaction_command.rs
+++ b/bathbot/src/util/ext/interaction_command.rs
@@ -157,7 +157,9 @@ impl InteractionCommandExt for InteractionCommand {
                 permissions.contains(Permissions::ATTACH_FILES)
             })
         }) {
-            req = req.attachments(slice::from_ref(attachment)).unwrap();
+            req = req
+                .attachments(slice::from_ref(attachment))
+                .expect("invalid attachments");
         }
 
         req.into_future()

--- a/bathbot/src/util/ext/interaction_command.rs
+++ b/bathbot/src/util/ext/interaction_command.rs
@@ -37,7 +37,12 @@ pub trait InteractionCommandExt {
     /// Update a command to some content in a red embed.
     ///
     /// Be sure the command was deferred beforehand.
-    fn error(&self, ctx: &Context, content: impl Into<String>) -> ResponseFuture<Message>;
+    fn error(&self, ctx: &Context, content: impl Into<String>) -> ResponseFuture<Message> {
+        let embed = EmbedBuilder::new().description(content).color_red();
+        let builder = MessageBuilder::new().embed(embed);
+
+        self.update(ctx, builder)
+    }
 
     /// Respond to a command with some content in a red embed.
     ///
@@ -46,7 +51,12 @@ pub trait InteractionCommandExt {
         &self,
         ctx: &Context,
         content: impl Into<String>,
-    ) -> ResponseFuture<EmptyBody>;
+    ) -> ResponseFuture<EmptyBody> {
+        let embed = EmbedBuilder::new().description(content).color_red();
+        let builder = MessageBuilder::new().embed(embed);
+
+        self.callback(ctx, builder, false)
+    }
 
     /// Callback to an autocomplete action.
     fn autocomplete(
@@ -151,40 +161,6 @@ impl InteractionCommandExt for InteractionCommand {
         }
 
         req.into_future()
-    }
-
-    #[inline]
-    fn error(&self, ctx: &Context, content: impl Into<String>) -> ResponseFuture<Message> {
-        let embed = EmbedBuilder::new().description(content).color_red().build();
-
-        ctx.interaction()
-            .update_response(&self.token)
-            .embeds(Some(&[embed]))
-            .expect("invalid embed")
-            .into_future()
-    }
-
-    #[inline]
-    fn error_callback(
-        &self,
-        ctx: &Context,
-        content: impl Into<String>,
-    ) -> ResponseFuture<EmptyBody> {
-        let embed = EmbedBuilder::new().description(content).color_red().build();
-
-        let data = InteractionResponseData {
-            embeds: Some(vec![embed]),
-            ..Default::default()
-        };
-
-        let response = InteractionResponse {
-            kind: InteractionResponseType::ChannelMessageWithSource,
-            data: Some(data),
-        };
-
-        ctx.interaction()
-            .create_response(self.id, &self.token, &response)
-            .into_future()
     }
 
     #[inline]

--- a/bathbot/src/util/ext/modal.rs
+++ b/bathbot/src/util/ext/modal.rs
@@ -1,4 +1,4 @@
-use std::future::IntoFuture;
+use std::{future::IntoFuture, slice};
 
 use bathbot_util::MessageBuilder;
 use twilight_http::response::{marker::EmptyBody, ResponseFuture};
@@ -8,7 +8,6 @@ use twilight_model::{
     http::interaction::{InteractionResponse, InteractionResponseData, InteractionResponseType},
 };
 
-use super::MessageExt;
 use crate::{core::Context, util::interaction::InteractionModal};
 
 pub trait ModalExt {
@@ -21,10 +20,7 @@ pub trait ModalExt {
     /// After having already ackowledged the modal either via
     /// [`ModalExt::callback`] or [`ModalExt::defer`],
     /// use this to update the message.
-    ///
-    /// Note: Can only be used if `ModalSubmitInteraction::message` is `Some`.
-    fn update(&self, ctx: &Context, builder: MessageBuilder<'_>)
-        -> Option<ResponseFuture<Message>>;
+    fn update(&self, ctx: &Context, builder: MessageBuilder<'_>) -> ResponseFuture<Message>;
 }
 
 impl ModalExt for InteractionModal {
@@ -69,14 +65,36 @@ impl ModalExt for InteractionModal {
     }
 
     #[inline]
-    fn update(
-        &self,
-        ctx: &Context,
-        builder: MessageBuilder<'_>,
-    ) -> Option<ResponseFuture<Message>> {
-        self.message
-            .as_ref()
-            .expect("no message in modal")
-            .update(ctx, builder, self.permissions)
+    fn update(&self, ctx: &Context, builder: MessageBuilder<'_>) -> ResponseFuture<Message> {
+        let client = ctx.interaction();
+
+        let mut req = client.update_response(&self.token);
+
+        if let Some(ref content) = builder.content {
+            req = req
+                .content(Some(content.as_ref()))
+                .expect("invalid content");
+        }
+
+        let embed = builder.embed.build();
+        req = req.embeds(embed.as_option_slice()).expect("invalid embed");
+
+        if let Some(ref components) = builder.components {
+            req = req
+                .components(Some(components))
+                .expect("invalid components");
+        }
+
+        if let Some(attachment) = builder.attachment.as_ref().filter(|_| {
+            self.permissions.map_or(true, |permissions| {
+                permissions.contains(Permissions::ATTACH_FILES)
+            })
+        }) {
+            req = req
+                .attachments(slice::from_ref(attachment))
+                .expect("invalid attachments");
+        }
+
+        req.into_future()
     }
 }


### PR DESCRIPTION
Makes the bot no longer require the "Send message" permission to edit messages on pagination.
Also fixes pagination on ephemeral responses i.e. `/bookmark`