### PR TITLE
fix: use Score::id instead of Score::legacy_score_id

### DIFF
--- a/bathbot-model/src/score_slim.rs
+++ b/bathbot-model/src/score_slim.rs
@@ -15,7 +15,7 @@ pub struct ScoreSlim {
     pub mods: GameMods,
     pub pp: f32,
     pub score: u32,
-    pub score_id: Option<u64>,
+    pub score_id: u64,
     pub statistics: LegacyScoreStatistics,
 }
 
@@ -30,7 +30,7 @@ impl ScoreSlim {
             mods: score.mods,
             pp,
             score: score.score,
-            score_id: score.legacy_score_id,
+            score_id: score.id,
             statistics: score.statistics.as_legacy(score.mode),
         }
     }

--- a/bathbot-psql/src/impls/osu/score.rs
+++ b/bathbot-psql/src/impls/osu/score.rs
@@ -1081,8 +1081,8 @@ FROM
                 mods,
                 statistics,
                 map_id,
-                best_id,
-                id: _,
+                best_id: _,
+                id: score_id,
                 grade,
                 kind: _,
                 user_id,
@@ -1108,8 +1108,6 @@ FROM
                 user: _,
                 weight: _,
             } = score;
-
-            let Some(score_id) = best_id else { continue };
 
             // TODO: remove from database?
             let perfect = legacy_perfect.unwrap_or(*is_perfect_combo);

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -114,7 +114,7 @@ impl IActiveMessage for CompareScoresPagination {
 
                 let mut pinned = args.pinned.iter();
 
-                if pinned.any(|s| s.legacy_score_id == entry.score.score_id) {
+                if pinned.any(|s| s.id == entry.score.score_id) {
                     args.description.push_str(" 📌");
                 }
 
@@ -151,11 +151,12 @@ impl IActiveMessage for CompareScoresPagination {
                     timestamp = HowLongAgoDynamic::new(&entry.score.ended_at)
                 );
 
-                if let Some(score_id) = entry.score.score_id.filter(|_| entry.has_replay) {
+                if entry.has_replay {
                     let _ = write!(
                         args.description,
                         " • [Replay]({OSU_BASE}scores/{mode}/{score_id}/download)",
-                        mode = entry.score.mode
+                        mode = entry.score.mode,
+                        score_id = entry.score.score_id,
                     );
                 }
 
@@ -286,7 +287,7 @@ fn write_compact_entry(
 
     let mut pinned = args.pinned.iter();
 
-    if pinned.any(|s| s.legacy_score_id == entry.score.score_id) {
+    if pinned.any(|s| s.id == entry.score.score_id) {
         args.description.push_str(" 📌");
     }
 

--- a/bathbot/src/active/impls/edit_on_timeout/recent_score.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/recent_score.rs
@@ -41,7 +41,7 @@ impl RecentScoreEdit {
         map_score: Option<&BeatmapUserScore>,
         #[cfg(feature = "twitch")] twitch_stream: Option<RecentTwitchStream>,
         minimized_pp: MinimizedPp,
-        score_id: Option<u64>,
+        score_id: u64,
         with_miss_analyzer_button: bool,
         replay_score: Option<OwnedReplayScore>,
         origin: &MessageOrigin,

--- a/bathbot/src/active/impls/edit_on_timeout/top_score.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/top_score.rs
@@ -37,7 +37,7 @@ impl TopScoreEdit {
         personal_idx: Option<usize>,
         global_idx: Option<usize>,
         minimized_pp: MinimizedPp,
-        score_id: Option<u64>,
+        score_id: u64,
         replay_score: Option<OwnedReplayScore>,
         size: ScoreSize,
         content: Option<String>,

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -129,7 +129,7 @@ impl OsuStatsScoresPagination {
                     mods: score.mods,
                     pp,
                     score: score.score,
-                    score_id: None,
+                    score_id: 0,
                     statistics: LegacyScoreStatistics {
                         count_geki: score.count_geki,
                         count_300: score.count300,

--- a/bathbot/src/active/impls/render/cached.rs
+++ b/bathbot/src/active/impls/render/cached.rs
@@ -106,7 +106,7 @@ impl CachedRender {
 
                 let replay_manager = ctx.replay();
                 let score = ReplayScore::from(score);
-                let replay_fut = replay_manager.get_replay(Some(self.score_id), &score);
+                let replay_fut = replay_manager.get_replay(self.score_id, &score);
                 let settings_fut = replay_manager.get_settings(owner);
 
                 (status, tokio::join!(replay_fut, settings_fut))
@@ -142,7 +142,7 @@ impl CachedRender {
                 let _ = component.update(&ctx, status.as_message()).await;
 
                 let replay_manager = ctx.replay();
-                let replay_fut = replay_manager.get_replay(score.legacy_score_id, &replay_score);
+                let replay_fut = replay_manager.get_replay(score.id, &replay_score);
                 let settings_fut = replay_manager.get_settings(owner);
 
                 (status, tokio::join!(replay_fut, settings_fut))

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -510,7 +510,7 @@ async fn process_scores(
             mods: score.mods,
             pp,
             score: score.score,
-            score_id: None,
+            score_id: 0,
             statistics: LegacyScoreStatistics {
                 count_geki: score.count_geki,
                 count_300: score.count300,

--- a/bathbot/src/commands/osu/recent/score.rs
+++ b/bathbot/src/commands/osu/recent/score.rs
@@ -569,7 +569,7 @@ pub(super) async fn score(
     let grade = if score.passed { score.grade } else { Grade::F };
     let status = map.status();
     let map_id = score.map_id;
-    let score_id = score.legacy_score_id;
+    let score_id = score.id;
 
     let mut with_miss_analyzer = orig
         .guild_id()
@@ -602,7 +602,7 @@ pub(super) async fn score(
         }
     };
 
-    let score_id_opt = score_id.zip(orig.guild_id());
+    let guild_id_opt = orig.guild_id();
     with_miss_analyzer &= mode == GameMode::Osu;
     with_render &= mode == GameMode::Osu
         && score.replay
@@ -610,7 +610,7 @@ pub(super) async fn score(
         && ctx.ordr().is_some();
 
     let miss_analyzer_fut = async {
-        if let Some((score_id, guild_id)) = score_id_opt.filter(|_| with_miss_analyzer) {
+        if let Some(guild_id) = guild_id_opt.filter(|_| with_miss_analyzer) {
             debug!(score_id, "Sending score id to miss analyzer");
 
             ctx.client()

--- a/bathbot/src/commands/osu/render.rs
+++ b/bathbot/src/commands/osu/render.rs
@@ -292,7 +292,7 @@ async fn render_score(
     let _ = command.update(&ctx, status.as_message()).await;
 
     let replay_manager = ctx.replay();
-    let replay_fut = replay_manager.get_replay(score.legacy_score_id, &replay_score);
+    let replay_fut = replay_manager.get_replay(score.id, &replay_score);
     let settings_fut = replay_manager.get_settings(owner);
 
     let (replay_res, settings_res) = tokio::join!(replay_fut, settings_fut);

--- a/bathbot/src/manager/replay.rs
+++ b/bathbot/src/manager/replay.rs
@@ -36,13 +36,9 @@ impl<'d> ReplayManager<'d> {
 
     pub async fn get_replay(
         self,
-        score_id: Option<u64>,
+        score_id: u64,
         score: &ReplayScore<'_>,
     ) -> Result<Option<Box<[u8]>>> {
-        let Some(score_id) = score_id else {
-            return Ok(None);
-        };
-
         match self.psql.select_osu_replay(score_id).await {
             Ok(Some(replay)) => return Ok(Some(replay)),
             Ok(None) => {}


### PR DESCRIPTION
Seems like `Score::legacy_score_id` contains irrelevant values so `Score::id` should be used again.

Unfortunately, it seems that pinned scores have the same irrelevant value for `Score::id`, `Score::best_id`, and `Score::legacy_score_id` so those scores' ids currently never match.