### PR TITLE
feat(psql,bot): lazer/stable toggle in user/guild config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "rosu-v2"
 version = "0.8.0"
-source = "git+https://github.com/MaxOhn/rosu-v2?branch=lazer#b2f3ac508cfe6d542e5b2a249f80772b53461328"
+source = "git+https://github.com/MaxOhn/rosu-v2?branch=lazer#085ebf24017868ad578e9980977e4b46844dc7c8"
 dependencies = [
  "bytes",
  "futures",

--- a/bathbot-psql/migrations/20240407231623_lazer_stable_toggle.down.sql
+++ b/bathbot-psql/migrations/20240407231623_lazer_stable_toggle.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_configs DROP COLUMN legacy_scores;
+ALTER TABLE guild_configs DROP COLUMN legacy_scores;

--- a/bathbot-psql/migrations/20240407231623_lazer_stable_toggle.up.sql
+++ b/bathbot-psql/migrations/20240407231623_lazer_stable_toggle.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_configs ADD COLUMN legacy_scores BOOL;
+ALTER TABLE guild_configs ADD COLUMN legacy_scores BOOL;

--- a/bathbot-psql/src/impls/configs/guild.rs
+++ b/bathbot-psql/src/impls/configs/guild.rs
@@ -31,7 +31,8 @@ SELECT
   list_size, 
   render_button, 
   allow_custom_skins, 
-  hide_medal_solution 
+  hide_medal_solution, 
+  legacy_scores 
 FROM 
   guild_configs"#
         );
@@ -65,6 +66,7 @@ FROM
             render_button,
             allow_custom_skins,
             hide_medal_solution,
+            legacy_scores,
         } = config;
 
         let authorities =
@@ -79,12 +81,13 @@ INSERT INTO guild_configs (
   guild_id, authorities, prefixes, allow_songs, 
   score_size, retries, osu_track_limit, 
   minimized_pp, list_size, render_button, 
-  allow_custom_skins, hide_medal_solution
+  allow_custom_skins, hide_medal_solution, 
+  legacy_scores
 ) 
 VALUES 
   (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 
-    $11, $12
+    $11, $12, $13
   ) ON CONFLICT (guild_id) DO 
 UPDATE 
 SET 
@@ -98,7 +101,8 @@ SET
   list_size = $9, 
   render_button = $10, 
   allow_custom_skins = $11, 
-  hide_medal_solution = $12"#,
+  hide_medal_solution = $12, 
+  legacy_scores = $13"#,
             guild_id.get() as i64,
             &authorities as &[u8],
             &prefixes as &[u8],
@@ -111,6 +115,7 @@ SET
             *render_button,
             *allow_custom_skins,
             hide_medal_solution.map(i16::from),
+            *legacy_scores,
         );
 
         query

--- a/bathbot-psql/src/impls/configs/user.rs
+++ b/bathbot-psql/src/impls/configs/user.rs
@@ -29,7 +29,8 @@ SELECT
   retries, 
   twitch_id, 
   timezone_seconds, 
-  render_button 
+  render_button, 
+  legacy_scores 
 FROM 
   user_configs 
 WHERE 
@@ -67,7 +68,8 @@ SELECT
   retries, 
   twitch_id, 
   timezone_seconds, 
-  render_button 
+  render_button, 
+  legacy_scores 
 FROM 
   user_configs 
 WHERE 
@@ -95,6 +97,7 @@ WHERE
                     .map(UtcOffset::from_whole_seconds)
                     .map(Result::unwrap),
                 render_button: row.render_button,
+                legacy_scores: row.legacy_scores,
             });
 
         Ok(config_opt)
@@ -318,6 +321,7 @@ FROM
             twitch_id,
             timezone,
             render_button,
