### PR TITLE
fix: adjust bonus pp formula

### DIFF
--- a/bathbot-util/src/osu.rs
+++ b/bathbot-util/src/osu.rs
@@ -291,8 +291,8 @@ impl Default for BonusPP {
 }
 
 impl BonusPP {
-    // The actual scores count is being limited to 1,000 in the SQL query resulting in a maximum slightly below 416.67
-    // <https://github.com/ppy/osu-queue-score-statistics/blob/219183cdf1870fd8ce81f2a80b1fe6a4dad48688/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs#L73>
+    // The actual scores count is being limited to 1,000 in the SQL query resulting
+    // in a maximum slightly below 416.67 <https://github.com/ppy/osu-queue-score-statistics/blob/219183cdf1870fd8ce81f2a80b1fe6a4dad48688/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs#L73>
     const LIMIT: i32 = 1_000;
     const MAX: f32 = 413.89;
 


### PR DESCRIPTION
Weighting slightly changed and the maximum bonus pp is slightly lower now, due to the scores count being limited to 1000.
See: https://github.com/ppy/osu-queue-score-statistics/blob/219183cdf1870fd8ce81f2a80b1fe6a4dad48688/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs#L73