### PR TITLE
refactor(bot): add completion% sorting for fails

### DIFF
--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -649,7 +649,34 @@ async fn process_scores(
                 let a_len = a_map.seconds_drain() as f32 / a.score.mods.clock_rate().unwrap_or(1.0);
                 let b_len = b_map.seconds_drain() as f32 / b.score.mods.clock_rate().unwrap_or(1.0);
 
-                b_len.partial_cmp(&a_len).unwrap_or(Ordering::Equal)
+                b_len
+                    .partial_cmp(&a_len)
+                    .unwrap_or(Ordering::Equal)
+                    .then_with(|| {
+                        if a_map.map_id() != b_map.map_id() {
+                            Ordering::Equal
+                        } else {
+                            let a_is_fail = a.score.grade == Grade::F;
+                            let b_is_fail = b.score.grade == Grade::F;
+                            match (a_is_fail, b_is_fail) {
+                                (true, true) => {
+                                    let a_completion = a.score.statistics.total_hits(a.score.mode)
+                                        as f32
+                                        / a_map.n_objects() as f32;
+                                    let b_completion = b.score.statistics.total_hits(b.score.mode)
+                                        as f32
+                                        / b_map.n_objects() as f32;
+
+                                    b_completion
+                                        .partial_cmp(&a_completion)
+                                        .unwrap_or(Ordering::Equal)
+                                }
+                                (true, false) => Ordering::Greater,
+                                (false, true) => Ordering::Less,
+                                (false, false) => Ordering::Equal,
+                            }
+                        }
+                    })
             });
         }
         Some(ScoreOrder::Misses) => entries.sort_by(|a, b| {


### PR DESCRIPTION
try number 2

Closes #417, sorts fails on the same map by completion% when sorting by Length

all reviews from #600 are applied so should be fine