+            legacy_scores,
         } = config;
 
         let query = sqlx::query!(
@@ -325,10 +329,11 @@ FROM
 INSERT INTO user_configs (
   discord_id, osu_id, gamemode, twitch_id, 
   score_size, retries, minimized_pp, 
-  list_size, timezone_seconds, render_button
+  list_size, timezone_seconds, render_button, 
+  legacy_scores
 ) 
 VALUES 
-  ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT (discord_id) DO 
+  ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT (discord_id) DO 
 UPDATE 
 SET 
   osu_id = $2, 
@@ -339,7 +344,8 @@ SET
   minimized_pp = $7, 
   list_size = $8, 
   timezone_seconds = $9, 
-  render_button = $10"#,
+  render_button = $10, 
+  legacy_scores = $11"#,
             user_id.get() as i64,
             osu.map(|id| id as i32),
             mode.map(|mode| mode as i16) as Option<i16>,
@@ -350,6 +356,7 @@ SET
             list_size.map(i16::from),
             timezone.map(UtcOffset::whole_seconds),
             *render_button,
+            *legacy_scores,
         );
 
         query

--- a/bathbot-psql/src/model/configs/guild.rs
+++ b/bathbot-psql/src/model/configs/guild.rs
@@ -16,6 +16,7 @@ pub struct DbGuildConfig {
     pub render_button: Option<bool>,
     pub allow_custom_skins: Option<bool>,
     pub hide_medal_solution: Option<i16>,
+    pub legacy_scores: Option<bool>,
 }
 
 #[derive(Clone, Default)]
@@ -31,6 +32,7 @@ pub struct GuildConfig {
     pub render_button: Option<bool>,
     pub allow_custom_skins: Option<bool>,
     pub hide_medal_solution: Option<HideSolutions>,
+    pub legacy_scores: Option<bool>,
 }
 
 impl From<DbGuildConfig> for GuildConfig {
@@ -49,6 +51,7 @@ impl From<DbGuildConfig> for GuildConfig {
             render_button,
             allow_custom_skins,
             hide_medal_solution,
+            legacy_scores,
         } = config;
 
         // SAFETY: The bytes originate from the DB which only provides valid archived
@@ -70,6 +73,7 @@ impl From<DbGuildConfig> for GuildConfig {
             hide_medal_solution: hide_medal_solution
                 .map(HideSolutions::try_from)
                 .and_then(Result::ok),
+            legacy_scores,
         }
     }
 }

--- a/bathbot-psql/src/model/configs/user.rs
+++ b/bathbot-psql/src/model/configs/user.rs
@@ -13,6 +13,7 @@ pub struct DbUserConfig {
     pub twitch_id: Option<i64>,
     pub timezone_seconds: Option<i32>,
     pub render_button: Option<bool>,
+    pub legacy_scores: Option<bool>,
 }
 
 pub trait OsuId {
@@ -44,6 +45,7 @@ pub struct UserConfig<O: OsuId> {
     pub twitch_id: Option<u64>,
     pub timezone: Option<UtcOffset>,
     pub render_button: Option<bool>,
+    pub legacy_scores: Option<bool>,
 }
 
 impl<O: OsuId> Default for UserConfig<O> {
@@ -59,6 +61,7 @@ impl<O: OsuId> Default for UserConfig<O> {
             twitch_id: None,
             timezone: None,
             render_button: None,
+            legacy_scores: None,
         }
     }
 }
@@ -76,6 +79,7 @@ impl From<DbUserConfig> for UserConfig<OsuUserId> {
             twitch_id,
             timezone_seconds,
             render_button,
+            legacy_scores,
         } = config;
 
         Self {
@@ -90,6 +94,7 @@ impl From<DbUserConfig> for UserConfig<OsuUserId> {
                 .map(UtcOffset::from_whole_seconds)
                 .map(Result::unwrap),
             render_button,
+            legacy_scores,
         }
     }
 }

