### PR TITLE
feat: If user makes a duplicate bookmark, start pagination at the index of the initial one

### DIFF
--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -305,6 +305,10 @@ impl BookmarksPagination {
 
         ComponentResult::BuildPage
     }
+
+    pub fn set_index(&mut self, index: usize) {
+        self.pages.set_index(index);
+    }
 }
 
 impl IActiveMessage for BookmarksPagination {

--- a/bathbot/src/commands/osu/bookmarks/message.rs
+++ b/bathbot/src/commands/osu/bookmarks/message.rs
@@ -103,8 +103,8 @@ async fn bookmark_map(ctx: Arc<Context>, mut command: InteractionCommand) -> Res
 
     let user_id = command.user_id()?;
 
-    let bookmark_ex = match ctx.bookmarks().get(user_id).await {
-        Ok(marks) => marks,
+    let bookmarks = match ctx.bookmarks().get(user_id).await {
+        Ok(bookmarks) => bookmarks,
         Err(err) => {
             let _ = command.error(&ctx, GENERAL_ISSUE).await?;
 
@@ -112,7 +112,7 @@ async fn bookmark_map(ctx: Arc<Context>, mut command: InteractionCommand) -> Res
         }
     };
 
-    let idx = match bookmark_ex.iter().position(|x| x.map_id == map_id) {
+    let idx = match bookmarks.iter().position(|x| x.map_id == map_id) {
         Some(index) => index,
         None => {
             if let Err(err) = ctx.bookmarks().add(user_id, map_id).await {


### PR DESCRIPTION
Closes #450 

If user has a beatmap bookmarked and they bookmark it again, get the index of that beatmap in user's bookmarks and use that as the first page displayed

Issue: Requires requesting user's bookmarks twice, as
1. Manually inserting a beatmap into `Vec<MapBookmark>` requires creating a `MapBookmark` in place, which in turn requires an extra query by itself
2. I'm not too versed at SQL in general and PostgreSQL specifically so I don't think I can adjust the query for `.add()` to return bookmarks after the addition

Feel free to close based on that, but the base implementation works totally fine