### PR TITLE
fix: distinguish old vs new score id properly

### DIFF
--- a/bathbot-model/src/score_slim.rs
+++ b/bathbot-model/src/score_slim.rs
@@ -15,7 +15,9 @@ pub struct ScoreSlim {
     pub mods: GameMods,
     pub pp: f32,
     pub score: u32,
+    /// Note that this is the *new* kind of score id
     pub score_id: u64,
+    pub legacy_id: Option<u64>,
     pub statistics: LegacyScoreStatistics,
 }
 
@@ -31,6 +33,7 @@ impl ScoreSlim {
             pp,
             score: score.score,
             score_id: score.id,
+            legacy_id: score.legacy_score_id,
             statistics: score.statistics.as_legacy(score.mode),
         }
     }

--- a/bathbot-psql/src/impls/osu/score.rs
+++ b/bathbot-psql/src/impls/osu/score.rs
@@ -1092,7 +1092,7 @@ FROM
                 has_replay: _,
                 is_perfect_combo,
                 legacy_perfect,
-                legacy_score_id: _,
+                legacy_score_id,
                 legacy_score: _,
                 max_combo,
                 passed,
@@ -1113,6 +1113,7 @@ FROM
             let perfect = legacy_perfect.unwrap_or(*is_perfect_combo);
 
             let grade = if *passed { *grade } else { Grade::F };
+            let score_id = legacy_score_id.unwrap_or(*score_id);
 
             let LegacyScoreStatistics {
                 count_geki,
@@ -1136,7 +1137,7 @@ VALUES
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 
     $11, $12, $13, $14, $15, $16
   ) ON CONFLICT (score_id) DO NOTHING"#,
-                *score_id as i64,
+                score_id as i64,
                 *user_id as i32,
                 *map_id as i32,
                 *mode as i16,
@@ -1165,7 +1166,7 @@ VALUES
 INSERT INTO osu_scores_performance (score_id, pp) 
 VALUES 
   ($1, $2) ON CONFLICT (score_id) DO NOTHING"#,
