### PR TITLE
Abbreviate score values in profile compare

### DIFF
--- a/bathbot-util/src/numbers.rs
+++ b/bathbot-util/src/numbers.rs
@@ -281,15 +281,13 @@ impl Display for AbbreviatedScore {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let score = self.score as f64;
         if score >= 1_000_000_000_000.0 {
-            write!(f, "{:.2}T", score / 1_000_000_000_000.0)
+            write!(f, "{:.2}tn", score / 1_000_000_000_000.0)
         } else if score >= 1_000_000_000.0 {
-            write!(f, "{:.2}B", score / 1_000_000_000.0)
+            write!(f, "{:.2}bn", score / 1_000_000_000.0)
         } else if score >= 1_000_000.0 {
-            write!(f, "{:.2}M", score / 1_000_000.0)
-        } else if score >= 1_000.0 {
-            write!(f, "{:.2}K", score / 1_000.0)
+            write!(f, "{:.2}m", score / 1_000_000.0)
         } else {
-            write!(f, "{}", self.score)
+            Display::fmt(&WithComma::new(self.score), f)
         }
     }
 }
@@ -328,22 +326,17 @@ mod tests {
     fn test_abbreviated_score() {
         assert_eq!(
             AbbreviatedScore::new(1_372_111_816_859_u64).to_string(),
-            "1.37T".to_owned()
+            "1.37tn".to_owned()
         );
 
         assert_eq!(
             AbbreviatedScore::new(893_135_435_096_u64).to_string(),
-            "893.14B".to_owned()
+            "893.14bn".to_owned()
         );
 
         assert_eq!(
             AbbreviatedScore::new(136_976_283_u64).to_string(),
-            "136.98M".to_owned()
-        );
-
-        assert_eq!(
-            AbbreviatedScore::new(193_064_u64).to_string(),
-            "193.06K".to_owned()
+            "136.98m".to_owned()
         );
 
         assert_eq!(AbbreviatedScore::new(727_u64).to_string(), "727".to_owned());

--- a/bathbot-util/src/numbers.rs
+++ b/bathbot-util/src/numbers.rs
@@ -323,4 +323,29 @@ mod tests {
             "31,925.53".to_owned()
         );
     }
+
+    #[test]
+    fn test_abbreviated_score() {
+        assert_eq!(
+            AbbreviatedScore::new(1_372_111_816_859_u64).to_string(),
+            "1.37T".to_owned()
+        );
+
+        assert_eq!(
+            AbbreviatedScore::new(893_135_435_096_u64).to_string(),
+            "893.14B".to_owned()
+        );
+
+        assert_eq!(
+            AbbreviatedScore::new(136_976_283_u64).to_string(),
+            "136.98M".to_owned()
+        );
+
+        assert_eq!(
+            AbbreviatedScore::new(193_064_u64).to_string(),
+            "193.06K".to_owned()
+        );
+
+        assert_eq!(AbbreviatedScore::new(727_u64).to_string(), "727".to_owned());
+    }
 }

--- a/bathbot-util/src/numbers.rs
+++ b/bathbot-util/src/numbers.rs
@@ -267,6 +267,33 @@ impl From<MinMaxAvg<f32>> for MinMaxAvg<u32> {
     }
 }
 
+pub struct AbbreviatedScore {
+    score: u64,
+}
+
+impl AbbreviatedScore {
+    pub fn new(score: u64) -> Self {
+        Self { score }
+    }
+}
+
+impl Display for AbbreviatedScore {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let score = self.score as f64;
+        if score >= 1_000_000_000_000.0 {
+            write!(f, "{:.2}T", score / 1_000_000_000_000.0)
+        } else if score >= 1_000_000_000.0 {
+            write!(f, "{:.2}B", score / 1_000_000_000.0)
+        } else if score >= 1_000_000.0 {
+            write!(f, "{:.2}M", score / 1_000_000.0)
+        } else if score >= 1_000.0 {
+            write!(f, "{:.2}K", score / 1_000.0)
+        } else {
+            write!(f, "{}", self.score)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bathbot/src/embeds/osu/profile_compare.rs
+++ b/bathbot/src/embeds/osu/profile_compare.rs
@@ -11,7 +11,7 @@ use bathbot_model::{
 };
 use bathbot_util::{
     datetime::{SecToMinSec, DATE_FORMAT},
-    numbers::WithComma,
+    numbers::{AbbreviatedScore, WithComma},
 };
 use rkyv::{with::DeserializeWith, Infallible};
 use rosu_v2::prelude::GameMode;
@@ -571,10 +571,10 @@ impl CompareStrings {
                     )
                 },
             ),
-            ranked_score: WithComma::new(stats.ranked_score())
+            ranked_score: AbbreviatedScore::new(stats.ranked_score())
                 .to_string()
                 .into_boxed_str(),
-            total_score: WithComma::new(stats.total_score())
+            total_score: AbbreviatedScore::new(stats.total_score())
                 .to_string()
                 .into_boxed_str(),
             total_hits: WithComma::new(stats.total_hits())


### PR DESCRIPTION
Closes #562

This adds a new `AbbreviatedScore` struct that can be used to format big numbers in a compact way. 
For now this is only used in profile compare and for score values, so it only works with u64 and also doesn't consider values greater than trillions. I'm not confident enough to correctly implement the macro magic just yet, but it would be an option to rename it to `AbbreviatedNumber` and make it work with more types, if you happen to wanna use it in more places than just score in the future.

The `B` could be misinterpreted as an 8 in code blocks, but I wasn't sure what would be a better way to abbreviate the numbers as there seem to be multiple "correct" ways. I just did whatever osu-web does for now, but feel free to change the letters to something else.