### PR TITLE
dep: bumped rosu-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "rosu-v2"
 version = "0.8.0"
-source = "git+https://github.com/MaxOhn/rosu-v2?branch=next#8ca437260bdc650df3104328218806df03f4a5e2"
+source = "git+https://github.com/MaxOhn/rosu-v2?branch=next#310c22d806962559a1dab073c6c6d336abea9c36"
 dependencies = [
  "bytes",
  "futures",


### PR DESCRIPTION
Fixes the `GetBeatmapScores` endpoint not working with mods and enhances metrics.