-                    *score_id as i64,
+                    score_id as i64,
                     *pp as f64,
                 );
 

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -154,8 +154,7 @@ impl IActiveMessage for CompareScoresPagination {
                 if entry.has_replay {
                     let _ = write!(
                         args.description,
-                        " • [Replay]({OSU_BASE}scores/{mode}/{score_id}/download)",
-                        mode = entry.score.mode,
+                        " • [Replay]({OSU_BASE}scores/{score_id}/download)",
                         score_id = entry.score.score_id,
                     );
                 }

--- a/bathbot/src/active/impls/edit_on_timeout/mod.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/mod.rs
@@ -136,7 +136,11 @@ impl EditOnTimeout {
                 handle_miss_analyzer_button(&ctx, component, score_id).await
             }
             "render" => {
-                let (score_id, score_opt) = button_data.borrow_mut_render();
+                let (Some(score_id), score_opt) = button_data.borrow_mut_render() else {
+                    return ComponentResult::Err(eyre!(
+                        "Unexpected render component for recent score"
+                    ));
+                };
 
                 let owner = match component.user_id() {
                     Ok(user_id) => user_id,
@@ -475,25 +479,26 @@ async fn handle_render_button(
 }
 
 struct ButtonData {
-    score_id: u64,
+    score_id: Option<u64>,
     with_miss_analyzer_button: bool,
     replay_score: Option<OwnedReplayScore>,
 }
 
 impl ButtonData {
     fn with_miss_analyzer(&self) -> bool {
-        self.with_miss_analyzer_button
+        self.score_id.is_some() && self.with_miss_analyzer_button
     }
 
     fn take_miss_analyzer(&mut self) -> Option<u64> {
-        mem::replace(&mut self.with_miss_analyzer_button, false).then_some(self.score_id)
+        self.score_id
+            .filter(|_| mem::replace(&mut self.with_miss_analyzer_button, false))
     }
 
     fn with_render(&self) -> bool {
-        self.replay_score.is_some()
+        self.score_id.is_some() && self.replay_score.is_some()
     }
 
-    fn borrow_mut_render(&mut self) -> (u64, &mut Option<OwnedReplayScore>) {
+    fn borrow_mut_render(&mut self) -> (Option<u64>, &mut Option<OwnedReplayScore>) {
         (self.score_id, &mut self.replay_score)
     }
 }

--- a/bathbot/src/active/impls/edit_on_timeout/recent_score.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/recent_score.rs
@@ -41,7 +41,7 @@ impl RecentScoreEdit {
         map_score: Option<&BeatmapUserScore>,
         #[cfg(feature = "twitch")] twitch_stream: Option<RecentTwitchStream>,
         minimized_pp: MinimizedPp,
-        score_id: u64,
+        score_id: Option<u64>,
         with_miss_analyzer_button: bool,
         replay_score: Option<OwnedReplayScore>,
         origin: &MessageOrigin,

--- a/bathbot/src/active/impls/edit_on_timeout/top_score.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/top_score.rs
@@ -37,7 +37,7 @@ impl TopScoreEdit {
         personal_idx: Option<usize>,
         global_idx: Option<usize>,
         minimized_pp: MinimizedPp,
-        score_id: u64,
+        score_id: Option<u64>,
         replay_score: Option<OwnedReplayScore>,
         size: ScoreSize,
         content: Option<String>,

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -130,6 +130,7 @@ impl OsuStatsScoresPagination {
                     pp,
                     score: score.score,
                     score_id: 0,
+                    legacy_id: None,
                     statistics: LegacyScoreStatistics {
                         count_geki: score.count_geki,
                         count_300: score.count300,

--- a/bathbot/src/active/impls/render/cached.rs
+++ b/bathbot/src/active/impls/render/cached.rs
@@ -137,12 +137,21 @@ impl CachedRender {
                     return Ok(());
                 };
 
+                let Some(score_id) = score.legacy_score_id else {
+                    let content = "Scores on osu!lazer currently cannot be rendered :(";
+                    let embed = EmbedBuilder::new().color_red().description(content);
+                    let builder = MessageBuilder::new().embed(embed);
+                    component.update(&ctx, builder).await?;
+
+                    return Ok(());
+                };
+
                 // Just a status update, no need to propagate an error
                 status.set(RenderStatusInner::PreparingReplay);
                 let _ = component.update(&ctx, status.as_message()).await;
 
                 let replay_manager = ctx.replay();
-                let replay_fut = replay_manager.get_replay(score.id, &replay_score);
+                let replay_fut = replay_manager.get_replay(score_id, &replay_score);
                 let settings_fut = replay_manager.get_settings(owner);
 
                 (status, tokio::join!(replay_fut, settings_fut))

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -511,6 +511,7 @@ async fn process_scores(
             pp,
             score: score.score,
             score_id: 0,
+            legacy_id: None,
             statistics: LegacyScoreStatistics {
                 count_geki: score.count_geki,
                 count_300: score.count300,

--- a/bathbot/src/commands/osu/pinned.rs
+++ b/bathbot/src/commands/osu/pinned.rs
@@ -350,7 +350,7 @@ async fn pinned(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pinned) -> Res
             personal_idx,
             global_idx,
             minimized_pp,
-            entry.score.score_id,
+            entry.score.legacy_id,
             replay_score,
             score_size,
             content,

--- a/bathbot/src/commands/osu/recent/score.rs
+++ b/bathbot/src/commands/osu/recent/score.rs
@@ -569,7 +569,7 @@ pub(super) async fn score(
     let grade = if score.passed { score.grade } else { Grade::F };
     let status = map.status();
     let map_id = score.map_id;
-    let score_id = score.id;
+    let score_id = score.legacy_score_id;
 
     let mut with_miss_analyzer = orig
         .guild_id()
@@ -610,7 +610,9 @@ pub(super) async fn score(
         && ctx.ordr().is_some();
 
     let miss_analyzer_fut = async {
-        if let Some(guild_id) = guild_id_opt.filter(|_| with_miss_analyzer) {
+        if let Some((guild_id, score_id)) =
+            guild_id_opt.filter(|_| with_miss_analyzer).zip(score_id)
+        {
             debug!(score_id, "Sending score id to miss analyzer");
 
             ctx.client()

--- a/bathbot/src/commands/osu/render.rs
+++ b/bathbot/src/commands/osu/render.rs
@@ -287,12 +287,19 @@ async fn render_score(
         return Ok(());
     };
 
+    let Some(score_id) = score.legacy_score_id else {
+        let content = "Scores on osu!lazer currently cannot be rendered :(";
+        command.error(&ctx, content).await?;
+
+        return Ok(());
+    };
+
     // Just a status update, no need to propagate an error
     status.set(RenderStatusInner::PreparingReplay);
     let _ = command.update(&ctx, status.as_message()).await;
 
     let replay_manager = ctx.replay();
-    let replay_fut = replay_manager.get_replay(score.id, &replay_score);
+    let replay_fut = replay_manager.get_replay(score_id, &replay_score);
     let settings_fut = replay_manager.get_settings(owner);
 
     let (replay_res, settings_res) = tokio::join!(replay_fut, settings_fut);

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -998,7 +998,7 @@ pub(super) async fn top(
             personal_idx,
             global_idx,
             minimized_pp,
-            entry.score.score_id,
+            entry.score.legacy_id,
             replay_score,
             score_size,
             content,


### PR DESCRIPTION
Partially reverting #630 