--- a/bathbot/src/active/impls/profile/availability.rs
+++ b/bathbot/src/active/impls/profile/availability.rs
@@ -31,6 +31,7 @@ impl Availability<Box<[Score]>> {
         ctx: &Context,
         user_id: u32,
         mode: GameMode,
+        legacy_scores: bool,
     ) -> Option<&[Score]> {
         match self {
             Self::Received(ref scores) => return Some(scores),
@@ -40,7 +41,7 @@ impl Availability<Box<[Score]>> {
 
         let user_args = UserArgsSlim::user_id(user_id).mode(mode);
 
-        match ctx.osu_scores().top().exec(user_args).await {
+        match ctx.osu_scores().top(legacy_scores).exec(user_args).await {
             Ok(scores) => Some(self.insert(scores.into_boxed_slice())),
             Err(err) => {
                 warn!(?err, "Failed to get top scores");

--- a/bathbot/src/active/impls/profile/top100_mappers.rs
+++ b/bathbot/src/active/impls/profile/top100_mappers.rs
@@ -16,7 +16,10 @@ impl Top100Mappers {
         let mut entries: Vec<_> = {
             let user_id = menu.user.user_id();
             let mode = menu.user.mode();
-            let scores = menu.scores.get(ctx, user_id, mode).await?;
+            let scores = menu
+                .scores
+                .get(ctx, user_id, mode, menu.legacy_scores)
+                .await?;
             let mut entries = HashMap::with_capacity_and_hasher(32, IntHasher);
 
             for score in scores {

--- a/bathbot/src/active/impls/profile/top100_mods.rs
+++ b/bathbot/src/active/impls/profile/top100_mods.rs
@@ -17,7 +17,10 @@ impl Top100Mods {
         let user_id = menu.user.user_id();
         let mode = menu.user.mode();
 
-        menu.scores.get(ctx, user_id, mode).await.map(Self::new)
+        menu.scores
+            .get(ctx, user_id, mode, menu.legacy_scores)
+            .await
+            .map(Self::new)
     }
 
     fn new(scores: &[Score]) -> Self {

--- a/bathbot/src/active/impls/profile/top100_stats.rs
+++ b/bathbot/src/active/impls/profile/top100_stats.rs
@@ -27,7 +27,10 @@ impl Top100Stats {
 
         let user_id = menu.user.user_id();
         let mode = menu.user.mode();
-        let scores = menu.scores.get(ctx, user_id, mode).await?;
+        let scores = menu
+            .scores
+            .get(ctx, user_id, mode, menu.legacy_scores)
+            .await?;
 
         match Self::new(ctx, scores).await {
             Ok(stats) => Some(menu.top100stats.insert(stats)),

--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -99,7 +99,11 @@ async fn slash_card(ctx: Arc<Context>, mut command: InteractionCommand) -> Resul
     let (user_id, mode) = user_id_mode!(ctx, orig, args);
 
     let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
-    let scores_fut = ctx.osu_scores().top().limit(100).exec_with_user(user_args);
+    let scores_fut = ctx
+        .osu_scores()
+        .top(true)
+        .limit(100)
+        .exec_with_user(user_args);
     let medals_fut = ctx.redis().medals();
 
     let (user, scores, total_medals) = match tokio::join!(scores_fut, medals_fut) {

--- a/bathbot/src/commands/osu/compare/common.rs
+++ b/bathbot/src/commands/osu/compare/common.rs
@@ -349,7 +349,11 @@ async fn get_user_and_scores(
 ) -> OsuResult<(RedisData<User>, Vec<Score>)> {
     let args = UserArgs::rosu_id(ctx, user_id).await.mode(mode);
 
-    ctx.osu_scores().top().limit(100).exec_with_user(args).await
+    ctx.osu_scores()
+        .top(false)
+        .limit(100)
+        .exec_with_user(args)
+        .await
 }
 
 #[derive(PartialEq)]

--- a/bathbot/src/commands/osu/compare/profile.rs
+++ b/bathbot/src/commands/osu/compare/profile.rs
@@ -145,7 +145,7 @@ pub(super) async fn profile(
     // Retrieve all users and their scores
     let user_args1 = UserArgs::rosu_id(&ctx, &user_id1).await.mode(mode);
     let user_args2 = UserArgs::rosu_id(&ctx, &user_id2).await.mode(mode);
-    let score_args = ctx.osu_scores().top().limit(100);
+    let score_args = ctx.osu_scores().top(false).limit(100);
 
     let fut1 = score_args.exec_with_user(user_args1);
     let fut2 = score_args.exec_with_user(user_args2);

--- a/bathbot/src/commands/osu/nochoke.rs
+++ b/bathbot/src/commands/osu/nochoke.rs
@@ -12,11 +12,12 @@ use rosu_pp::any::DifficultyAttributes;
 use rosu_v2::{
     model::score::LegacyScoreStatistics,
     prelude::{GameMode, GameMods, Grade, OsuError, Score},
+    request::UserId,
 };
 use twilight_interactions::command::{CommandModel, CommandOption, CreateCommand, CreateOption};
 use twilight_model::id::{marker::UserMarker, Id};
 
-use super::user_not_found;
+use super::{require_link, user_not_found};
 use crate::{
     active::{impls::NoChokePagination, ActiveMessages},
     core::commands::{prefix::Args, CommandOrigin},
@@ -194,11 +195,33 @@ async fn slash_nochoke(ctx: Arc<Context>, mut command: InteractionCommand) -> Re
 }
 
 async fn nochoke(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Nochoke<'_>) -> Result<()> {
-    let (user_id, mut mode) = user_id_mode!(ctx, orig, args);
+    let owner = orig.user_id()?;
+    let config = ctx.user_config().with_osu_id(owner).await?;
 
-    if mode == GameMode::Mania {
-        mode = GameMode::Osu;
-    }
+    let user_id = match user_id!(ctx, orig, args) {
+        Some(user_id) => user_id,
+        None => match config.osu {
+            Some(user_id) => UserId::Id(user_id),
+            None => return require_link(&ctx, &orig).await,
+        },
+    };
+
+    let mode = match args.mode.map(GameMode::from).or(config.mode) {
+        None | Some(GameMode::Mania) => GameMode::Osu,
+        Some(mode) => mode,
+    };
+
+    let legacy_scores = match config.legacy_scores {
+        Some(legacy_scores) => legacy_scores,
+        None => match orig.guild_id() {
+            Some(guild_id) => ctx
+                .guild_config()
+                .peek(guild_id, |config| config.legacy_scores)
+                .await
+                .unwrap_or(false),
+            None => false,
+        },
+    };
 
     let Nochoke {
         miss_limit,
@@ -209,7 +232,11 @@ async fn nochoke(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Nochoke<'_>) 
 
     // Retrieve the user and their top scores
     let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
-    let scores_fut = ctx.osu_scores().top().limit(100).exec_with_user(user_args);
+    let scores_fut = ctx
+        .osu_scores()
+        .top(legacy_scores)
+        .limit(100)
+        .exec_with_user(user_args);
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),
@@ -306,7 +333,7 @@ async fn nochoke(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Nochoke<'_>) 
         .unchoked_pp(unchoked_pp)
         .rank(rank)
         .content(content.into_boxed_str())
-        .msg_owner(orig.user_id()?)
+        .msg_owner(owner)
         .build();
 
     ActiveMessages::builder(pagination)

--- a/bathbot/src/commands/osu/pp.rs
+++ b/bathbot/src/commands/osu/pp.rs
@@ -188,7 +188,11 @@ async fn pp(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pp<'_>) -> Result<
 
     // Retrieve the user and their top scores
     let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
-    let scores_fut = ctx.osu_scores().top().limit(100).exec_with_user(user_args);
+    let scores_fut = ctx
+        .osu_scores()
+        .top(false)
+        .limit(100)
+        .exec_with_user(user_args);
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -148,6 +148,7 @@ pub(super) async fn player_stats(
         }
     };
 
+    // TODO: use ctx.osu_scores()
     let score_fut = ctx
         .osu()
         .beatmap_user_score(player.oldest_first.map_id, player.user_id)

--- a/bathbot/src/commands/osu/whatif.rs
+++ b/bathbot/src/commands/osu/whatif.rs
@@ -204,7 +204,11 @@ async fn whatif(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: WhatIf<'_>) ->
 
     // Retrieve the user and their top scores
     let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
-    let scores_fut = ctx.osu_scores().top().limit(100).exec_with_user(user_args);
+    let scores_fut = ctx
+        .osu_scores()
+        .top(false)
+        .limit(100)
+        .exec_with_user(user_args);
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),

--- a/bathbot/src/commands/utility/config.rs
+++ b/bathbot/src/commands/utility/config.rs
@@ -101,6 +101,12 @@ pub struct Config {
         In servers, this requires that the render button is not disabled in `/serverconfigs`."
     )]
     render_button: Option<ShowHideOption>,
+    #[command(
+        desc = "Whether scores should be requested as lazer or stable scores",
+        help = "Whether scores should be requested as lazer or stable scores.\n\
+        They have a different score and grade calculation and only lazer adds the new mods."
+    )]
+    score_data: Option<ScoreData>,
 }
 
 // FIXME: Some attribute command does not register the #[cfg(feature = "")]
@@ -161,6 +167,12 @@ pub struct Config {
         In servers, this requires that the render button is not disabled in `/serverconfigs`."
     )]
     render_button: Option<ShowHideOption>,
+    #[command(
+        desc = "Whether scores should be requested as lazer or stable scores",
+        help = "Whether scores should be requested as lazer or stable scores.\n\
+        They have a different score and grade calculation and only lazer adds the new mods."
+    )]
+    score_data: Option<ScoreData>,
 }
 
 #[derive(CommandOption, CreateOption)]
@@ -197,6 +209,14 @@ impl From<ConfigGameMode> for Option<GameMode> {
     }
 }
 
+#[derive(CommandOption, CreateOption)]
+enum ScoreData {
+    #[option(name = "Lazer", value = "lazer")]
+    Lazer,
+    #[option(name = "Stable", value = "stable")]
+    Stable,
+}
+
 async fn slash_config(ctx: Arc<Context>, mut command: InteractionCommand) -> Result<()> {
     let args = Config::from_interaction(command.input_data())?;
 
@@ -217,6 +237,7 @@ pub async fn config(ctx: Arc<Context>, command: InteractionCommand, config: Conf
         timezone,
         mut skin_url,
         render_button,
+        score_data,
     } = config;
 
     if let Some(ref skin_url) = skin_url {
@@ -268,6 +289,10 @@ pub async fn config(ctx: Arc<Context>, command: InteractionCommand, config: Conf
 
     if let Some(render_button) = render_button {
         config.render_button = Some(matches!(render_button, ShowHideOption::Show));
+    }
+
+    if let Some(score_data) = score_data {
+        config.legacy_scores = Some(matches!(score_data, ScoreData::Stable));
     }
 
     #[cfg(feature = "server")]
@@ -604,6 +629,7 @@ async fn convert_config(
         twitch_id,
         timezone,
         render_button,
+        legacy_scores,
     } = config;
 
     UserConfig {
@@ -616,6 +642,7 @@ async fn convert_config(
         twitch_id,
         timezone,
         render_button,
+        legacy_scores,
     }
 }
 

--- a/bathbot/src/embeds/utility/config.rs
+++ b/bathbot/src/embeds/utility/config.rs
@@ -60,20 +60,6 @@ impl ConfigEmbed {
         );
 
         let mut fields = vec![
-            EmbedField {
-                inline: false,
-                name: "Accounts".to_owned(),
-                value: account_value,
-            },
-            create_field(
-                "Retries",
-                config.retries.unwrap_or(Retries::ConsiderMods),
-                &[
-                    (Retries::Hide, "hide"),
-                    (Retries::ConsiderMods, "reset on different mods"),
-                    (Retries::IgnoreMods, "ignore mods"),
-                ],
-            ),
             create_field(
                 "Minimized PP",
                 config.minimized_pp.unwrap_or_default(),
@@ -84,6 +70,38 @@ impl ConfigEmbed {
                 config.render_button,
                 &[(Some(true), "show"), (Some(false), "hide")],
             ),
+            create_field(
+                "Score data",
+                config.legacy_scores.unwrap_or(false),
+                &[(false, "lazer"), (true, "stable")],
+            ),
+            EmbedField {
+                inline: true,
+                name: "Accounts".to_owned(),
+                value: account_value,
+            },
+            create_field(
+                "Mode",
+                config.mode,
+                &[
+                    (Some(GameMode::Osu), "osu"),
+                    (Some(GameMode::Taiko), "taiko"),
+                    (Some(GameMode::Catch), "catch"),
+                    (Some(GameMode::Mania), "mania"),
+                ],
+            ),
+            EmbedField {
+                inline: false,
+                ..create_field(
+                    "Retries",
+                    config.retries.unwrap_or(Retries::ConsiderMods),
+                    &[
+                        (Retries::Hide, "hide"),
+                        (Retries::ConsiderMods, "reset on different mods"),
+                        (Retries::IgnoreMods, "ignore mods"),
+                    ],
+                )
+            },
             create_field(
                 "Score embeds",
                 config.score_size.unwrap_or_default(),
@@ -100,16 +118,6 @@ impl ConfigEmbed {
                     (ListSize::Condensed, "condensed"),
                     (ListSize::Detailed, "detailed"),
                     (ListSize::Single, "single"),
-                ],
-            ),
-            create_field(
-                "Mode",
-                config.mode,
-                &[
-                    (Some(GameMode::Osu), "osu"),
-                    (Some(GameMode::Taiko), "taiko"),
-                    (Some(GameMode::Catch), "catch"),
-                    (Some(GameMode::Mania), "mania"),
                 ],
             ),
         ];

--- a/bathbot/src/embeds/utility/server_config.rs
+++ b/bathbot/src/embeds/utility/server_config.rs
@@ -68,9 +68,9 @@ impl ServerConfigEmbed {
 
         let fields = vec![
             create_field(
-                "Render button",
-                config.render_button.unwrap_or(true),
-                &[(false, "hide"), (true, "let user decide")],
+                "Minimized PP*",
+                config.minimized_pp.unwrap_or_default(),
+                &[(MinimizedPp::MaxPp, "max pp"), (MinimizedPp::IfFc, "if FC")],
             ),
             create_field(
                 "Song commands",
@@ -83,15 +83,6 @@ impl ServerConfigEmbed {
                 &[(true, "allow"), (false, "deny")],
             ),
             create_field(
-                "Score embeds*",
-                config.score_size.unwrap_or_default(),
-                &[
-                    (ScoreSize::AlwaysMinimized, "always minimized"),
-                    (ScoreSize::AlwaysMaximized, "always maximized"),
-                    (ScoreSize::InitialMaximized, "initial maximized"),
-                ],
-            ),
-            create_field(
                 "List embeds*",
                 config.list_size.unwrap_or_default(),
                 &[
@@ -101,28 +92,48 @@ impl ServerConfigEmbed {
                 ],
             ),
             create_field(
-                "Medal solutions",
-                config.hide_medal_solution.unwrap_or(HideSolutions::ShowAll),
+                "Score embeds*",
+                config.score_size.unwrap_or_default(),
                 &[
-                    (HideSolutions::ShowAll, "show"),
-                    (HideSolutions::HideHushHush, "hide hush-hush"),
-                    (HideSolutions::HideAll, "hide all"),
+                    (ScoreSize::AlwaysMinimized, "always minimized"),
+                    (ScoreSize::AlwaysMaximized, "always maximized"),
+                    (ScoreSize::InitialMaximized, "initial maximized"),
                 ],
             ),
+            EmbedField {
+                inline: false,
+                ..create_field(
+                    "Medal solutions",
+                    config.hide_medal_solution.unwrap_or(HideSolutions::ShowAll),
+                    &[
+                        (HideSolutions::ShowAll, "show"),
+                        (HideSolutions::HideHushHush, "hide hush-hush"),
+                        (HideSolutions::HideAll, "hide all"),
+                    ],
+                )
+            },
             create_field(
-                "Minimized PP*",
-                config.minimized_pp.unwrap_or_default(),
-                &[(MinimizedPp::MaxPp, "max pp"), (MinimizedPp::IfFc, "if FC")],
+                "Score data*",
+                config.legacy_scores.unwrap_or(false),
+                &[(false, "lazer"), (true, "stable")],
             ),
             create_field(
-                "Retries*",
-                config.retries.unwrap_or(Retries::ConsiderMods),
-                &[
-                    (Retries::Hide, "hide"),
-                    (Retries::ConsiderMods, "reset on different mods"),
-                    (Retries::IgnoreMods, "ignore mods"),
-                ],
+                "Render button",
+                config.render_button.unwrap_or(true),
+                &[(false, "hide"), (true, "let user decide")],
             ),
+            EmbedField {
+                inline: false,
+                ..create_field(
+                    "Retries*",
+                    config.retries.unwrap_or(Retries::ConsiderMods),
+                    &[
+                        (Retries::Hide, "hide"),
+                        (Retries::ConsiderMods, "reset on different mods"),
+                        (Retries::IgnoreMods, "ignore mods"),
+                    ],
+                )
+            },
         ];
 
         Self {


### PR DESCRIPTION
Adds a DB migration to add `legacy_scores` columns to user- and guild config tables.

Users and guilds can now specify through the config commands whether scores of their commands should be retrieved as legacy format or lazer format.

Noteworthy, using the legacy format will currently also fully exclude lazer scores; could maybe be changed later on.