### PR TITLE
feat: display speed value in mods fmt

### DIFF
--- a/bathbot-util/src/lib.rs
+++ b/bathbot-util/src/lib.rs
@@ -6,6 +6,7 @@ mod hasher;
 mod macros;
 mod matrix;
 mod metrics;
+mod mods_fmt;
 mod msg_origin;
 mod tourney_badges;
 
@@ -24,6 +25,7 @@ pub use self::{
     hasher::{IntHash, IntHasher},
     matrix::Matrix,
     metrics::MetricsReader,
+    mods_fmt::ModsFormatter,
     msg_origin::MessageOrigin,
     tourney_badges::TourneyBadges,
 };

--- a/bathbot-util/src/mods_fmt.rs
+++ b/bathbot-util/src/mods_fmt.rs
@@ -1,0 +1,61 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use rosu_v2::model::mods::{
+    DaycoreCatch, DaycoreMania, DaycoreOsu, DaycoreTaiko, DoubleTimeCatch, DoubleTimeMania,
+    DoubleTimeOsu, DoubleTimeTaiko, GameMod, GameMods, HalfTimeCatch, HalfTimeMania, HalfTimeOsu,
+    HalfTimeTaiko, NightcoreCatch, NightcoreMania, NightcoreOsu, NightcoreTaiko,
+};
+
+pub struct ModsFormatter<'a> {
+    mods: &'a GameMods,
+}
+
+impl<'a> ModsFormatter<'a> {
+    pub fn new(mods: &'a GameMods) -> Self {
+        Self { mods }
+    }
+}
+
+impl Display for ModsFormatter<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        if self.mods.is_empty() {
+            return f.write_str("NM");
+        }
+
+        for gamemod in self.mods.iter() {
+            f.write_str(gamemod.acronym().as_str())?;
+
+            match gamemod {
+                GameMod::HalfTimeOsu(HalfTimeOsu { speed_change, .. })
+                | GameMod::DaycoreOsu(DaycoreOsu { speed_change, .. })
+                | GameMod::DoubleTimeOsu(DoubleTimeOsu { speed_change, .. })
+                | GameMod::NightcoreOsu(NightcoreOsu { speed_change, .. })
+                | GameMod::HalfTimeTaiko(HalfTimeTaiko { speed_change, .. })
+                | GameMod::DaycoreTaiko(DaycoreTaiko { speed_change, .. })
+                | GameMod::DoubleTimeTaiko(DoubleTimeTaiko { speed_change, .. })
+                | GameMod::NightcoreTaiko(NightcoreTaiko { speed_change, .. })
+                | GameMod::HalfTimeCatch(HalfTimeCatch { speed_change, .. })
+                | GameMod::DaycoreCatch(DaycoreCatch { speed_change, .. })
+                | GameMod::DoubleTimeCatch(DoubleTimeCatch { speed_change, .. })
+                | GameMod::NightcoreCatch(NightcoreCatch { speed_change, .. })
+                | GameMod::HalfTimeMania(HalfTimeMania { speed_change, .. })
+                | GameMod::DaycoreMania(DaycoreMania { speed_change, .. })
+                | GameMod::DoubleTimeMania(DoubleTimeMania { speed_change, .. })
+                | GameMod::NightcoreMania(NightcoreMania { speed_change, .. }) => {
+                    if let Some(speed_change) = speed_change {
+                        write!(f, "({}x)", (*speed_change * 100.0).round() / 100.0)?
+                    }
+                }
+
+                GameMod::DifficultyAdjustOsu(_)
+                | GameMod::DifficultyAdjustTaiko(_)
+                | GameMod::DifficultyAdjustCatch(_)
+                | GameMod::DifficultyAdjustMania(_) => {} // TODO: print something?
+
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -9,7 +9,7 @@ use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
-    CowUtils, EmbedBuilder, FooterBuilder, MessageOrigin, ScoreExt,
+    CowUtils, EmbedBuilder, FooterBuilder, MessageOrigin, ModsFormatter, ScoreExt,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -127,7 +127,7 @@ impl IActiveMessage for CompareScoresPagination {
                     "{grade} **+{mods}** [{stars:.2}★] • {score} • {acc}%\n\
                     {pp_format}**{pp:.2}**{pp_format}/{max_pp:.2}PP • {combo}",
                     grade = BotConfig::get().grade(entry.score.grade),
-                    mods = entry.score.mods,
+                    mods = ModsFormatter::new(&entry.score.mods),
                     stars = entry.stars,
                     score = WithComma::new(entry.score.score),
                     acc = round(entry.score.accuracy),
@@ -274,7 +274,7 @@ fn write_compact_entry(
         "{grade} **+{mods}** [{stars:.2}★] {pp_format}{pp:.2}pp{pp_format} \
         ({acc}%) {combo}x • {miss} {timestamp}",
         grade = config.grade(entry.score.grade),
-        mods = entry.score.mods,
+        mods = ModsFormatter::new(&entry.score.mods),
         stars = entry.stars,
         pp_format = if args.pp_idx == Some(i) { "**" } else { "~~" },
         pp = entry.score.pp,

--- a/bathbot/src/active/impls/higherlower/score_pp.rs
+++ b/bathbot/src/active/impls/higherlower/score_pp.rs
@@ -4,7 +4,7 @@ use bathbot_model::rosu_v2::ranking::ArchivedRankingsUser;
 use bathbot_util::{
     constants::OSU_BASE,
     numbers::{round, WithComma},
-    EmbedBuilder,
+    EmbedBuilder, ModsFormatter,
 };
 use eyre::{Result, WrapErr};
 use image::{GenericImageView, ImageBuffer};
@@ -15,7 +15,6 @@ use twilight_model::channel::message::embed::EmbedField;
 use crate::{
     active::impls::higherlower::state::{mapset_cover, HigherLowerState, H, W},
     core::Context,
-    embeds::ModsFormatter,
     manager::{redis::RedisData, OsuMapSlim},
     util::{osu::grade_emote, Emote},
 };
@@ -193,7 +192,7 @@ impl ScorePp {
 
     pub(super) fn play_string(&self, pp_visible: bool) -> String {
         format!(
-            "**{map} {mods}**\n{grade} {score} • **{acc}%** • **{combo}x**{max_combo} {miss}• **{pp}pp**",
+            "**{map} +{mods}**\n{grade} {score} • **{acc}%** • **{combo}x**{max_combo} {miss}• **{pp}pp**",
             map = self.map_string,
             mods = ModsFormatter::new(&self.mods),
             grade = grade_emote(self.grade),

--- a/bathbot/src/active/impls/leaderboard.rs
+++ b/bathbot/src/active/impls/leaderboard.rs
@@ -6,7 +6,7 @@ use std::{
 use bathbot_macros::PaginationBuilder;
 use bathbot_util::{
     constants::OSU_BASE, datetime::HowLongAgoDynamic, numbers::WithComma, AuthorBuilder, CowUtils,
-    EmbedBuilder, FooterBuilder,
+    EmbedBuilder, FooterBuilder, ModsFormatter,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -250,7 +250,7 @@ impl Display for ScoreFormatter<'_> {
             grade = grade_emote(self.score.grade),
             score = WithComma::new(self.score.score),
             combo = self.combo,
-            mods = self.score.mods,
+            mods = ModsFormatter::new(&self.score.mods),
             pp = self.pp,
             acc = self.score.accuracy,
             miss = MissFormat(self.score.statistics.count_miss),

--- a/bathbot/src/active/impls/nochoke.rs
+++ b/bathbot/src/active/impls/nochoke.rs
@@ -6,7 +6,7 @@ use std::{
 use bathbot_macros::PaginationBuilder;
 use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
-    constants::OSU_BASE, numbers::WithComma, CowUtils, EmbedBuilder, FooterBuilder,
+    constants::OSU_BASE, numbers::WithComma, CowUtils, EmbedBuilder, FooterBuilder, ModsFormatter,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -22,7 +22,6 @@ use crate::{
     },
     commands::osu::NochokeEntry,
     core::Context,
-    embeds::ModsFormatter,
     manager::redis::RedisData,
     util::{
         interaction::{InteractionComponent, InteractionModal},
@@ -74,7 +73,7 @@ impl IActiveMessage for NoChokePagination {
 
             let _ = writeln!(
                 description,
-                "**#{idx} [{title} [{version}]]({OSU_BASE}b/{id}) {mods}** [{stars:.2}★]\n\
+                "**#{idx} [{title} [{version}]]({OSU_BASE}b/{id}) +{mods}** [{stars:.2}★]\n\
                 {grade} {old_pp:.2} → **{new_pp:.2}pp**/{max_pp:.2}PP • {old_acc:.2} → **{new_acc:.2}%**\n\
                 [ {old_combo} → **{new_combo}x**/{max_combo}x ]{misses}",
                 idx = original_idx + 1,

--- a/bathbot/src/active/impls/osustats/best.rs
+++ b/bathbot/src/active/impls/osustats/best.rs
@@ -9,7 +9,7 @@ use bathbot_util::{
     constants::OSU_BASE,
     datetime::{HowLongAgoDynamic, DATE_FORMAT},
     numbers::{round, WithComma},
-    AuthorBuilder, EmbedBuilder, FooterBuilder,
+    AuthorBuilder, EmbedBuilder, FooterBuilder, ModsFormatter,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -100,7 +100,7 @@ impl IActiveMessage for OsuStatsBestPagination {
                 title = score.map.title,
                 version = score.map.version,
                 map_id = score.map.map_id,
-                mods = score.mods,
+                mods = ModsFormatter::new(&score.mods),
                 user = score.user.username,
                 user_id = score.user.user_id,
                 grade = config.grade(score.grade),

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
-    CowUtils, EmbedBuilder, FooterBuilder,
+    CowUtils, EmbedBuilder, FooterBuilder, ModsFormatter,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -26,7 +26,7 @@ use crate::{
     },
     commands::osu::OsuStatsEntry,
     core::Context,
-    embeds::{ComboFormatter, HitResultFormatter, ModsFormatter, PpFormatter},
+    embeds::{ComboFormatter, HitResultFormatter, PpFormatter},
     manager::redis::RedisData,
     util::{
         interaction::{InteractionComponent, InteractionModal},
@@ -185,7 +185,7 @@ impl OsuStatsScoresPagination {
 
             let _ = writeln!(
                 description,
-                "**#{rank} [{title} [{version}]]({OSU_BASE}b/{map_id}) {mods}** [{stars:.2}★]\n\
+                "**#{rank} [{title} [{version}]]({OSU_BASE}b/{map_id}) +{mods}** [{stars:.2}★]\n\
                 {grade} {pp} • {acc}% • {score}\n\
                 [ {combo} ] • {hits} • {ago}",
                 title = map.title().cow_escape_markdown(),

--- a/bathbot/src/active/impls/snipe/player_list.rs
+++ b/bathbot/src/active/impls/snipe/player_list.rs
@@ -12,7 +12,7 @@ use bathbot_util::{
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
     osu::calculate_grade,
-    CowUtils, EmbedBuilder, FooterBuilder, IntHasher,
+    CowUtils, EmbedBuilder, FooterBuilder, IntHasher, ModsFormatter,
 };
 use eyre::{Result, WrapErr};
 use futures::future::BoxFuture;
@@ -28,7 +28,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     core::Context,
-    embeds::{HitResultFormatter, ModsFormatter, PpFormatter},
+    embeds::{HitResultFormatter, PpFormatter},
     manager::{redis::RedisData, OsuMap},
     util::{
         interaction::{InteractionComponent, InteractionModal},
@@ -164,7 +164,7 @@ impl SnipePlayerListPagination {
 
             let _ = write!(
                 description,
-                "**#{idx} [{title} [{version}]]({OSU_BASE}b/{map_id}) {mods}** [{stars:.2}★]\n\
+                "**#{idx} [{title} [{version}]]({OSU_BASE}b/{map_id}) +{mods}** [{stars:.2}★]\n\
                 {grade} {pp} • {acc}% • {score}\n\
                 [ {combo} ] • {hits}",
                 idx = idx + 1,

--- a/bathbot/src/active/impls/top.rs
+++ b/bathbot/src/active/impls/top.rs
@@ -11,7 +11,7 @@ use bathbot_util::{
     datetime::HowLongAgoDynamic,
     fields,
     numbers::{round, WithComma},
-    CowUtils, EmbedBuilder, FooterBuilder, IntHasher,
+    CowUtils, EmbedBuilder, FooterBuilder, IntHasher, ModsFormatter,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -29,7 +29,7 @@ use crate::{
     },
     commands::osu::{TopEntry, TopScoreOrder},
     core::Context,
-    embeds::{ComboFormatter, HitResultFormatter, KeyFormatter, ModsFormatter, PpFormatter},
+    embeds::{ComboFormatter, HitResultFormatter, KeyFormatter, PpFormatter},
     manager::{redis::RedisData, OsuMap},
     util::{
         interaction::{InteractionComponent, InteractionModal},
@@ -122,7 +122,7 @@ impl TopPagination {
                 acc = round(score.accuracy),
                 combo = score.max_combo,
                 miss = MissFormat(score.statistics.count_miss),
-                mods = score.mods,
+                mods = ModsFormatter::new(&score.mods),
                 appendix = OrderAppendix::new(self.sort_by, entry, map.ranked_date(), &self.farm, true),
             );
         }
@@ -161,7 +161,7 @@ impl TopPagination {
                 n320 = stats.count_geki,
                 n300 = stats.count_300,
                 miss = stats.count_miss,
-                mods = score.mods,
+                mods = ModsFormatter::new(&score.mods),
                 appendix =
                     OrderAppendix::new(self.sort_by, entry, map.ranked_date(), &self.farm, true),
             );
@@ -190,7 +190,7 @@ impl TopPagination {
 
             let _ = writeln!(
                 description,
-                "**#{idx} [{title} [{version}]]({OSU_BASE}b/{id}) {mods}** [{stars:.2}★]\n\
+                "**#{idx} [{title} [{version}]]({OSU_BASE}b/{id}) +{mods}** [{stars:.2}★]\n\
                 {grade} {pp} • {acc}% • {score}\n[ {combo} ] • {hits} • {appendix}",
                 idx = *original_idx + 1,
                 title = map.title().cow_escape_markdown(),

--- a/bathbot/src/active/impls/top_if.rs
+++ b/bathbot/src/active/impls/top_if.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
-    CowUtils, EmbedBuilder, FooterBuilder,
+    CowUtils, EmbedBuilder, FooterBuilder, ModsFormatter,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -23,7 +23,7 @@ use crate::{
     },
     commands::osu::TopIfEntry,
     core::Context,
-    embeds::{ComboFormatter, HitResultFormatter, ModsFormatter, PpFormatter},
+    embeds::{ComboFormatter, HitResultFormatter, PpFormatter},
     manager::redis::RedisData,
     util::{
         interaction::{InteractionComponent, InteractionModal},
@@ -66,7 +66,7 @@ impl IActiveMessage for TopIfPagination {
 
             let _ = writeln!(
                 description,
-                "**#{original_idx} [{title} [{version}]]({OSU_BASE}b/{id}) {mods}** [{stars:.2}★]\n\
+                "**#{original_idx} [{title} [{version}]]({OSU_BASE}b/{id}) +{mods}** [{stars:.2}★]\n\
                 {grade} {old_pp:.2} → {pp} • {acc}% • {score}\n\
                 [ {combo} ] • {hits} • {ago}",
                 title = map.title().cow_escape_markdown(),

--- a/bathbot/src/util/osu.rs
+++ b/bathbot/src/util/osu.rs
@@ -12,7 +12,7 @@ use bathbot_model::{rosu_v2::user::User, OsuStatsParams, ScoreSlim};
 use bathbot_util::{
     datetime::SecToMinSec,
     numbers::{round, WithComma},
-    MessageOrigin, ScoreExt,
+    MessageOrigin, ModsFormatter, ScoreExt,
 };
 use eyre::{Result, WrapErr};
 use futures::{stream::FuturesOrdered, StreamExt};
@@ -64,17 +64,20 @@ pub fn grade_completion_mods_raw(
     n_objects: u32,
 ) -> Cow<'static, str> {
     let grade_str = BotConfig::get().grade(grade);
+    let mods_fmt = ModsFormatter::new(mods);
 
     match (
         mods.is_empty(),
         grade == Grade::F && mode != GameMode::Catch,
     ) {
         (true, true) => format!("{grade_str}@{}%", completion(score_hits, n_objects)).into(),
-        (false, true) => {
-            format!("{grade_str}@{}% +{mods}", completion(score_hits, n_objects)).into()
-        }
+        (false, true) => format!(
+            "{grade_str}@{}% +{mods_fmt}",
+            completion(score_hits, n_objects)
+        )
+        .into(),
         (true, false) => grade_str.into(),
-        (false, false) => format!("{grade_str} +{mods}").into(),
+        (false, false) => format!("{grade_str} +{mods_fmt}").into(),
     }
 }
 


### PR DESCRIPTION
Closes #595 

Also closes #110 as a side effect by always showing `+NM` in case of empty mods.