### PR TITLE
perf(bot): store data into DB in new tasks

### DIFF
--- a/bathbot/src/active/builder.rs
+++ b/bathbot/src/active/builder.rs
@@ -15,7 +15,7 @@ use super::{
     origin::{ActiveMessageOrigin, ActiveMessageOriginError},
     ActiveMessage, BuildPage, FullActiveMessage, IActiveMessage,
 };
-use crate::core::Context;
+use crate::core::{Context, ContextExt};
 
 pub struct ActiveMessagesBuilder {
     inner: ActiveMessage,
@@ -61,7 +61,7 @@ impl ActiveMessagesBuilder {
             content,
             defer: _,
         } = active_msg
-            .build_page(Arc::clone(&ctx))
+            .build_page(ctx.cloned())
             .await
             .wrap_err("Failed to build page")?;
 
@@ -95,7 +95,7 @@ impl ActiveMessagesBuilder {
         let (activity_tx, activity_rx) = watch::channel(());
 
         if let Some(until_timeout) = active_msg.until_timeout() {
-            Self::spawn_timeout(Arc::clone(&ctx), activity_rx, msg, channel, until_timeout);
+            Self::spawn_timeout(ctx.cloned(), activity_rx, msg, channel, until_timeout);
 
             let full = FullActiveMessage {
                 active_msg,

--- a/bathbot/src/active/impls/bg_game/game_wrapper.rs
+++ b/bathbot/src/active/impls/bg_game/game_wrapper.rs
@@ -21,7 +21,7 @@ use twilight_model::{
 };
 
 use super::game::{game_loop, Game, LoopResult};
-use crate::{commands::fun::GameDifficulty, util::ChannelExt, Context};
+use crate::{commands::fun::GameDifficulty, core::ContextExt, util::ChannelExt, Context};
 
 const GAME_LEN: Duration = Duration::from_secs(180);
 
@@ -49,8 +49,14 @@ impl BackgroundGame {
         let mut scores = HashMap::with_hasher(IntHasher);
 
         // Initialize game
-        let (game, mut img) =
-            Game::new(&ctx, &entries, &mut previous_ids, effects, difficulty).await;
+        let (game, mut img) = Game::new(
+            ctx.cloned(),
+            &entries,
+            &mut previous_ids,
+            effects,
+            difficulty,
+        )
+        .await;
         let game = Arc::new(RwLock::new(game));
         let game_clone = Arc::clone(&game);
 
@@ -122,8 +128,14 @@ impl BackgroundGame {
                 }
 
                 // Initialize next game
-                let (game, img_) =
-                    Game::new(&ctx, &entries, &mut previous_ids, effects, difficulty).await;
+                let (game, img_) = Game::new(
+                    ctx.cloned(),
+                    &entries,
+                    &mut previous_ids,
+                    effects,
+                    difficulty,
+                )
+                .await;
                 img = img_;
                 *game_clone.write().await = game;
             }

--- a/bathbot/src/active/impls/bg_game/mapset.rs
+++ b/bathbot/src/active/impls/bg_game/mapset.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use bathbot_psql::model::osu::ArtistTitle;
 use bathbot_util::string_cmp::{gestalt_pattern_matching, levenshtein_similarity};
 use eyre::{Report, Result};
 
-use crate::core::Context;
+use crate::core::{Context, ContextExt};
 
 pub struct GameMapset {
     pub mapset_id: u32,
@@ -12,7 +14,7 @@ pub struct GameMapset {
 }
 
 impl GameMapset {
-    pub async fn new(ctx: &Context, mapset_id: u32) -> Result<Self> {
+    pub async fn new(ctx: Arc<Context>, mapset_id: u32) -> Result<Self> {
         let ArtistTitle { artist, title } = match ctx.osu_map().artist_title(mapset_id).await {
             Ok(mut artist_title) => {
                 artist_title.title.make_ascii_lowercase();

--- a/bathbot/src/active/impls/bg_game/mod.rs
+++ b/bathbot/src/active/impls/bg_game/mod.rs
@@ -21,7 +21,7 @@ pub use self::game_wrapper::BackgroundGame;
 use crate::{
     active::{BuildPage, ComponentResult, IActiveMessage},
     commands::fun::GameDifficulty,
-    core::Context,
+    core::{Context, ContextExt},
     util::{interaction::InteractionComponent, Authored, ComponentExt},
 };
 
@@ -404,7 +404,7 @@ impl BackgroundGameSetup {
             );
 
             let game_fut = BackgroundGame::new(
-                Arc::clone(&ctx),
+                ctx.cloned(),
                 channel,
                 entries,
                 self.effects,

--- a/bathbot/src/active/impls/edit_on_timeout/mod.rs
+++ b/bathbot/src/active/impls/edit_on_timeout/mod.rs
@@ -23,7 +23,7 @@ use super::render::CachedRender;
 use crate::{
     active::{ActiveMessages, BuildPage, ComponentResult, IActiveMessage},
     commands::osu::{OngoingRender, RenderStatus, RenderStatusInner, RENDERER_NAME},
-    core::{buckets::BucketName, Context},
+    core::{buckets::BucketName, Context, ContextExt},
     manager::{OwnedReplayScore, ReplayScore},
     util::{interaction::InteractionComponent, Authored, Emote, MessageExt},
 };
@@ -467,7 +467,7 @@ async fn handle_render_button(
     };
 
     let ongoing_fut = OngoingRender::new(
-        Arc::clone(&ctx),
+        ctx.cloned(),
         render.render_id,
         (msg, permissions),
         status,

--- a/bathbot/src/active/impls/higherlower/farm_maps.rs
+++ b/bathbot/src/active/impls/higherlower/farm_maps.rs
@@ -1,6 +1,7 @@
 use std::{
     f32::consts::SQRT_2,
     fmt::{Display, Formatter, Result as FmtResult},
+    sync::Arc,
 };
 
 use bathbot_model::OsuTrackerIdCount;
@@ -11,7 +12,10 @@ use rand::{prelude::SliceRandom, Rng};
 use time::OffsetDateTime;
 
 use super::state::{mapset_cover, HigherLowerState, H, W};
-use crate::{core::Context, manager::redis::RedisData};
+use crate::{
+    core::{Context, ContextExt},
+    manager::redis::RedisData,
+};
 
 pub type FarmEntries = RedisData<Vec<OsuTrackerIdCount>>;
 
@@ -57,7 +61,7 @@ fn weight(prev: u32, curr: u32, max: f32, score: u32) -> f32 {
 
 impl FarmMap {
     pub(super) async fn random(
-        ctx: &Context,
+        ctx: Arc<Context>,
         entries: &FarmEntries,
         prev: Option<&Self>,
         curr_score: u32,
@@ -197,7 +201,7 @@ impl FarmMap {
         EmbedBuilder::new().description(description)
     }
 
-    async fn new(ctx: &Context, map_id: u32, farm: u32) -> Result<Self> {
+    async fn new(ctx: Arc<Context>, map_id: u32, farm: u32) -> Result<Self> {
         let map = match ctx.osu_map().map(map_id, None).await {
             Ok(map) => map,
             Err(err) => return Err(Report::new(err).wrap_err("Failed to get beatmap")),

--- a/bathbot/src/active/impls/higherlower/mod.rs
+++ b/bathbot/src/active/impls/higherlower/mod.rs
@@ -26,7 +26,7 @@ use twilight_model::{
 use self::state::{ButtonState, HigherLowerState};
 use crate::{
     active::{BuildPage, ComponentResult, IActiveMessage},
-    core::Context,
+    core::{Context, ContextExt},
     util::{interaction::InteractionComponent, Authored, ComponentExt, Emote, MessageExt},
 };
 
@@ -111,11 +111,11 @@ impl IActiveMessage for HigherLowerGame {
 
 impl HigherLowerGame {
     pub async fn new_score_pp(
-        ctx: &Context,
+        ctx: Arc<Context>,
         mode: GameMode,
         msg_owner: Id<UserMarker>,
     ) -> Result<Self> {
-        let game_fut = HigherLowerState::start_score_pp(ctx, mode);
+        let game_fut = HigherLowerState::start_score_pp(ctx.cloned(), mode);
         let highscore_fut = ctx
             .games()
             .higherlower_highscore(msg_owner, HlVersion::ScorePp);
@@ -133,7 +133,7 @@ impl HigherLowerGame {
         })
     }
 
-    pub async fn new_farm_maps(ctx: &Context, msg_owner: Id<UserMarker>) -> Result<Self> {
+    pub async fn new_farm_maps(ctx: Arc<Context>, msg_owner: Id<UserMarker>) -> Result<Self> {
         let entries_fut = ctx.redis().osutracker_counts();
         let highscore_fut = ctx
             .games()
@@ -377,7 +377,7 @@ impl HigherLowerGame {
             warn!(?err, "Failed to callback try again button");
         }
 
-        let (state, rx) = match self.state.restart(&ctx).await {
+        let (state, rx) = match self.state.restart(ctx).await {
             Ok(tuple) => tuple,
             Err(err) => return ComponentResult::Err(err),
         };

--- a/bathbot/src/active/impls/higherlower/score_pp.rs
+++ b/bathbot/src/active/impls/higherlower/score_pp.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, sync::Arc};
 
 use bathbot_model::rosu_v2::ranking::ArchivedRankingsUser;
 use bathbot_util::{
@@ -14,7 +14,7 @@ use twilight_model::channel::message::embed::EmbedField;
 
 use crate::{
     active::impls::higherlower::state::{mapset_cover, HigherLowerState, H, W},
-    core::Context,
+    core::{Context, ContextExt},
     manager::{redis::RedisData, OsuMapSlim},
     util::{osu::grade_emote, Emote},
 };
@@ -40,7 +40,7 @@ pub(super) struct ScorePp {
 
 impl ScorePp {
     pub(super) async fn random(
-        ctx: &Context,
+        ctx: Arc<Context>,
         mode: GameMode,
         prev: Option<&Self>,
         curr_score: u32,

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -25,7 +25,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::CustomAttrs,
-    core::Context,
+    core::{Context, ContextExt},
     embeds::attachment,
     manager::redis::{osu::UserArgs, RedisData},
     util::{
@@ -116,8 +116,9 @@ impl MapPagination {
         let mut info_value = String::with_capacity(128);
         let mut fields = Vec::with_capacity(3);
 
-        let map_fut = ctx.osu_map().pp_map(map.map_id);
-        let creator_fut = creator_name(&ctx, map, &self.mapset);
+        let map_manager = ctx.osu_map();
+        let map_fut = map_manager.pp_map(map.map_id);
+        let creator_fut = creator_name(ctx.cloned(), map, &self.mapset);
         let (map_res, gd_creator) = tokio::join!(map_fut, creator_fut);
 
         let mut rosu_map = map_res.wrap_err("Failed to get pp map")?;
@@ -315,10 +316,10 @@ impl MapPagination {
     }
 }
 
-async fn creator_name<'m>(
-    ctx: &Context,
+async fn creator_name(
+    ctx: Arc<Context>,
     map: &BeatmapExtended,
-    mapset: &'m BeatmapsetExtended,
+    mapset: &BeatmapsetExtended,
 ) -> Option<Username> {
     if map.creator_id == mapset.creator_id {
         return None;

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -25,7 +25,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::OsuStatsEntry,
-    core::Context,
+    core::{Context, ContextExt},
     embeds::{ComboFormatter, HitResultFormatter, PpFormatter},
     manager::redis::RedisData,
     util::{

--- a/bathbot/src/active/impls/popular/mapsets.rs
+++ b/bathbot/src/active/impls/popular/mapsets.rs
@@ -20,7 +20,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::MapsetEntry,
-    core::Context,
+    core::{Context, ContextExt},
     util::interaction::{InteractionComponent, InteractionModal},
 };
 

--- a/bathbot/src/active/impls/profile/availability.rs
+++ b/bathbot/src/active/impls/profile/availability.rs
@@ -1,10 +1,13 @@
-use std::{collections::HashMap, hint, iter, num::NonZeroU32};
+use std::{collections::HashMap, hint, iter, num::NonZeroU32, sync::Arc};
 
 use bathbot_model::RespektiveUserRankHighest;
 use bathbot_util::IntHasher;
 use rosu_v2::prelude::{GameMode, Score, Username};
 
-use crate::{core::Context, manager::redis::osu::UserArgsSlim};
+use crate::{
+    core::{Context, ContextExt},
+    manager::redis::osu::UserArgsSlim,
+};
 
 #[derive(Copy, Clone)]
 pub(super) enum Availability<T> {
@@ -28,7 +31,7 @@ impl<T> Availability<T> {
 impl Availability<Box<[Score]>> {
     pub(super) async fn get(
         &mut self,
-        ctx: &Context,
+        ctx: Arc<Context>,
         user_id: u32,
         mode: GameMode,
         legacy_scores: bool,

--- a/bathbot/src/active/impls/profile/availability.rs
+++ b/bathbot/src/active/impls/profile/availability.rs
@@ -95,9 +95,7 @@ impl Availability<MapperNames> {
                             }
                         };
 
-                        if let Err(err) = ctx.osu_user().store_user(&user, mode).await {
-                            warn!(?err, "Failed to upsert user");
-                        }
+                        ctx.osu_user().store(&user, mode).await;
 
                         names.insert(user.user_id, user.username);
                     }

--- a/bathbot/src/active/impls/profile/top100_mappers.rs
+++ b/bathbot/src/active/impls/profile/top100_mappers.rs
@@ -44,7 +44,7 @@ impl Top100Mappers {
         entries.truncate(10);
 
         let mode = menu.user.mode();
-        let MapperNames(mapper_names) = menu.mapper_names.get(&ctx, mode, &entries).await?;
+        let MapperNames(mapper_names) = menu.mapper_names.get(ctx, mode, &entries).await?;
 
         let mappers = entries
             .into_iter()

--- a/bathbot/src/active/impls/profile/top100_mappers.rs
+++ b/bathbot/src/active/impls/profile/top100_mappers.rs
@@ -1,24 +1,24 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use bathbot_util::IntHasher;
 use rosu_v2::prelude::Username;
 
 use super::{availability::MapperNames, ProfileMenu};
-use crate::core::Context;
+use crate::core::{Context, ContextExt};
 
 pub(super) struct Top100Mappers;
 
 impl Top100Mappers {
-    pub(super) async fn prepare<'s>(
-        ctx: &Context,
-        menu: &'s mut ProfileMenu,
-    ) -> Option<Vec<MapperEntry<'s>>> {
+    pub(super) async fn prepare(
+        ctx: Arc<Context>,
+        menu: &mut ProfileMenu,
+    ) -> Option<Vec<MapperEntry<'_>>> {
         let mut entries: Vec<_> = {
             let user_id = menu.user.user_id();
             let mode = menu.user.mode();
             let scores = menu
                 .scores
-                .get(ctx, user_id, mode, menu.legacy_scores)
+                .get(ctx.cloned(), user_id, mode, menu.legacy_scores)
                 .await?;
             let mut entries = HashMap::with_capacity_and_hasher(32, IntHasher);
 
@@ -44,7 +44,7 @@ impl Top100Mappers {
         entries.truncate(10);
 
         let mode = menu.user.mode();
-        let MapperNames(mapper_names) = menu.mapper_names.get(ctx, mode, &entries).await?;
+        let MapperNames(mapper_names) = menu.mapper_names.get(&ctx, mode, &entries).await?;
 
         let mappers = entries
             .into_iter()

--- a/bathbot/src/active/impls/profile/top100_mods.rs
+++ b/bathbot/src/active/impls/profile/top100_mods.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Reverse, collections::HashMap};
+use std::{cmp::Reverse, collections::HashMap, sync::Arc};
 
 use bathbot_util::IntHasher;
 use rosu_v2::prelude::{GameMod, GameModIntermode, GameModsIntermode, Score};
@@ -13,7 +13,7 @@ pub(super) struct Top100Mods {
 }
 
 impl Top100Mods {
-    pub(super) async fn prepare(ctx: &Context, menu: &mut ProfileMenu) -> Option<Self> {
+    pub(super) async fn prepare(ctx: Arc<Context>, menu: &mut ProfileMenu) -> Option<Self> {
         let user_id = menu.user.user_id();
         let mode = menu.user.mode();
 

--- a/bathbot/src/active/impls/ranking.rs
+++ b/bathbot/src/active/impls/ranking.rs
@@ -26,7 +26,7 @@ use crate::{
         pagination::{handle_pagination_component, handle_pagination_modal, Pages},
         BuildPage, ComponentResult, IActiveMessage,
     },
-    core::Context,
+    core::{Context, ContextExt},
     manager::redis::RedisData,
     util::interaction::{InteractionComponent, InteractionModal},
 };
@@ -91,11 +91,11 @@ impl RankingPagination {
         let mut page = ((idx - idx % 50) + 50) / 50;
         page += self.entries.contains_key(idx) as usize;
 
-        self.assure_present_users(&ctx, page).await?;
+        self.assure_present_users(ctx.cloned(), page).await?;
 
         // Handle edge cases like idx=140;total=151 where two pages have to be requested
         // at once
-        self.assure_present_users(&ctx, page + 1).await?;
+        self.assure_present_users(ctx.cloned(), page + 1).await?;
 
         let idx = self.pages.index();
 
@@ -204,7 +204,7 @@ impl RankingPagination {
         }
     }
 
-    async fn assure_present_users(&mut self, ctx: &Context, page: usize) -> Result<()> {
+    async fn assure_present_users(&mut self, ctx: Arc<Context>, page: usize) -> Result<()> {
         let pages = &self.pages;
         let range = pages.index()..pages.index() + pages.per_page();
         let count = self.entries.entry_count(range);

--- a/bathbot/src/active/impls/snipe/difference.rs
+++ b/bathbot/src/active/impls/snipe/difference.rs
@@ -25,7 +25,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::Difference,
-    core::Context,
+    core::{Context, ContextExt},
     embeds::ModsFormatter,
     manager::redis::RedisData,
     util::interaction::{InteractionComponent, InteractionModal},

--- a/bathbot/src/active/impls/snipe/player_list.rs
+++ b/bathbot/src/active/impls/snipe/player_list.rs
@@ -27,7 +27,7 @@ use crate::{
         pagination::{handle_pagination_component, handle_pagination_modal, Pages},
         BuildPage, ComponentResult, IActiveMessage,
     },
-    core::Context,
+    core::{Context, ContextExt},
     embeds::{HitResultFormatter, PpFormatter},
     manager::{redis::RedisData, OsuMap},
     util::{

--- a/bathbot/src/commands/fun/bg_game/mod.rs
+++ b/bathbot/src/commands/fun/bg_game/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         ActiveMessages,
     },
     commands::ThreadChannel,
+    core::ContextExt,
     util::{interaction::InteractionCommand, Authored, ChannelExt, InteractionCommandExt},
     Context,
 };
@@ -325,13 +326,8 @@ async fn slash_bg(ctx: Arc<Context>, mut command: InteractionCommand) -> Result<
                 command.callback(&ctx, builder, false).await?;
             }
 
-            let game_fut = BackgroundGame::new(
-                Arc::clone(&ctx),
-                channel,
-                entries,
-                Effects::empty(),
-                difficulty,
-            );
+            let game_fut =
+                BackgroundGame::new(ctx.cloned(), channel, entries, Effects::empty(), difficulty);
 
             ctx.bg_games().own(channel).await.insert(game_fut.await);
 

--- a/bathbot/src/commands/fun/higherlower_game.rs
+++ b/bathbot/src/commands/fun/higherlower_game.rs
@@ -17,6 +17,7 @@ use crate::{
         ActiveMessages,
     },
     commands::GameModeOption,
+    core::ContextExt,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
     Context,
 };
@@ -78,9 +79,9 @@ async fn slash_higherlower(ctx: Arc<Context>, mut command: InteractionCommand) -
                 None => ctx.user_config().mode(user).await?.unwrap_or(GameMode::Osu),
             };
 
-            HigherLowerGame::new_score_pp(&ctx, mode, user).await
+            HigherLowerGame::new_score_pp(ctx.cloned(), mode, user).await
         }
-        HigherLower::FarmMaps(_) => HigherLowerGame::new_farm_maps(&ctx, user).await,
+        HigherLower::FarmMaps(_) => HigherLowerGame::new_farm_maps(ctx.cloned(), user).await,
         HigherLower::Leaderboard(ref args) => {
             return higherlower_leaderboard(ctx, command, args.version).await
         }

--- a/bathbot/src/commands/help/message.rs
+++ b/bathbot/src/commands/help/message.rs
@@ -17,7 +17,7 @@ use crate::{
     active::{impls::HelpPrefixMenu, ActiveMessageOriginError, ActiveMessages},
     core::{
         commands::prefix::{PrefixCommand, PrefixCommands},
-        Context,
+        Context, ContextExt,
     },
     util::ChannelExt,
 };
@@ -224,7 +224,7 @@ async fn dm_help(ctx: Arc<Context>, msg: &Message, permissions: Option<Permissio
     }
 
     let help_menu = HelpPrefixMenu::new(msg.guild_id);
-    let active_fut = ActiveMessages::builder(help_menu).begin_with_err(Arc::clone(&ctx), channel);
+    let active_fut = ActiveMessages::builder(help_menu).begin_with_err(ctx.cloned(), channel);
 
     match active_fut.await {
         Ok(_) => Ok(()),

--- a/bathbot/src/commands/osu/avatar.rs
+++ b/bathbot/src/commands/osu/avatar.rs
@@ -83,7 +83,7 @@ async fn avatar(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Avatar<'_>) ->
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/avatar.rs
+++ b/bathbot/src/commands/osu/avatar.rs
@@ -14,7 +14,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 
 use super::{require_link, user_not_found};
 use crate::{
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,

--- a/bathbot/src/commands/osu/badges/user.rs
+++ b/bathbot/src/commands/osu/badges/user.rs
@@ -12,7 +12,7 @@ use super::BadgesUser;
 use crate::{
     active::{impls::BadgesPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     util::osu::get_combined_thumbnail,
 };

--- a/bathbot/src/commands/osu/badges/user.rs
+++ b/bathbot/src/commands/osu/badges/user.rs
@@ -37,7 +37,7 @@ pub(super) async fn user(
         },
     };
 
-    let user_args_fut = UserArgs::rosu_id(&ctx, &user_id);
+    let user_args_fut = UserArgs::rosu_id(ctx.cloned(), &user_id);
     let badges_fut = ctx.redis().badges();
 
     let (user_args_res, badges_res) = tokio::join!(user_args_fut, badges_fut);

--- a/bathbot/src/commands/osu/bookmarks/message.rs
+++ b/bathbot/src/commands/osu/bookmarks/message.rs
@@ -78,7 +78,9 @@ async fn bookmark_map(ctx: Arc<Context>, mut command: InteractionCommand) -> Res
         }
     };
 
-    ctx.osu_map().store(&mapset).await;
+    let mapset_clone = mapset.clone();
+    let ctx_clone = ctx.cloned();
+    tokio::spawn(async move { ctx_clone.osu_map().store(&mapset_clone).await });
 
     let map_opt = mapset
         .maps

--- a/bathbot/src/commands/osu/bookmarks/message.rs
+++ b/bathbot/src/commands/osu/bookmarks/message.rs
@@ -12,7 +12,7 @@ use twilight_model::channel::Message;
 
 use crate::{
     active::{impls::BookmarksPagination, ActiveMessages},
-    core::Context,
+    core::{Context, ContextExt},
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
 };
 

--- a/bathbot/src/commands/osu/bookmarks/message.rs
+++ b/bathbot/src/commands/osu/bookmarks/message.rs
@@ -78,11 +78,7 @@ async fn bookmark_map(ctx: Arc<Context>, mut command: InteractionCommand) -> Res
         }
     };
 
-    if let Err(err) = ctx.osu_map().store(&mapset).await {
-        let _ = command.error(&ctx, GENERAL_ISSUE).await;
-
-        return Err(err);
-    }
+    ctx.osu_map().store(&mapset).await;
 
     let map_opt = mapset
         .maps

--- a/bathbot/src/commands/osu/bws.rs
+++ b/bathbot/src/commands/osu/bws.rs
@@ -160,7 +160,7 @@ async fn bws(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Bws<'_>) -> Resul
 
     let Bws { rank, badges, .. } = args;
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/bws.rs
+++ b/bathbot/src/commands/osu/bws.rs
@@ -12,7 +12,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 
 use super::{require_link, user_not_found};
 use crate::{
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     embeds::{BWSEmbed, EmbedData},
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},

--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -98,7 +98,7 @@ async fn slash_card(ctx: Arc<Context>, mut command: InteractionCommand) -> Resul
 
     let (user_id, mode) = user_id_mode!(ctx, orig, args);
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(true)

--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -18,7 +18,7 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::user_not_found;
 use crate::{
     commands::GameModeOption,
-    core::{commands::CommandOrigin, BotConfig, Context},
+    core::{commands::CommandOrigin, BotConfig, Context, ContextExt},
     embeds::attachment,
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, InteractionCommandExt},

--- a/bathbot/src/commands/osu/claim_name.rs
+++ b/bathbot/src/commands/osu/claim_name.rs
@@ -77,7 +77,7 @@ async fn slash_claimname(ctx: Arc<Context>, mut command: InteractionCommand) -> 
         return Ok(());
     }
 
-    let user_id = match UserArgs::username(&ctx, &name).await {
+    let user_id = match UserArgs::username(ctx.cloned(), &name).await {
         UserArgs::Args(args) => args.user_id,
         UserArgs::User { user, .. } => user.user_id,
         UserArgs::Err(OsuError::NotFound) => {

--- a/bathbot/src/commands/osu/claim_name.rs
+++ b/bathbot/src/commands/osu/claim_name.rs
@@ -19,7 +19,7 @@ use time::{OffsetDateTime, Time};
 use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
-    core::Context,
+    core::{Context, ContextExt},
     embeds::{ClaimNameEmbed, EmbedData},
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, InteractionCommandExt},

--- a/bathbot/src/commands/osu/compare/common.rs
+++ b/bathbot/src/commands/osu/compare/common.rs
@@ -27,7 +27,10 @@ use crate::{
         osu::{user_not_found, UserExtraction},
         GameModeOption,
     },
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, osu::get_combined_thumbnail, InteractionCommandExt},
     Context,
@@ -210,8 +213,8 @@ pub(super) async fn top(
         },
     };
 
-    let fut1 = get_user_and_scores(&ctx, &user_id1, mode);
-    let fut2 = get_user_and_scores(&ctx, &user_id2, mode);
+    let fut1 = get_user_and_scores(ctx.cloned(), &user_id1, mode);
+    let fut2 = get_user_and_scores(ctx.cloned(), &user_id2, mode);
 
     let (user1, scores1, user2, scores2) = match tokio::join!(fut1, fut2) {
         (Ok((user1, scores1)), Ok((user2, scores2))) => (user1, scores1, user2, scores2),
@@ -343,11 +346,11 @@ pub(super) async fn top(
 }
 
 async fn get_user_and_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     user_id: &UserId,
     mode: GameMode,
 ) -> OsuResult<(RedisData<User>, Vec<Score>)> {
-    let args = UserArgs::rosu_id(ctx, user_id).await.mode(mode);
+    let args = UserArgs::rosu_id(&ctx, user_id).await.mode(mode);
 
     ctx.osu_scores()
         .top(false)

--- a/bathbot/src/commands/osu/compare/common.rs
+++ b/bathbot/src/commands/osu/compare/common.rs
@@ -350,7 +350,7 @@ async fn get_user_and_scores(
     user_id: &UserId,
     mode: GameMode,
 ) -> OsuResult<(RedisData<User>, Vec<Score>)> {
-    let args = UserArgs::rosu_id(&ctx, user_id).await.mode(mode);
+    let args = UserArgs::rosu_id(ctx.cloned(), user_id).await.mode(mode);
 
     ctx.osu_scores()
         .top(false)

--- a/bathbot/src/commands/osu/compare/most_played.rs
+++ b/bathbot/src/commands/osu/compare/most_played.rs
@@ -193,7 +193,7 @@ async fn get_user_and_scores(
     ctx: Arc<Context>,
     user_id: &UserId,
 ) -> OsuResult<(RedisData<User>, Vec<MostPlayedMap>)> {
-    match UserArgs::rosu_id(&ctx, user_id).await {
+    match UserArgs::rosu_id(ctx.cloned(), user_id).await {
         UserArgs::Args(args) => {
             let score_fut = ctx.osu().user_most_played(args.user_id).limit(100);
             let user_fut = ctx.redis().osu_user_from_args(args);

--- a/bathbot/src/commands/osu/compare/profile.rs
+++ b/bathbot/src/commands/osu/compare/profile.rs
@@ -146,8 +146,8 @@ pub(super) async fn profile(
     };
 
     // Retrieve all users and their scores
-    let user_args1 = UserArgs::rosu_id(&ctx, &user_id1).await.mode(mode);
-    let user_args2 = UserArgs::rosu_id(&ctx, &user_id2).await.mode(mode);
+    let user_args1 = UserArgs::rosu_id(ctx.cloned(), &user_id1).await.mode(mode);
+    let user_args2 = UserArgs::rosu_id(ctx.cloned(), &user_id2).await.mode(mode);
     let score_args = ctx.osu_scores().top(false).limit(100);
 
     let fut1 = score_args.clone().exec_with_user(user_args1);

--- a/bathbot/src/commands/osu/compare/profile.rs
+++ b/bathbot/src/commands/osu/compare/profile.rs
@@ -29,7 +29,10 @@ use twilight_model::{
 use super::{CompareProfile, AT_LEAST_ONE};
 use crate::{
     commands::{osu::UserExtraction, GameModeOption},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     embeds::{EmbedData, ProfileCompareEmbed},
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, InteractionCommandExt},
@@ -147,7 +150,7 @@ pub(super) async fn profile(
     let user_args2 = UserArgs::rosu_id(&ctx, &user_id2).await.mode(mode);
     let score_args = ctx.osu_scores().top(false).limit(100);
 
-    let fut1 = score_args.exec_with_user(user_args1);
+    let fut1 = score_args.clone().exec_with_user(user_args1);
     let fut2 = score_args.exec_with_user(user_args2);
 
     let (user1, user2, scores1, scores2) = match tokio::try_join!(fut1, fut2) {

--- a/bathbot/src/commands/osu/compare/score.rs
+++ b/bathbot/src/commands/osu/compare/score.rs
@@ -460,7 +460,7 @@ pub(super) async fn score(
     };
 
     let mode = map.mode();
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let (user_res, score_res) = match user_args {
         UserArgs::Args(args) => {

--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -361,7 +361,10 @@ async fn request_by_map(
         }
     };
 
-    let (user_res, scores_res) = match UserArgs::rosu_id(&ctx, &user_id).await.mode(map.mode()) {
+    let (user_res, scores_res) = match UserArgs::rosu_id(ctx.cloned(), &user_id)
+        .await
+        .mode(map.mode())
+    {
         UserArgs::Args(args) => {
             let user_fut = ctx.redis().osu_user_from_args(args);
             let scores_fut = ctx
@@ -475,7 +478,7 @@ async fn request_by_score(
     legacy_scores: bool,
 ) -> ScoreResult {
     let score_fut = ctx.osu().score(score_id, mode);
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let user_fut = ctx.redis().osu_user(user_args);
 
     let (user, score) = match tokio::join!(user_fut, score_fut) {

--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -21,7 +21,10 @@ use twilight_model::{
 
 use super::{require_link, user_not_found, HasMods, ModsResult};
 use crate::{
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     embeds::{EmbedData, FixScoreEmbed},
     manager::{
         redis::{
@@ -237,10 +240,18 @@ async fn fix(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: FixArgs<'_>) -> R
 
     let data_result = match args.id {
         Some(MapOrScore::Score { id, mode }) => {
-            request_by_score(&ctx, &orig, id, mode, user_id, legacy_scores).await
+            request_by_score(ctx.cloned(), &orig, id, mode, user_id, legacy_scores).await
         }
         Some(MapOrScore::Map(MapIdType::Map(id))) => {
-            request_by_map(&ctx, &orig, id, user_id, mods.as_ref(), legacy_scores).await
+            request_by_map(
+                ctx.cloned(),
+                &orig,
+                id,
+                user_id,
+                mods.as_ref(),
+                legacy_scores,
+            )
+            .await
         }
         Some(MapOrScore::Map(MapIdType::Set(_))) => {
             let content = "Looks like you gave me a mapset id, I need a map id though";
@@ -259,7 +270,15 @@ async fn fix(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: FixArgs<'_>) -> R
 
             match ctx.find_map_id_in_msgs(&msgs, 0).await {
                 Some(MapIdType::Map(id)) => {
-                    request_by_map(&ctx, &orig, id, user_id, mods.as_ref(), legacy_scores).await
+                    request_by_map(
+                        ctx.cloned(),
+                        &orig,
+                        id,
+                        user_id,
+                        mods.as_ref(),
+                        legacy_scores,
+                    )
+                    .await
                 }
                 None | Some(MapIdType::Set(_)) => {
                     let content = "No beatmap specified and none found in recent channel history. \
@@ -315,7 +334,7 @@ pub struct FixScore {
 // Retrieve user's score on the map, the user itself, and the map including
 // mapset
 async fn request_by_map(
-    ctx: &Context,
+    ctx: Arc<Context>,
     orig: &CommandOrigin<'_>,
     map_id: u32,
     user_id: UserId,
@@ -330,19 +349,19 @@ async fn request_by_map(
                 Did you give me a mapset id instead of a map id?"
             );
 
-            return match orig.error(ctx, content).await {
+            return match orig.error(&ctx, content).await {
                 Ok(_) => ScoreResult::Done,
                 Err(err) => ScoreResult::Error(err),
             };
         }
         Err(MapError::Report(err)) => {
-            let _ = orig.error(ctx, GENERAL_ISSUE).await;
+            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
 
             return ScoreResult::Error(err);
         }
     };
 
-    let (user_res, scores_res) = match UserArgs::rosu_id(ctx, &user_id).await.mode(map.mode()) {
+    let (user_res, scores_res) = match UserArgs::rosu_id(&ctx, &user_id).await.mode(map.mode()) {
         UserArgs::Args(args) => {
             let user_fut = ctx.redis().osu_user_from_args(args);
             let scores_fut = ctx
@@ -368,15 +387,15 @@ async fn request_by_map(
     let user = match user_res {
         Ok(user) => user,
         Err(OsuError::NotFound) => {
-            let content = user_not_found(ctx, user_id).await;
+            let content = user_not_found(&ctx, user_id).await;
 
-            return match orig.error(ctx, content).await {
+            return match orig.error(&ctx, content).await {
                 Ok(_) => ScoreResult::Done,
                 Err(err) => ScoreResult::Error(err),
             };
         }
         Err(err) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let wrap = "Failed to get user";
 
             return ScoreResult::Error(Report::new(err).wrap_err(wrap));
@@ -397,7 +416,7 @@ async fn request_by_map(
             }),
         },
         Err(err) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let wrap = "Failed to get scores";
 
             return ScoreResult::Error(Report::new(err).wrap_err(wrap));
@@ -426,7 +445,7 @@ async fn request_by_map(
             let top = match top_res {
                 Ok(scores) => scores,
                 Err(err) => {
-                    let _ = orig.error(ctx, OSU_API_ISSUE).await;
+                    let _ = orig.error(&ctx, OSU_API_ISSUE).await;
                     let wrap = "failed to get top scores";
 
                     return ScoreResult::Error(Report::new(err).wrap_err(wrap));
@@ -437,7 +456,7 @@ async fn request_by_map(
 
             // Not being done concurrently with the previous two because
             // then the map retrieval might happen twice
-            let if_fc = IfFc::new(ctx, &score, &map).await;
+            let if_fc = IfFc::new(&ctx, &score, &map).await;
 
             Some(FixScore { score, top, if_fc })
         }
@@ -448,7 +467,7 @@ async fn request_by_map(
 }
 
 async fn request_by_score(
-    ctx: &Context,
+    ctx: Arc<Context>,
     orig: &CommandOrigin<'_>,
     score_id: u64,
     mode: GameMode,
@@ -456,15 +475,15 @@ async fn request_by_score(
     legacy_scores: bool,
 ) -> ScoreResult {
     let score_fut = ctx.osu().score(score_id, mode);
-    let user_args = UserArgs::rosu_id(ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
     let user_fut = ctx.redis().osu_user(user_args);
 
     let (user, score) = match tokio::join!(user_fut, score_fut) {
         (Ok(user), Ok(score)) => (user, score),
         (Err(OsuError::NotFound), _) => {
-            let content = user_not_found(ctx, user_id).await;
+            let content = user_not_found(&ctx, user_id).await;
 
-            return match orig.error(ctx, content).await {
+            return match orig.error(&ctx, content).await {
                 Ok(_) => ScoreResult::Done,
                 Err(err) => ScoreResult::Error(err),
             };
@@ -472,13 +491,13 @@ async fn request_by_score(
         (_, Err(OsuError::NotFound)) => {
             let content = format!("A score with id {score_id} does not exists");
 
-            return match orig.error(ctx, content).await {
+            return match orig.error(&ctx, content).await {
                 Ok(_) => ScoreResult::Done,
                 Err(err) => ScoreResult::Error(err),
             };
         }
         (Err(err), _) | (_, Err(err)) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let err = Report::new(err).wrap_err("failed to get user or scores");
 
             return ScoreResult::Error(err);
@@ -501,18 +520,18 @@ async fn request_by_score(
         (Err(MapError::NotFound), _) => {
             let content = format!("There is no map with id {map_id}");
 
-            return match orig.error(ctx, content).await {
+            return match orig.error(&ctx, content).await {
                 Ok(_) => ScoreResult::Done,
                 Err(err) => ScoreResult::Error(err),
             };
         }
         (Err(MapError::Report(err)), _) => {
-            let _ = orig.error(ctx, GENERAL_ISSUE).await;
+            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
 
             return ScoreResult::Error(err);
         }
         (_, Err(err)) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let err = Report::new(err).wrap_err("failed to get top scores");
 
             return ScoreResult::Error(err);
@@ -525,7 +544,7 @@ async fn request_by_score(
     };
 
     let score = ScoreSlim::new(score, pp);
-    let if_fc = IfFc::new(ctx, &score, &map).await;
+    let if_fc = IfFc::new(&ctx, &score, &map).await;
 
     let data = FixEntry {
         user,

--- a/bathbot/src/commands/osu/graphs/medals.rs
+++ b/bathbot/src/commands/osu/graphs/medals.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{mem, sync::Arc};
 
 use bathbot_model::rosu_v2::user::{MedalCompact as MedalCompactRkyv, User};
 use bathbot_util::{
@@ -15,27 +15,27 @@ use rosu_v2::{prelude::OsuError, request::UserId};
 use super::{H, W};
 use crate::{
     commands::osu::{medals::stats as medals_stats, user_not_found},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
 };
 
 pub async fn medals_graph(
-    ctx: &Context,
+    ctx: Arc<Context>,
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
 
     let mut user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,
         Err(OsuError::NotFound) => {
-            let content = user_not_found(ctx, user_id).await;
-            orig.error(ctx, content).await?;
+            let content = user_not_found(&ctx, user_id).await;
+            orig.error(&ctx, content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let report = Report::new(err).wrap_err("failed to get user");
 
             return Err(report);
@@ -56,12 +56,12 @@ pub async fn medals_graph(
         Ok(None) => {
             let content = format!("`{}` does not have any medals", user.username());
             let builder = MessageBuilder::new().embed(content);
-            orig.create_message(ctx, builder).await?;
+            orig.create_message(&ctx, builder).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(ctx, GENERAL_ISSUE).await;
+            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
             warn!(?err, "Failed to create medals graph");
 
             return Ok(None);

--- a/bathbot/src/commands/osu/graphs/medals.rs
+++ b/bathbot/src/commands/osu/graphs/medals.rs
@@ -24,7 +24,7 @@ pub async fn medals_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let mut user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -32,7 +32,7 @@ use self::{
 use super::{require_link, user_not_found};
 use crate::{
     commands::{GameModeOption, ShowHideOption, TimezoneOption},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     embeds::attachment,
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, InteractionCommandExt},
@@ -207,7 +207,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
                 },
             };
 
-            medals_graph(&ctx, &orig, user_id)
+            medals_graph(ctx.cloned(), &orig, user_id)
                 .await
                 .wrap_err("failed to create medals graph")?
         }
@@ -243,7 +243,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
                 return orig.error(&ctx, ":clown:").await;
             }
 
-            playcount_replays_graph(&ctx, &orig, user_id, flags)
+            playcount_replays_graph(ctx.cloned(), &orig, user_id, flags)
                 .await
                 .wrap_err("failed to create profile graph")?
         }
@@ -251,7 +251,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
             let (user_id, mode) = user_id_mode!(ctx, orig, args);
             let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
 
-            rank_graph(&ctx, &orig, user_id, user_args)
+            rank_graph(ctx.cloned(), &orig, user_id, user_args)
                 .await
                 .wrap_err("failed to create rank graph")?
         }
@@ -269,7 +269,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
                 },
             };
 
-            sniped_graph(&ctx, &orig, user_id)
+            sniped_graph(ctx.cloned(), &orig, user_id)
                 .await
                 .wrap_err("failed to create snipe graph")?
         }
@@ -287,7 +287,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
                 },
             };
 
-            snipe_count_graph(&ctx, &orig, user_id)
+            snipe_count_graph(ctx.cloned(), &orig, user_id)
                 .await
                 .wrap_err("failed to create snipe count graph")?
         }
@@ -337,7 +337,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
             };
 
             top_graph(
-                &ctx,
+                ctx.cloned(),
                 &orig,
                 user_id,
                 user_args,
@@ -350,9 +350,8 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
         }
     };
 
-    let (user, graph) = match tuple_option {
-        Some(tuple) => tuple,
-        None => return Ok(()),
+    let Some((user, graph)) = tuple_option else {
+        return Ok(());
     };
 
     let embed = EmbedBuilder::new()
@@ -372,7 +371,7 @@ const W: u32 = 1350;
 const H: u32 = 711;
 
 async fn top_graph(
-    ctx: &Context,
+    ctx: Arc<Context>,
     orig: &CommandOrigin<'_>,
     user_id: UserId,
     user_args: UserArgs,
@@ -389,13 +388,13 @@ async fn top_graph(
     let (user, mut scores) = match scores_fut.await {
         Ok(tuple) => tuple,
         Err(OsuError::NotFound) => {
-            let content = user_not_found(ctx, user_id).await;
-            orig.error(ctx, content).await?;
+            let content = user_not_found(&ctx, user_id).await;
+            orig.error(&ctx, content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let err = Report::new(err).wrap_err("failed to get user or scores");
 
             return Err(err);
@@ -404,7 +403,7 @@ async fn top_graph(
 
     if scores.is_empty() {
         let content = "User's top scores are empty";
-        orig.error(ctx, content).await?;
+        orig.error(&ctx, content).await?;
 
         return Ok(None);
     }
@@ -454,7 +453,7 @@ async fn top_graph(
     let bytes = match graph_result {
         Ok(graph) => graph,
         Err(err) => {
-            let _ = orig.error(ctx, GENERAL_ISSUE).await;
+            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
             warn!("{err:?}");
 
             return Ok(None);

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -249,7 +249,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
         }
         Graph::Rank(args) => {
             let (user_id, mode) = user_id_mode!(ctx, orig, args);
-            let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
             rank_graph(ctx.cloned(), &orig, user_id, user_args)
                 .await
@@ -317,7 +317,7 @@ async fn graph(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Graph) -> Resul
                 },
             };
 
-            let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
             let tz = args
                 .timezone

--- a/bathbot/src/commands/osu/graphs/playcount_replays.rs
+++ b/bathbot/src/commands/osu/graphs/playcount_replays.rs
@@ -49,7 +49,7 @@ pub async fn playcount_replays_graph(
     user_id: UserId,
     flags: ProfileGraphFlags,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let mut user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     constants::{GENERAL_ISSUE, HUISMETBENEN_ISSUE, OSU_API_ISSUE},
@@ -9,27 +11,27 @@ use rosu_v2::{prelude::OsuError, request::UserId};
 use super::{H, W};
 use crate::{
     commands::osu::{player_snipe_stats, user_not_found},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
 };
 
 pub async fn snipe_count_graph(
-    ctx: &Context,
+    ctx: Arc<Context>,
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,
         Err(OsuError::NotFound) => {
-            let content = user_not_found(ctx, user_id).await;
-            orig.error(ctx, content).await?;
+            let content = user_not_found(&ctx, user_id).await;
+            orig.error(&ctx, content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let err = Report::new(err).wrap_err("failed to get user");
 
             return Err(err);
@@ -61,12 +63,12 @@ pub async fn snipe_count_graph(
             Ok(None) => {
                 let content = format!("`{username}` has never had any national #1s");
                 let builder = MessageBuilder::new().embed(content);
-                orig.create_message(ctx, builder).await?;
+                orig.create_message(&ctx, builder).await?;
 
                 return Ok(None);
             }
             Err(err) => {
-                let _ = orig.error(ctx, HUISMETBENEN_ISSUE).await;
+                let _ = orig.error(&ctx, HUISMETBENEN_ISSUE).await;
 
                 return Err(err);
             }
@@ -74,7 +76,7 @@ pub async fn snipe_count_graph(
     } else {
         let content = format!("`{username}`'s country {country_code} is not supported :(");
 
-        orig.error(ctx, content).await?;
+        orig.error(&ctx, content).await?;
 
         return Ok(None);
     };
@@ -85,7 +87,7 @@ pub async fn snipe_count_graph(
     let bytes = match graph_result {
         Ok(graph) => graph,
         Err(err) => {
-            let _ = orig.error(ctx, GENERAL_ISSUE).await;
+            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
             warn!(?err, "Failed to create snipe count graph");
 
             return Ok(None);

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -20,7 +20,7 @@ pub async fn snipe_count_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -21,7 +21,7 @@ pub async fn sniped_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     constants::{GENERAL_ISSUE, HUISMETBENEN_ISSUE, OSU_API_ISSUE},
@@ -10,27 +12,27 @@ use time::{Duration, OffsetDateTime};
 use super::{H, W};
 use crate::{
     commands::osu::{sniped, user_not_found},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
 };
 
 pub async fn sniped_graph(
-    ctx: &Context,
+    ctx: Arc<Context>,
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,
         Err(OsuError::NotFound) => {
-            let content = user_not_found(ctx, user_id).await;
-            orig.error(ctx, content).await?;
+            let content = user_not_found(&ctx, user_id).await;
+            orig.error(&ctx, content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(ctx, OSU_API_ISSUE).await;
+            let _ = orig.error(&ctx, OSU_API_ISSUE).await;
             let err = Report::new(err).wrap_err("failed to get user");
 
             return Err(err);
@@ -70,14 +72,14 @@ pub async fn sniped_graph(
                 (sniper, snipee)
             }
             Err(err) => {
-                let _ = orig.error(ctx, HUISMETBENEN_ISSUE).await;
+                let _ = orig.error(&ctx, HUISMETBENEN_ISSUE).await;
 
                 return Err(err.wrap_err("failed to get sniper or snipee"));
             }
         }
     } else {
         let content = format!("`{username}`'s country {country_code} is not supported :(");
-        orig.error(ctx, content).await?;
+        orig.error(&ctx, content).await?;
 
         return Ok(None);
     };
@@ -89,12 +91,12 @@ pub async fn sniped_graph(
                 "`{username}` was neither sniped nor sniped other people in the last 8 weeks"
             );
             let builder = MessageBuilder::new().embed(content);
-            orig.create_message(ctx, builder).await?;
+            orig.create_message(&ctx, builder).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(ctx, GENERAL_ISSUE).await;
+            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
             warn!(?err, "Failed to create sniped graph");
 
             return Ok(None);

--- a/bathbot/src/commands/osu/leaderboard.rs
+++ b/bathbot/src/commands/osu/leaderboard.rs
@@ -32,7 +32,10 @@ use twilight_model::{
 use super::{HasMods, ModsResult};
 use crate::{
     active::{impls::LeaderboardPagination, ActiveMessages},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{
         redis::{osu::UserArgs, RedisData},
         MapError, Mods, OsuMap,
@@ -336,7 +339,7 @@ async fn leaderboard(
     );
 
     let user_fut = get_user_score(
-        &ctx,
+        ctx.cloned(),
         config.osu,
         map_id,
         map.mode(),
@@ -490,7 +493,7 @@ async fn get_map_id(
 }
 
 async fn get_user_score(
-    ctx: &Context,
+    ctx: Arc<Context>,
     osu_id: Option<u32>,
     map_id: u32,
     mode: GameMode,

--- a/bathbot/src/commands/osu/map.rs
+++ b/bathbot/src/commands/osu/map.rs
@@ -321,9 +321,7 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
         }
     };
 
-    if let Err(err) = ctx.osu_map().store(&mapset).await {
-        warn!("{err:?}");
-    }
+    ctx.osu_map().store(&mapset).await;
 
     let Some(mut maps) = mapset.maps.take().filter(|maps| !maps.is_empty()) else {
         return orig.error(&ctx, "The mapset has no maps").await;

--- a/bathbot/src/commands/osu/map.rs
+++ b/bathbot/src/commands/osu/map.rs
@@ -29,7 +29,10 @@ use twilight_model::{
 use super::{BitMapElement, HasMods, ModsResult};
 use crate::{
     active::{impls::MapPagination, ActiveMessages},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     util::{interaction::InteractionCommand, ChannelExt, CheckPermissions, InteractionCommandExt},
     Context,
 };
@@ -376,7 +379,8 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
         Ok::<_, Report>(cover.thumbnail_exact(W, H))
     };
 
-    let (strain_values_res, img_res) = tokio::join!(strain_values(&ctx, map_id, &mods), bg_fut);
+    let (strain_values_res, img_res) =
+        tokio::join!(strain_values(ctx.cloned(), map_id, &mods), bg_fut);
 
     let img_opt = match img_res {
         Ok(img) => Some(img),
@@ -436,7 +440,7 @@ struct GraphStrains {
 const NEW_STRAIN_COUNT: usize = 200;
 
 async fn strain_values(
-    ctx: &Context,
+    ctx: Arc<Context>,
     map_id: u32,
     mods: &GameModsIntermode,
 ) -> Result<GraphStrains> {

--- a/bathbot/src/commands/osu/map.rs
+++ b/bathbot/src/commands/osu/map.rs
@@ -321,7 +321,9 @@ async fn map(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: MapArgs<'_>) -> R
         }
     };
 
-    ctx.osu_map().store(&mapset).await;
+    let mapset_clone = mapset.clone();
+    let ctx_clone = ctx.cloned();
+    tokio::spawn(async move { ctx_clone.osu_map().store(&mapset_clone).await });
 
     let Some(mut maps) = mapset.maps.take().filter(|maps| !maps.is_empty()) else {
         return orig.error(&ctx, "The mapset has no maps").await;

--- a/bathbot/src/commands/osu/mapper.rs
+++ b/bathbot/src/commands/osu/mapper.rs
@@ -250,11 +250,13 @@ async fn mapper(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Mapper<'_>) ->
     };
 
     let mapper = args.mapper.cow_to_ascii_lowercase();
-    let mapper_args = UserArgs::username(&ctx, mapper.as_ref()).await.mode(mode);
+    let mapper_args = UserArgs::username(ctx.cloned(), mapper.as_ref())
+        .await
+        .mode(mode);
     let mapper_fut = ctx.redis().osu_user(mapper_args);
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(legacy_scores)

--- a/bathbot/src/commands/osu/mapper.rs
+++ b/bathbot/src/commands/osu/mapper.rs
@@ -24,7 +24,10 @@ use super::{require_link, user_not_found, ScoreOrder, TopEntry};
 use crate::{
     active::{impls::TopPagination, ActiveMessages},
     commands::GameModeOption,
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,
@@ -285,7 +288,7 @@ async fn mapper(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Mapper<'_>) ->
 
     let username = user.username();
 
-    let entries = match process_scores(&ctx, scores, mapper_id, args.sort).await {
+    let entries = match process_scores(ctx.cloned(), scores, mapper_id, args.sort).await {
         Ok(entries) => entries,
         Err(err) => {
             let _ = orig.error(&ctx, GENERAL_ISSUE).await;
@@ -380,7 +383,7 @@ async fn mapper(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Mapper<'_>) ->
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<Score>,
     mapper_id: u32,
     sort: Option<ScoreOrder>,

--- a/bathbot/src/commands/osu/medals/common.rs
+++ b/bathbot/src/commands/osu/medals/common.rs
@@ -25,7 +25,7 @@ use super::{MedalCommon, MedalCommonFilter, MedalCommonOrder};
 use crate::{
     active::{impls::MedalsCommonPagination, ActiveMessages},
     commands::osu::UserExtraction,
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     util::osu::get_combined_thumbnail,
     Context,

--- a/bathbot/src/commands/osu/medals/common.rs
+++ b/bathbot/src/commands/osu/medals/common.rs
@@ -130,10 +130,10 @@ pub(super) async fn common(
     let MedalCommon { sort, filter, .. } = args;
 
     // Retrieve all users and their scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id1).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id1).await;
     let user_fut1 = ctx.redis().osu_user(user_args);
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id2).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id2).await;
     let user_fut2 = ctx.redis().osu_user(user_args);
 
     let medals_fut = ctx.redis().medals();

--- a/bathbot/src/commands/osu/medals/list.rs
+++ b/bathbot/src/commands/osu/medals/list.rs
@@ -50,7 +50,7 @@ pub(super) async fn list(
         ..
     } = args;
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
     let user_fut = ctx.redis().osu_user(user_args);
     let medals_fut = ctx.redis().medals();
     let ranking_fut = ctx.redis().osekai_ranking::<Rarity>();

--- a/bathbot/src/commands/osu/medals/list.rs
+++ b/bathbot/src/commands/osu/medals/list.rs
@@ -18,7 +18,7 @@ use super::{MedalList, MedalListOrder};
 use crate::{
     active::{impls::MedalsListPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     Context,
 };

--- a/bathbot/src/commands/osu/medals/medal.rs
+++ b/bathbot/src/commands/osu/medals/medal.rs
@@ -26,7 +26,7 @@ use twilight_model::{
 
 use super::{MedalAchieved, MedalInfo_};
 use crate::{
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::RedisData,
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,
@@ -77,10 +77,10 @@ pub(super) async fn info(
 
     let name = match (name, &orig) {
         (AutocompleteValue::None, CommandOrigin::Interaction { command }) => {
-            return handle_autocomplete(&ctx, command, String::new()).await
+            return handle_autocomplete(ctx, command, String::new()).await
         }
         (AutocompleteValue::Focused(name), CommandOrigin::Interaction { command }) => {
-            return handle_autocomplete(&ctx, command, name).await
+            return handle_autocomplete(ctx, command, name).await
         }
         (AutocompleteValue::Completed(name), _) => name,
         _ => unreachable!(),
@@ -200,12 +200,12 @@ async fn no_medal(
 }
 
 pub async fn handle_autocomplete(
-    ctx: &Context,
+    ctx: Arc<Context>,
     command: &InteractionCommand,
     name: String,
 ) -> Result<()> {
     let name = if name.is_empty() {
-        command.autocomplete(ctx, Vec::new()).await?;
+        command.autocomplete(&ctx, Vec::new()).await?;
 
         return Ok(());
     } else {
@@ -247,7 +247,7 @@ pub async fn handle_autocomplete(
         }
     }
 
-    command.autocomplete(ctx, choices).await?;
+    command.autocomplete(&ctx, choices).await?;
 
     Ok(())
 }

--- a/bathbot/src/commands/osu/medals/missing.rs
+++ b/bathbot/src/commands/osu/medals/missing.rs
@@ -66,7 +66,7 @@ pub(super) async fn missing(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
     let user_fut = ctx.redis().osu_user(user_args);
     let medals_fut = ctx.redis().medals();
 

--- a/bathbot/src/commands/osu/medals/missing.rs
+++ b/bathbot/src/commands/osu/medals/missing.rs
@@ -15,7 +15,7 @@ use super::{MedalMissing, MedalMissingOrder};
 use crate::{
     active::{impls::MedalsMissingPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     Context,
 };

--- a/bathbot/src/commands/osu/medals/recent.rs
+++ b/bathbot/src/commands/osu/medals/recent.rs
@@ -23,7 +23,7 @@ use super::{MedalEmbed, MedalRecent};
 use crate::{
     active::{impls::MedalsRecentPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     Context,
 };

--- a/bathbot/src/commands/osu/medals/recent.rs
+++ b/bathbot/src/commands/osu/medals/recent.rs
@@ -75,7 +75,7 @@ pub(super) async fn recent(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
     let user_fut = ctx.redis().osu_user(user_args);
     let medals_fut = ctx.redis().medals();
 

--- a/bathbot/src/commands/osu/medals/stats.rs
+++ b/bathbot/src/commands/osu/medals/stats.rs
@@ -79,7 +79,7 @@ pub(super) async fn stats(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
     let user_fut = ctx.redis().osu_user(user_args);
     let medals_fut = ctx.redis().medals();
 

--- a/bathbot/src/commands/osu/medals/stats.rs
+++ b/bathbot/src/commands/osu/medals/stats.rs
@@ -25,7 +25,7 @@ use twilight_model::guild::Permissions;
 use super::MedalStats;
 use crate::{
     commands::osu::{require_link, user_not_found},
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{EmbedData, MedalStatsEmbed, StatsMedal},
     manager::redis::{osu::UserArgs, RedisData},
     util::Monthly,

--- a/bathbot/src/commands/osu/most_played.rs
+++ b/bathbot/src/commands/osu/most_played.rs
@@ -84,7 +84,7 @@ async fn mostplayed(
     };
 
     // Retrieve the user and their most played maps
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/most_played.rs
+++ b/bathbot/src/commands/osu/most_played.rs
@@ -13,7 +13,7 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::{require_link, user_not_found};
 use crate::{
     active::{impls::MostPlayedPagination, ActiveMessages},
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,

--- a/bathbot/src/commands/osu/nochoke.rs
+++ b/bathbot/src/commands/osu/nochoke.rs
@@ -20,7 +20,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::{require_link, user_not_found};
 use crate::{
     active::{impls::NoChokePagination, ActiveMessages},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{redis::osu::UserArgs, OsuMap},
     util::{interaction::InteractionCommand, osu::IfFc, InteractionCommandExt},
     Context,
@@ -255,7 +258,7 @@ async fn nochoke(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Nochoke<'_>) 
 
     let version = version.unwrap_or_default();
 
-    let mut entries = match process_scores(&ctx, scores, miss_limit, version).await {
+    let mut entries = match process_scores(ctx.cloned(), scores, miss_limit, version).await {
         Ok(entries) => entries,
         Err(err) => {
             let _ = orig.error(&ctx, GENERAL_ISSUE).await;
@@ -409,7 +412,7 @@ impl Unchoked {
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<Score>,
     miss_limit: Option<u32>,
     version: NochokeVersion,
@@ -453,11 +456,11 @@ async fn process_scores(
         let unchoked = match version {
             NochokeVersion::Unchoke if too_many_misses => None,
             // Skip unchoking because it has too many misses or because its a convert
-            NochokeVersion::Unchoke => IfFc::new(ctx, &score, &map)
+            NochokeVersion::Unchoke => IfFc::new(&ctx, &score, &map)
                 .await
                 .map(|if_fc| Unchoked::new(if_fc, &score.mods, score.mode)),
             NochokeVersion::Perfect if too_many_misses => None,
-            NochokeVersion::Perfect => Some(perfect_score(ctx, &score, &map).await),
+            NochokeVersion::Perfect => Some(perfect_score(&ctx, &score, &map).await),
         };
 
         let entry = NochokeEntry {

--- a/bathbot/src/commands/osu/nochoke.rs
+++ b/bathbot/src/commands/osu/nochoke.rs
@@ -234,7 +234,7 @@ async fn nochoke(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Nochoke<'_>) 
     } = args;
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(legacy_scores)

--- a/bathbot/src/commands/osu/osekai/medal_count.rs
+++ b/bathbot/src/commands/osu/osekai/medal_count.rs
@@ -7,6 +7,7 @@ use eyre::Result;
 use super::OsekaiMedalCount;
 use crate::{
     active::{impls::MedalCountPagination, ActiveMessages},
+    core::ContextExt,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
     Context,
 };

--- a/bathbot/src/commands/osu/osekai/rarity.rs
+++ b/bathbot/src/commands/osu/osekai/rarity.rs
@@ -6,6 +6,7 @@ use eyre::Result;
 
 use crate::{
     active::{impls::MedalRarityPagination, ActiveMessages},
+    core::ContextExt,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
     Context,
 };

--- a/bathbot/src/commands/osu/osekai/user_value.rs
+++ b/bathbot/src/commands/osu/osekai/user_value.rs
@@ -10,6 +10,7 @@ use rosu_v2::prelude::Username;
 
 use crate::{
     active::{impls::RankingPagination, ActiveMessages},
+    core::ContextExt,
     manager::redis::RedisData,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
     Context,

--- a/bathbot/src/commands/osu/osustats/best.rs
+++ b/bathbot/src/commands/osu/osustats/best.rs
@@ -7,7 +7,7 @@ use rosu_v2::prelude::GameMode;
 use super::{OsuStatsBest, OsuStatsBestSort};
 use crate::{
     active::{impls::OsuStatsBestPagination, ActiveMessages},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
 };
 
 pub(super) async fn recentbest(

--- a/bathbot/src/commands/osu/osustats/counts.rs
+++ b/bathbot/src/commands/osu/osustats/counts.rs
@@ -13,7 +13,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::OsuStatsCount;
 use crate::{
     commands::{osu::user_not_found, GameModeOption},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     embeds::{EmbedData, OsuStatsCountsEmbed},
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, osu::TopCounts, InteractionCommandExt},

--- a/bathbot/src/commands/osu/osustats/counts.rs
+++ b/bathbot/src/commands/osu/osustats/counts.rs
@@ -159,7 +159,7 @@ pub(super) async fn count(
     args: OsuStatsCount<'_>,
 ) -> Result<()> {
     let (user_id, mode) = user_id_mode!(ctx, orig, args);
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -23,7 +23,10 @@ use crate::{
         osu::{user_not_found, HasMods, ModsResult},
         GameModeOption,
     },
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{redis::osu::UserArgs, OsuMap},
     util::ChannelExt,
     Context,
@@ -216,7 +219,7 @@ pub(super) async fn scores(
         }
     };
 
-    let entries = match process_scores(&ctx, scores, mode).await {
+    let entries = match process_scores(ctx.cloned(), scores, mode).await {
         Ok(entries) => entries,
         Err(err) => {
             let _ = orig.error(&ctx, GENERAL_ISSUE).await;
@@ -468,7 +471,7 @@ pub struct OsuStatsEntry {
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<OsuStatsScore>,
     mode: GameMode,
 ) -> Result<BTreeMap<usize, OsuStatsEntry>> {

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -188,7 +188,7 @@ pub(super) async fn scores(
     };
 
     let (user_id, mode) = user_id_mode!(ctx, orig, args);
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     // Retrieve user
     let user = match ctx.redis().osu_user(user_args).await {

--- a/bathbot/src/commands/osu/pinned.rs
+++ b/bathbot/src/commands/osu/pinned.rs
@@ -167,7 +167,7 @@ async fn pinned(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pinned) -> Res
         },
     };
 
-    let (user_args, user_opt) = match UserArgs::rosu_id(&ctx, &user_id).await.mode(mode) {
+    let (user_args, user_opt) = match UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode) {
         UserArgs::Args(args) => (args, None),
         UserArgs::User { user, mode } => (
             UserArgsSlim::user_id(user.user_id).mode(mode),

--- a/bathbot/src/commands/osu/popular/mappers.rs
+++ b/bathbot/src/commands/osu/popular/mappers.rs
@@ -7,7 +7,7 @@ use rkyv::{DeserializeUnsized, Infallible};
 
 use crate::{
     active::{impls::PopularMappersPagination, ActiveMessages},
-    core::Context,
+    core::{Context, ContextExt},
     manager::redis::RedisData,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
 };

--- a/bathbot/src/commands/osu/popular/maps.rs
+++ b/bathbot/src/commands/osu/popular/maps.rs
@@ -8,7 +8,7 @@ use rkyv::{Deserialize, Infallible};
 use super::PopularMapsPp;
 use crate::{
     active::{impls::PopularMapsPagination, ActiveMessages},
-    core::Context,
+    core::{Context, ContextExt},
     manager::redis::RedisData,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
 };

--- a/bathbot/src/commands/osu/popular/mapsets.rs
+++ b/bathbot/src/commands/osu/popular/mapsets.rs
@@ -12,7 +12,7 @@ use time::OffsetDateTime;
 
 use crate::{
     active::{impls::PopularMapsetsPagination, ActiveMessages},
-    core::Context,
+    core::{Context, ContextExt},
     manager::redis::RedisData,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
 };

--- a/bathbot/src/commands/osu/popular/mods.rs
+++ b/bathbot/src/commands/osu/popular/mods.rs
@@ -6,7 +6,7 @@ use rkyv::{Deserialize, Infallible};
 
 use crate::{
     active::{impls::PopularModsPagination, ActiveMessages},
-    core::Context,
+    core::{Context, ContextExt},
     manager::redis::RedisData,
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},
 };

--- a/bathbot/src/commands/osu/pp.rs
+++ b/bathbot/src/commands/osu/pp.rs
@@ -190,7 +190,7 @@ async fn pp(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Pp<'_>) -> Result<
     }
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(false)

--- a/bathbot/src/commands/osu/pp.rs
+++ b/bathbot/src/commands/osu/pp.rs
@@ -10,7 +10,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::user_not_found;
 use crate::{
     commands::GameModeOption,
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     embeds::{EmbedData, PpMissingEmbed},
     manager::redis::{osu::UserArgs, RedisData},
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},

--- a/bathbot/src/commands/osu/profile.rs
+++ b/bathbot/src/commands/osu/profile.rs
@@ -17,7 +17,10 @@ use super::{require_link, user_not_found};
 use crate::{
     active::{impls::ProfileMenu, ActiveMessages},
     commands::GameModeOption,
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,

--- a/bathbot/src/commands/osu/profile.rs
+++ b/bathbot/src/commands/osu/profile.rs
@@ -214,7 +214,7 @@ async fn profile(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Profile<'_>) 
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/rank/pp.rs
+++ b/bathbot/src/commands/osu/rank/pp.rs
@@ -21,7 +21,10 @@ use rosu_v2::prelude::{CountryCode, OsuError, Score, UserId, Username};
 use super::{RankPp, RankValue};
 use crate::{
     commands::{osu::user_not_found, GameModeOption},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{
         osu::{UserArgs, UserArgsSlim},
         RedisData,

--- a/bathbot/src/commands/osu/rank/pp.rs
+++ b/bathbot/src/commands/osu/rank/pp.rs
@@ -69,7 +69,7 @@ pub(super) async fn pp(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: RankPp<
             .await;
     }
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let user_fut = ctx.redis().osu_user(user_args);
 
     let user = match user_fut.await {
@@ -94,7 +94,7 @@ pub(super) async fn pp(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: RankPp<
         RankValue::Raw(rank) => RankOrHolder::Rank(rank),
         RankValue::Name(name) => {
             let user_id = UserId::from(name);
-            let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
             match ctx.redis().osu_user(user_args).await {
                 Ok(target_user) => {

--- a/bathbot/src/commands/osu/rank/score.rs
+++ b/bathbot/src/commands/osu/rank/score.rs
@@ -15,7 +15,10 @@ use rosu_v2::prelude::{OsuError, UserId, Username};
 use super::{RankScore, RankValue};
 use crate::{
     commands::{osu::user_not_found, GameModeOption},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{osu::UserArgs, RedisData},
     util::ChannelExt,
     Context,

--- a/bathbot/src/commands/osu/rank/score.rs
+++ b/bathbot/src/commands/osu/rank/score.rs
@@ -171,7 +171,7 @@ pub(super) async fn score(
             .await;
     }
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,
@@ -222,7 +222,7 @@ pub(super) async fn score(
         }
         RankValue::Raw(rank) => rank,
         RankValue::Name(name) => {
-            let user_id = match UserArgs::username(&ctx, name).await {
+            let user_id = match UserArgs::username(ctx.cloned(), name).await {
                 UserArgs::Args(args) => args.user_id,
                 UserArgs::User { user, .. } => {
                     rank_holder = Some(RankHolder {

--- a/bathbot/src/commands/osu/ranking/players.rs
+++ b/bathbot/src/commands/osu/ranking/players.rs
@@ -12,7 +12,7 @@ use super::{RankingPp, RankingScore};
 use crate::{
     active::{impls::RankingPagination, ActiveMessages},
     commands::GameModeOption,
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     util::ChannelExt,
     Context,
@@ -82,7 +82,7 @@ pub(super) async fn pp(
             })
     };
 
-    let author_idx_fut = pp_author_idx(&ctx, author_id, mode, country.as_ref());
+    let author_idx_fut = pp_author_idx(ctx.cloned(), author_id, mode, country.as_ref());
 
     let (ranking_res, author_idx) = tokio::join!(ranking_fut, author_idx_fut);
     let kind = OsuRankingKind::Performance;
@@ -91,7 +91,7 @@ pub(super) async fn pp(
 }
 
 async fn pp_author_idx(
-    ctx: &Context,
+    ctx: Arc<Context>,
     author_id: Option<u32>,
     mode: GameMode,
     country: Option<&CountryCode>,

--- a/bathbot/src/commands/osu/ratios.rs
+++ b/bathbot/src/commands/osu/ratios.rs
@@ -105,7 +105,7 @@ async fn ratios(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Ratios<'_>) ->
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id)
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id)
         .await
         .mode(GameMode::Mania);
 

--- a/bathbot/src/commands/osu/ratios.rs
+++ b/bathbot/src/commands/osu/ratios.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{marker::UserMarker, Id};
 
 use super::{require_link, user_not_found};
 use crate::{
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{EmbedData, RatioEmbed},
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, InteractionCommandExt},

--- a/bathbot/src/commands/osu/recent/fix.rs
+++ b/bathbot/src/commands/osu/recent/fix.rs
@@ -15,7 +15,7 @@ use rosu_v2::{
 use super::RecentFix;
 use crate::{
     commands::osu::{require_link, user_not_found, FixEntry, FixScore},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     embeds::{EmbedData, FixScoreEmbed},
     manager::redis::osu::{UserArgs, UserArgsSlim},
     util::osu::IfFc,

--- a/bathbot/src/commands/osu/recent/fix.rs
+++ b/bathbot/src/commands/osu/recent/fix.rs
@@ -52,7 +52,7 @@ pub(super) async fn fix(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: Recent
     };
 
     // Retrieve the user and their recent scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let scores_fut = ctx
         .osu_scores()

--- a/bathbot/src/commands/osu/recent/leaderboard.rs
+++ b/bathbot/src/commands/osu/recent/leaderboard.rs
@@ -23,7 +23,10 @@ use crate::{
         },
         GameModeOption,
     },
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{redis::osu::UserArgs, Mods},
     Context,
 };

--- a/bathbot/src/commands/osu/recent/leaderboard.rs
+++ b/bathbot/src/commands/osu/recent/leaderboard.rs
@@ -223,7 +223,7 @@ pub(super) async fn leaderboard(
     };
 
     // Retrieve the recent scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let scores_fut = ctx
         .osu_scores()

--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -379,7 +379,7 @@ pub(super) async fn list(
     let grade = grade.map(Grade::from);
 
     // Retrieve the user and their recent scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let include_fails = match (grade, passes) {
         (Some(Grade::F), Some(true)) => return orig.error(&ctx, ":clown:").await,

--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -28,7 +28,10 @@ use crate::{
         osu::{require_link, user_not_found, HasMods, ModsResult, ScoreOrder},
         GameModeOption, GradeOption,
     },
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{redis::osu::UserArgs, Mods, OsuMap},
     util::{
         query::{IFilterCriteria, RegularCriteria, Searchable},
@@ -422,14 +425,15 @@ pub(super) async fn list(
         }
     };
 
-    let (entries, maps) = match process_scores(&ctx, scores, &args, mode, mods.as_ref()).await {
-        Ok(entries) => entries,
-        Err(err) => {
-            let _ = orig.error(&ctx, GENERAL_ISSUE).await;
+    let (entries, maps) =
+        match process_scores(ctx.cloned(), scores, &args, mode, mods.as_ref()).await {
+            Ok(entries) => entries,
+            Err(err) => {
+                let _ = orig.error(&ctx, GENERAL_ISSUE).await;
 
-            return Err(err.wrap_err("Failed to process scores"));
-        }
-    };
+                return Err(err.wrap_err("Failed to process scores"));
+            }
+        };
 
     let content = message_content(grade, mods.as_ref(), query.as_deref()).unwrap_or_default();
 
@@ -495,7 +499,7 @@ pub struct RecentListEntry {
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<Score>,
     args: &RecentList<'_>,
     mode: GameMode,

--- a/bathbot/src/commands/osu/recent/score.rs
+++ b/bathbot/src/commands/osu/recent/score.rs
@@ -392,7 +392,7 @@ pub(super) async fn score(
     let grade = grade.map(Grade::from);
 
     // Retrieve the user and their recent scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
 
     let include_fails = match (grade, passes) {
         (Some(Grade::F), Some(true)) => return orig.error(&ctx, ":clown:").await,

--- a/bathbot/src/commands/osu/recent/score.rs
+++ b/bathbot/src/commands/osu/recent/score.rs
@@ -30,7 +30,10 @@ use crate::{
         osu::{require_link, user_not_found},
         GameModeOption, GradeOption,
     },
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{
         redis::osu::{UserArgs, UserArgsSlim},
         OsuMap, OwnedReplayScore,

--- a/bathbot/src/commands/osu/scores/map.rs
+++ b/bathbot/src/commands/osu/scores/map.rs
@@ -18,7 +18,7 @@ use crate::{
         compare::{slash_compare_score, ScoreOrder},
         CompareScoreAutocomplete, HasMods, ModsResult,
     },
-    core::Context,
+    core::{Context, ContextExt},
     util::{
         interaction::InteractionCommand,
         query::{FilterCriteria, IFilterCriteria, ScoresCriteria},

--- a/bathbot/src/commands/osu/scores/server.rs
+++ b/bathbot/src/commands/osu/scores/server.rs
@@ -16,7 +16,7 @@ use super::{get_mode, process_scores, separate_content, MapStatus, ServerScores}
 use crate::{
     active::{impls::ScoresServerPagination, ActiveMessages},
     commands::osu::{user_not_found, HasMods, ModsResult, ScoresOrder},
-    core::Context,
+    core::{Context, ContextExt},
     manager::redis::osu::UserArgs,
     util::{
         interaction::InteractionCommand,

--- a/bathbot/src/commands/osu/scores/server.rs
+++ b/bathbot/src/commands/osu/scores/server.rs
@@ -116,7 +116,7 @@ pub async fn server_scores(
     };
 
     let creator_id = match args.mapper {
-        Some(ref mapper) => match UserArgs::username(&ctx, mapper).await {
+        Some(ref mapper) => match UserArgs::username(ctx.cloned(), mapper).await {
             UserArgs::Args(args) => Some(args.user_id),
             UserArgs::User { user, .. } => Some(user.user_id),
             UserArgs::Err(OsuError::NotFound) => {

--- a/bathbot/src/commands/osu/scores/user.rs
+++ b/bathbot/src/commands/osu/scores/user.rs
@@ -92,7 +92,7 @@ pub async fn user_scores(
     };
 
     let creator_id = match args.mapper {
-        Some(ref mapper) => match UserArgs::username(&ctx, mapper).await {
+        Some(ref mapper) => match UserArgs::username(ctx.cloned(), mapper).await {
             UserArgs::Args(args) => Some(args.user_id),
             UserArgs::User { user, .. } => Some(user.user_id),
             UserArgs::Err(OsuError::NotFound) => {
@@ -159,7 +159,7 @@ async fn get_user(
     user_id: &UserId,
     mode: Option<GameMode>,
 ) -> Result<RedisData<User>, OsuError> {
-    let mut args = UserArgs::rosu_id(&ctx, user_id).await;
+    let mut args = UserArgs::rosu_id(ctx.cloned(), user_id).await;
 
     if let Some(mode) = mode {
         args = args.mode(mode);

--- a/bathbot/src/commands/osu/scores/user.rs
+++ b/bathbot/src/commands/osu/scores/user.rs
@@ -15,7 +15,7 @@ use super::{process_scores, separate_content, MapStatus, ScoresOrder, UserScores
 use crate::{
     active::{impls::ScoresUserPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found, HasMods, ModsResult},
-    core::{commands::CommandOrigin, Context},
+    core::{commands::CommandOrigin, Context, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     util::{
         interaction::InteractionCommand,
@@ -58,7 +58,7 @@ pub async fn user_scores(
         }
     };
 
-    let user_fut = get_user(&ctx, &user_id, mode);
+    let user_fut = get_user(ctx.cloned(), &user_id, mode);
 
     let user = match user_fut.await {
         Ok(user) => user,
@@ -155,11 +155,11 @@ pub async fn user_scores(
 }
 
 async fn get_user(
-    ctx: &Context,
+    ctx: Arc<Context>,
     user_id: &UserId,
     mode: Option<GameMode>,
 ) -> Result<RedisData<User>, OsuError> {
-    let mut args = UserArgs::rosu_id(ctx, user_id).await;
+    let mut args = UserArgs::rosu_id(&ctx, user_id).await;
 
     if let Some(mode) = mode {
         args = args.mode(mode);

--- a/bathbot/src/commands/osu/snipe/country_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_list.rs
@@ -16,7 +16,10 @@ use super::{SnipeCountryList, SnipeCountryListOrder};
 use crate::{
     active::{impls::SnipeCountryListPagination, ActiveMessages},
     commands::osu::user_not_found,
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{osu::UserArgs, RedisData},
     util::ChannelExt,
     Context,

--- a/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
@@ -19,7 +19,7 @@ use twilight_model::guild::Permissions;
 use super::SnipeCountryStats;
 use crate::{
     commands::osu::user_not_found,
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{CountrySnipeStatsEmbed, EmbedData},
     manager::redis::{osu::UserArgs, RedisData},
     Context,

--- a/bathbot/src/commands/osu/snipe/player_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_list.rs
@@ -95,7 +95,7 @@ pub(super) async fn player_list(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/player_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_list.rs
@@ -20,7 +20,10 @@ use super::{SnipePlayerList, SnipePlayerListOrder};
 use crate::{
     active::{impls::SnipePlayerListPagination, ActiveMessages},
     commands::osu::{require_link, HasMods, ModsResult},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::redis::{osu::UserArgs, RedisData},
     util::ChannelExt,
     Context,

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -19,7 +19,7 @@ use twilight_model::guild::Permissions;
 use super::SnipePlayerStats;
 use crate::{
     commands::osu::require_link,
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{EmbedData, PlayerSnipeStatsEmbed},
     manager::redis::{osu::UserArgs, RedisData},
     util::Monthly,

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -78,7 +78,7 @@ pub(super) async fn player_stats(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/sniped.rs
+++ b/bathbot/src/commands/osu/snipe/sniped.rs
@@ -30,7 +30,7 @@ use twilight_model::guild::Permissions;
 use super::SnipePlayerSniped;
 use crate::{
     commands::osu::require_link,
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{EmbedData, SnipedEmbed},
     manager::redis::{osu::UserArgs, RedisData},
     Context,

--- a/bathbot/src/commands/osu/snipe/sniped.rs
+++ b/bathbot/src/commands/osu/snipe/sniped.rs
@@ -88,7 +88,7 @@ pub(super) async fn player_sniped(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/sniped_difference.rs
+++ b/bathbot/src/commands/osu/snipe/sniped_difference.rs
@@ -13,7 +13,7 @@ use super::{SnipePlayerGain, SnipePlayerLoss};
 use crate::{
     active::{impls::SnipeDifferencePagination, ActiveMessages},
     commands::osu::require_link,
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     manager::redis::{osu::UserArgs, RedisData},
     Context,
 };

--- a/bathbot/src/commands/osu/snipe/sniped_difference.rs
+++ b/bathbot/src/commands/osu/snipe/sniped_difference.rs
@@ -125,7 +125,7 @@ async fn sniped_diff(
     };
 
     // Request the user
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await;
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await;
 
     let user = match ctx.redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/top/if_.rs
+++ b/bathbot/src/commands/osu/top/if_.rs
@@ -23,7 +23,10 @@ use crate::{
         osu::{require_link, user_not_found},
         GameModeOption,
     },
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{redis::osu::UserArgs, OsuMap},
     util::{
         interaction::InteractionCommand,
@@ -269,7 +272,7 @@ async fn topif(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: TopIf<'_>) -> R
     let sort = args.sort.unwrap_or_default();
     let content = get_content(user.username(), mode, &mods, args.query.as_deref(), sort);
 
-    let mut entries = match process_scores(&ctx, scores, mods, mode, sort).await {
+    let mut entries = match process_scores(ctx.cloned(), scores, mods, mode, sort).await {
         Ok(scores) => scores,
         Err(err) => {
             let _ = orig.error(&ctx, GENERAL_ISSUE).await;
@@ -432,7 +435,7 @@ impl<'q> Searchable<TopCriteria<'q>> for TopIfEntry {
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<Score>,
     mut arg_mods: ModSelection,
     mode: GameMode,

--- a/bathbot/src/commands/osu/top/if_.rs
+++ b/bathbot/src/commands/osu/top/if_.rs
@@ -240,7 +240,7 @@ async fn topif(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: TopIf<'_>) -> R
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(legacy_scores)

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -819,7 +819,7 @@ pub(super) async fn top(
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(legacy_scores)

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -36,7 +36,10 @@ use crate::{
         ActiveMessages,
     },
     commands::{GameModeOption, GradeOption},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{
         redis::{osu::UserArgs, RedisData},
         OsuMap, OwnedReplayScore,
@@ -886,7 +889,7 @@ pub(super) async fn top(
     let pre_len = scores.len();
 
     // Filter scores according to mods, combo, acc, and grade
-    let entries = match process_scores(&ctx, scores, &args, &farm).await {
+    let entries = match process_scores(ctx.cloned(), scores, &args, &farm).await {
         Ok(entries) => entries,
         Err(err) => {
             let _ = orig.error(&ctx, GENERAL_ISSUE).await;
@@ -1192,7 +1195,7 @@ impl<'q> Searchable<TopCriteria<'q>> for TopEntry {
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<Score>,
     args: &TopArgs<'_>,
     farm: &Farm,

--- a/bathbot/src/commands/osu/top/old.rs
+++ b/bathbot/src/commands/osu/top/old.rs
@@ -22,7 +22,10 @@ use super::TopIfEntry;
 use crate::{
     active::{impls::TopIfPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found, HasMods, ModsResult, TopIfScoreOrder},
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     manager::{redis::osu::UserArgs, OsuMap},
     util::{
         interaction::InteractionCommand,
@@ -794,7 +797,7 @@ async fn topold(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: TopOld<'_>) ->
     let pre_pp = user.stats().pp();
     let bonus_pp = pre_pp - actual_pp;
 
-    let mut entries = match process_scores(&ctx, scores, &args).await {
+    let mut entries = match process_scores(ctx.cloned(), scores, &args).await {
         Ok(scores) => scores,
         Err(err) => {
             let _ = orig.error(&ctx, GENERAL_ISSUE).await;
@@ -866,7 +869,7 @@ async fn topold(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: TopOld<'_>) ->
 }
 
 async fn process_scores(
-    ctx: &Context,
+    ctx: Arc<Context>,
     scores: Vec<Score>,
     args: &TopOld<'_>,
 ) -> Result<Vec<TopIfEntry>> {
@@ -930,7 +933,7 @@ async fn process_scores(
                 TopOldOsuVersion::November21September22 => {
                     pp_std!(osu_2021_november, rosu_map, score, mods)
                 }
-                TopOldOsuVersion::September22Now => use_current_system(ctx, &score, &map).await,
+                TopOldOsuVersion::September22Now => use_current_system(&ctx, &score, &map).await,
             },
             TopOld::Taiko(t) => match t.version {
                 TopOldTaikoVersion::March14September20 => {
@@ -939,11 +942,11 @@ async fn process_scores(
                 TopOldTaikoVersion::September20September22 => {
                     pp_tko!(taiko_2020, rosu_map, score, mods)
                 }
-                TopOldTaikoVersion::September22Now => use_current_system(ctx, &score, &map).await,
+                TopOldTaikoVersion::September22Now => use_current_system(&ctx, &score, &map).await,
             },
             TopOld::Catch(c) => match c.version {
                 TopOldCatchVersion::March14May20 => pp_ctb!(fruits_ppv1, rosu_map, score, mods),
-                TopOldCatchVersion::May20Now => use_current_system(ctx, &score, &map).await,
+                TopOldCatchVersion::May20Now => use_current_system(&ctx, &score, &map).await,
             },
             TopOld::Mania(m) => match m.version {
                 TopOldManiaVersion::March14May18 => {
@@ -981,7 +984,7 @@ async fn process_scores(
 
                     (pp, max_pp, stars, max_combo)
                 }
-                TopOldManiaVersion::October22Now => use_current_system(ctx, &score, &map).await,
+                TopOldManiaVersion::October22Now => use_current_system(&ctx, &score, &map).await,
             },
         };
 

--- a/bathbot/src/commands/osu/top/old.rs
+++ b/bathbot/src/commands/osu/top/old.rs
@@ -765,7 +765,7 @@ async fn topold(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: TopOld<'_>) ->
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(legacy_scores)

--- a/bathbot/src/commands/osu/whatif.rs
+++ b/bathbot/src/commands/osu/whatif.rs
@@ -15,7 +15,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::user_not_found;
 use crate::{
     commands::GameModeOption,
-    core::commands::{prefix::Args, CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        ContextExt,
+    },
     embeds::{EmbedData, WhatIfEmbed},
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},

--- a/bathbot/src/commands/osu/whatif.rs
+++ b/bathbot/src/commands/osu/whatif.rs
@@ -206,7 +206,7 @@ async fn whatif(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: WhatIf<'_>) ->
     }
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&ctx, &user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(ctx.cloned(), &user_id).await.mode(mode);
     let scores_fut = ctx
         .osu_scores()
         .top(false)

--- a/bathbot/src/commands/owner/add_bg.rs
+++ b/bathbot/src/commands/owner/add_bg.rs
@@ -14,7 +14,7 @@ use tokio::{
 
 use super::OwnerAddBg;
 use crate::{
-    core::BotConfig,
+    core::{BotConfig, ContextExt},
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,
 };
@@ -91,7 +91,7 @@ pub async fn addbg(ctx: Arc<Context>, command: InteractionCommand, bg: OwnerAddB
     };
 
     // Check if valid mapset id
-    let content = match prepare_mapset(&ctx, mapset_id, &image.filename, mode).await {
+    let content = match prepare_mapset(ctx.cloned(), mapset_id, &image.filename, mode).await {
         Ok(ArtistTitle { artist, title }) => format!(
             "Background for [{artist} - {title}]({OSU_BASE}s/{mapset_id}) successfully added ({mode})",
         ),
@@ -109,7 +109,7 @@ pub async fn addbg(ctx: Arc<Context>, command: InteractionCommand, bg: OwnerAddB
 }
 
 async fn prepare_mapset(
-    ctx: &Context,
+    ctx: Arc<Context>,
     mapset_id: u32,
     filename: &str,
     mode: GameMode,

--- a/bathbot/src/commands/tracking/mod.rs
+++ b/bathbot/src/commands/tracking/mod.rs
@@ -140,7 +140,9 @@ async fn get_names(
             let name = name.cow_to_ascii_lowercase();
 
             if entries.keys().all(|n| name != n.cow_to_ascii_lowercase()) {
-                let args = UserArgs::username(&ctx, name.as_ref()).await.mode(mode);
+                let args = UserArgs::username(ctx.cloned(), name.as_ref())
+                    .await
+                    .mode(mode);
 
                 match ctx.redis().osu_user(args).await {
                     Ok(user) => entries.insert(user.username().into(), user.user_id()),

--- a/bathbot/src/commands/tracking/mod.rs
+++ b/bathbot/src/commands/tracking/mod.rs
@@ -11,7 +11,10 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 pub use self::{track::*, track_list::*, untrack::*, untrack_all::*};
 use super::GameModeOption;
 use crate::{
-    core::commands::prefix::{Args, ArgsNum},
+    core::{
+        commands::prefix::{Args, ArgsNum},
+        ContextExt,
+    },
     manager::redis::osu::UserArgs,
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,
@@ -118,11 +121,11 @@ async fn slash_track(ctx: Arc<Context>, mut command: InteractionCommand) -> Resu
     }
 }
 
-async fn get_names<'n>(
-    ctx: &Context,
-    names: &'n [String],
+async fn get_names(
+    ctx: Arc<Context>,
+    names: &[String],
     mode: GameMode,
-) -> Result<HashMap<Username, u32>, (OsuError, Cow<'n, str>)> {
+) -> Result<HashMap<Username, u32>, (OsuError, Cow<'_, str>)> {
     let mut entries = match ctx.osu_user().ids(names).await {
         Ok(names) => names,
         Err(err) => {
@@ -137,7 +140,7 @@ async fn get_names<'n>(
             let name = name.cow_to_ascii_lowercase();
 
             if entries.keys().all(|n| name != n.cow_to_ascii_lowercase()) {
-                let args = UserArgs::username(ctx, name.as_ref()).await.mode(mode);
+                let args = UserArgs::username(&ctx, name.as_ref()).await.mode(mode);
 
                 match ctx.redis().osu_user(args).await {
                     Ok(user) => entries.insert(user.username().into(), user.user_id()),

--- a/bathbot/src/commands/tracking/track.rs
+++ b/bathbot/src/commands/tracking/track.rs
@@ -8,7 +8,7 @@ use time::OffsetDateTime;
 
 use super::TrackArgs;
 use crate::{
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{EmbedData, TrackEmbed},
     util::ChannelExt,
     Context,
@@ -53,7 +53,7 @@ pub(super) async fn track(
 
     let mode = mode.unwrap_or(GameMode::Osu);
 
-    let users = match super::get_names(&ctx, &more_names, mode).await {
+    let users = match super::get_names(ctx.cloned(), &more_names, mode).await {
         Ok(map) => map,
         Err((OsuError::NotFound, name)) => {
             let content = format!("User `{name}` was not found");

--- a/bathbot/src/commands/tracking/track_list.rs
+++ b/bathbot/src/commands/tracking/track_list.rs
@@ -11,7 +11,7 @@ use rosu_v2::{
 use twilight_model::id::{marker::ChannelMarker, Id};
 
 use crate::{
-    core::commands::CommandOrigin,
+    core::{commands::CommandOrigin, ContextExt},
     embeds::{EmbedData, TrackListEmbed},
     manager::redis::osu::UserArgs,
     Context,
@@ -36,7 +36,7 @@ pub async fn tracklist(ctx: Arc<Context>, orig: CommandOrigin<'_>) -> Result<()>
     let channel_id = orig.channel_id();
     let tracked = ctx.tracking().list(channel_id).await;
 
-    let mut users = match get_users(&ctx, orig.channel_id(), tracked).await {
+    let mut users = match get_users(ctx.cloned(), orig.channel_id(), tracked).await {
         Ok(entries) => entries,
         Err(err) => {
             let _ = orig.error(&ctx, OSU_API_ISSUE).await;
@@ -69,7 +69,7 @@ pub async fn tracklist(ctx: Arc<Context>, orig: CommandOrigin<'_>) -> Result<()>
 }
 
 async fn get_users(
-    ctx: &Context,
+    ctx: Arc<Context>,
     channel: Id<ChannelMarker>,
     tracked: Vec<(TrackedOsuUserKey, u8)>,
 ) -> OsuResult<Vec<TracklistUserEntry>> {

--- a/bathbot/src/commands/utility/config.rs
+++ b/bathbot/src/commands/utility/config.rs
@@ -16,6 +16,8 @@ use twilight_interactions::command::{CommandModel, CommandOption, CreateCommand,
 use twilight_model::id::{marker::UserMarker, Id};
 
 use super::{SkinValidation, ValidationStatus};
+#[allow(unused)]
+use crate::core::ContextExt;
 use crate::{
     commands::{ShowHideOption, TimezoneOption},
     embeds::{ConfigEmbed, EmbedData},
@@ -309,9 +311,11 @@ pub async fn config(ctx: Arc<Context>, command: InteractionCommand, config: Conf
     let res = {
         match (osu, twitch) {
             (Some(ConfigLink::Link), Some(ConfigLink::Link)) => {
-                handle_both_links(&ctx, &command, &mut config).await
+                handle_both_links(ctx.cloned(), &command, &mut config).await
             }
-            (Some(ConfigLink::Link), _) => handle_osu_link(&ctx, &command, &mut config).await,
+            (Some(ConfigLink::Link), _) => {
+                handle_osu_link(ctx.cloned(), &command, &mut config).await
+            }
             (_, Some(ConfigLink::Link)) => handle_twitch_link(&ctx, &command, &mut config).await,
             (..) => handle_no_links(&ctx, &command, &mut config).await,
         }
@@ -389,7 +393,7 @@ fn twitch_content(state: u8) -> String {
 
 #[cfg(feature = "server")]
 async fn handle_both_links(
-    ctx: &Context,
+    ctx: Arc<Context>,
     command: &InteractionCommand,
     config: &mut UserConfig<OsuUserId>,
 ) -> HandleResult {
@@ -406,12 +410,15 @@ async fn handle_both_links(
     let builder = MessageBuilder::new().embed(embed);
     let fut = async { tokio::try_join!(osu_fut, twitch_fut) };
 
-    let twitch_name = match handle_ephemeral(ctx, command, builder, fut).await {
+    let twitch_name = match handle_ephemeral(&ctx, command, builder, fut).await {
         Some(Ok((osu, twitch))) => {
-            ctx.osu_user().store(&osu, osu.mode).await;
-
             config.osu = Some(osu.user_id);
             config.twitch_id = Some(twitch.user_id);
+
+            let ctx = ctx.cloned();
+            tokio::spawn(async move {
+                ctx.osu_user().store(&osu, osu.mode).await;
+            });
 
             Some(twitch.display_name)
         }
@@ -425,7 +432,7 @@ async fn handle_both_links(
     };
 
     if let Err(err) = ctx.user_config().store(author.id, config).await {
-        let _ = command.error(ctx, GENERAL_ISSUE).await;
+        let _ = command.error(&ctx, GENERAL_ISSUE).await;
 
         return HandleResult::Err(err);
     }
@@ -473,7 +480,7 @@ async fn handle_twitch_link(
 
 #[cfg(feature = "server")]
 async fn handle_osu_link(
-    ctx: &Context,
+    ctx: Arc<Context>,
     command: &InteractionCommand,
     config: &mut UserConfig<OsuUserId>,
 ) -> HandleResult {
@@ -485,11 +492,16 @@ async fn handle_osu_link(
 
     let builder = MessageBuilder::new().embed(embed);
 
-    config.osu = match handle_ephemeral(ctx, command, builder, fut).await {
+    config.osu = match handle_ephemeral(&ctx, command, builder, fut).await {
         Some(Ok(user)) => {
-            ctx.osu_user().store(&user, user.mode).await;
+            let user_id = user.user_id;
 
-            Some(user.user_id)
+            let ctx = ctx.cloned();
+            tokio::spawn(async move {
+                ctx.osu_user().store(&user, user.mode).await;
+            });
+
+            Some(user_id)
         }
         Some(Err(err)) => return HandleResult::Err(err),
         None => return HandleResult::Done,
@@ -511,7 +523,7 @@ async fn handle_osu_link(
             }
             Err(err) => {
                 let _ = command
-                    .error(ctx, bathbot_util::constants::TWITCH_API_ISSUE)
+                    .error(&ctx, bathbot_util::constants::TWITCH_API_ISSUE)
                     .await;
 
                 return HandleResult::Err(err.wrap_err("failed to get twitch user by id"));
@@ -520,7 +532,7 @@ async fn handle_osu_link(
     }
 
     if let Err(err) = ctx.user_config().store(author.id, config).await {
-        let _ = command.error(ctx, GENERAL_ISSUE).await;
+        let _ = command.error(&ctx, GENERAL_ISSUE).await;
 
         return HandleResult::Err(err);
     }

--- a/bathbot/src/commands/utility/config.rs
+++ b/bathbot/src/commands/utility/config.rs
@@ -408,9 +408,7 @@ async fn handle_both_links(
 
     let twitch_name = match handle_ephemeral(ctx, command, builder, fut).await {
         Some(Ok((osu, twitch))) => {
-            if let Err(err) = ctx.osu_user().store_user(&osu, osu.mode).await {
-                warn!("{err:?}");
-            }
+            ctx.osu_user().store(&osu, osu.mode).await;
 
             config.osu = Some(osu.user_id);
             config.twitch_id = Some(twitch.user_id);
@@ -489,9 +487,7 @@ async fn handle_osu_link(
 
     config.osu = match handle_ephemeral(ctx, command, builder, fut).await {
         Some(Ok(user)) => {
-            if let Err(err) = ctx.osu_user().store_user(&user, user.mode).await {
-                warn!("{err:?}");
-            }
+            ctx.osu_user().store(&user, user.mode).await;
 
             Some(user.user_id)
         }

--- a/bathbot/src/core/context/ext.rs
+++ b/bathbot/src/core/context/ext.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use super::Context;
+use crate::manager::{redis::RedisManager, HuismetbenenCountryManager, MapManager, ScoresManager};
+
+pub trait ContextExt {
+    fn cloned(&self) -> Arc<Context>;
+
+    fn redis(&self) -> RedisManager;
+
+    fn osu_map(&self) -> MapManager;
+
+    fn osu_scores(&self) -> ScoresManager;
+
+    fn huismetbenen(&self) -> HuismetbenenCountryManager;
+}
+
+impl ContextExt for Arc<Context> {
+    fn cloned(&self) -> Arc<Context> {
+        Arc::clone(self)
+    }
+
+    fn redis(&self) -> RedisManager {
+        RedisManager::new(Arc::clone(self))
+    }
+
+    fn osu_map(&self) -> MapManager {
+        MapManager::new(Arc::clone(self))
+    }
+
+    fn osu_scores(&self) -> ScoresManager {
+        ScoresManager::new(Arc::clone(self))
+    }
+
+    fn huismetbenen(&self) -> HuismetbenenCountryManager {
+        HuismetbenenCountryManager::new(Arc::clone(self))
+    }
+}

--- a/bathbot/src/core/context/manager.rs
+++ b/bathbot/src/core/context/manager.rs
@@ -3,9 +3,8 @@ use rosu_v2::prelude::GameMode;
 
 use super::Context;
 use crate::manager::{
-    redis::RedisManager, ApproxManager, BookmarkManager, GameManager, GithubManager,
-    GuildConfigManager, HuismetbenenCountryManager, MapManager, OsuMap, OsuTrackingManager,
-    OsuUserManager, PpManager, ReplayManager, ScoresManager, TwitchManager, UserConfigManager,
+    ApproxManager, BookmarkManager, GameManager, GithubManager, GuildConfigManager, OsuMap,
+    OsuTrackingManager, OsuUserManager, PpManager, ReplayManager, TwitchManager, UserConfigManager,
 };
 
 impl Context {
@@ -17,28 +16,12 @@ impl Context {
         UserConfigManager::new(&self.clients.psql)
     }
 
-    pub fn redis(&self) -> RedisManager<'_> {
-        RedisManager::new(self)
-    }
-
-    pub fn osu_map(&self) -> MapManager<'_> {
-        MapManager::new(&self.clients.psql, self)
-    }
-
     pub fn osu_user(&self) -> OsuUserManager<'_> {
         OsuUserManager::new(&self.clients.psql)
     }
 
-    pub fn osu_scores(&self) -> ScoresManager<'_> {
-        ScoresManager::new(self, &self.clients.psql)
-    }
-
     pub fn osu_tracking(&self) -> OsuTrackingManager<'_> {
         OsuTrackingManager::new(&self.clients.psql)
-    }
-
-    pub fn huismetbenen(&self) -> HuismetbenenCountryManager<'_> {
-        HuismetbenenCountryManager::new(self)
     }
 
     pub fn pp<'d, 'm>(&'d self, map: &'m OsuMap) -> PpManager<'d, 'm> {

--- a/bathbot/src/core/context/mod.rs
+++ b/bathbot/src/core/context/mod.rs
@@ -37,6 +37,7 @@ use twilight_model::{
 };
 use twilight_standby::Standby;
 
+pub use self::ext::ContextExt;
 use super::{
     buckets::{BucketName, Buckets},
     BotConfig, BotMetrics,
@@ -46,6 +47,7 @@ use crate::{
     tracking::Ordr,
 };
 
+mod ext;
 mod games;
 mod manager;
 mod matchlive;
@@ -90,6 +92,10 @@ impl Context {
 
     pub fn ordr(&self) -> Option<&Ordr> {
         self.clients.ordr.as_deref()
+    }
+
+    pub fn psql(&self) -> &Database {
+        &self.clients.psql
     }
 
     #[cfg(feature = "osutracking")]

--- a/bathbot/src/core/events/mod.rs
+++ b/bathbot/src/core/events/mod.rs
@@ -14,7 +14,7 @@ use twilight_model::{gateway::CloseCode, user::User};
 
 use self::{interaction::handle_interaction, message::handle_message};
 use super::{buckets::BucketName, BotMetrics, Context};
-use crate::util::Authored;
+use crate::{core::ContextExt, util::Authored};
 
 mod interaction;
 mod message;
@@ -132,7 +132,7 @@ pub async fn event_loop(ctx: Arc<Context>, shards: &mut Vec<Shard>, mut reshard_
                         ctx.standby.process(&event);
                         let change = ctx.cache.update(&event).await;
                         BotMetrics::event(&event, change);
-                        let ctx = Arc::clone(&ctx);
+                        let ctx = ctx.cloned();
                         let shard_id = shard.id().number();
 
                         tokio::spawn(async move {

--- a/bathbot/src/core/mod.rs
+++ b/bathbot/src/core/mod.rs
@@ -1,6 +1,6 @@
 pub use self::{
     config::BotConfig,
-    context::Context,
+    context::{Context, ContextExt},
     events::{event_loop, EventKind},
     metrics::BotMetrics,
 };

--- a/bathbot/src/main.rs
+++ b/bathbot/src/main.rs
@@ -29,7 +29,10 @@ use twilight_model::gateway::payload::outgoing::RequestGuildMembers;
 
 use crate::{
     commands::owner::RESHARD_TX,
-    core::{commands::interaction::InteractionCommands, event_loop, logging, BotConfig, Context},
+    core::{
+        commands::interaction::InteractionCommands, event_loop, logging, BotConfig, Context,
+        ContextExt,
+    },
 };
 
 fn main() {
@@ -116,26 +119,26 @@ async fn async_main() -> Result<()> {
     #[cfg(feature = "twitchtracking")]
     {
         // Spawn twitch worker
-        let twitch_ctx = Arc::clone(&ctx);
+        let twitch_ctx = ctx.cloned();
         tokio::spawn(tracking::twitch_tracking_loop(twitch_ctx));
     }
 
     #[cfg(feature = "osutracking")]
     {
         // Spawn osu tracking worker
-        let osu_tracking_ctx = Arc::clone(&ctx);
+        let osu_tracking_ctx = ctx.cloned();
         tokio::spawn(tracking::osu_tracking_loop(osu_tracking_ctx));
     }
 
     #[cfg(feature = "matchlive")]
     {
         // Spawn osu match ticker worker
-        let match_live_ctx = Arc::clone(&ctx);
+        let match_live_ctx = ctx.cloned();
         tokio::spawn(Context::match_live_loop(match_live_ctx));
     }
 
     // Request members
-    let member_ctx = Arc::clone(&ctx);
+    let member_ctx = ctx.cloned();
 
     tokio::spawn(async move {
         let mut interval = time::interval(Duration::from_millis(600));
@@ -190,7 +193,7 @@ async fn async_main() -> Result<()> {
         .set(reshard_tx)
         .expect("RESHARD_TX has already been set");
 
-    let event_ctx = Arc::clone(&ctx);
+    let event_ctx = ctx.cloned();
 
     tokio::select! {
         _ = event_loop(event_ctx, &mut shards, reshard_rx) => error!("Event loop ended"),

--- a/bathbot/src/manager/huismetbenen_country.rs
+++ b/bathbot/src/manager/huismetbenen_country.rs
@@ -1,22 +1,25 @@
+use std::sync::Arc;
+
 use bathbot_util::CowUtils;
 
-use super::redis::RedisData;
+use super::redis::{RedisData, RedisManager};
 use crate::core::Context;
 
-#[derive(Copy, Clone)]
-pub struct HuismetbenenCountryManager<'c> {
-    ctx: &'c Context,
+#[derive(Clone)]
+pub struct HuismetbenenCountryManager {
+    ctx: Arc<Context>,
 }
 
-impl<'c> HuismetbenenCountryManager<'c> {
-    pub fn new(ctx: &'c Context) -> Self {
+impl HuismetbenenCountryManager {
+    pub fn new(ctx: Arc<Context>) -> Self {
         Self { ctx }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub async fn is_supported(self, country_code: &str) -> bool {
         let country_code = country_code.cow_to_ascii_uppercase();
 
-        match self.ctx.redis().snipe_countries().await {
+        match RedisManager::new(self.ctx).snipe_countries().await {
             Ok(RedisData::Original(countries)) => countries.contains(country_code.as_ref()),
             Ok(RedisData::Archive(countries)) => countries.contains(country_code.as_ref()),
             Err(err) => {

--- a/bathbot/src/manager/osu_scores.rs
+++ b/bathbot/src/manager/osu_scores.rs
@@ -1,8 +1,7 @@
+use std::sync::Arc;
+
 use bathbot_model::rosu_v2::user::User;
-use bathbot_psql::{
-    model::osu::{DbScores, DbScoresBuilder, DbTopScores},
-    Database,
-};
+use bathbot_psql::model::osu::{DbScores, DbScoresBuilder, DbTopScores};
 use bathbot_util::{osu::ModSelection, IntHasher};
 use eyre::{Result, WrapErr};
 use rosu_v2::{
@@ -14,17 +13,16 @@ use super::redis::{
     osu::{UserArgs, UserArgsSlim},
     RedisData,
 };
-use crate::core::Context;
+use crate::core::{Context, ContextExt};
 
-#[derive(Copy, Clone)]
-pub struct ScoresManager<'c> {
-    ctx: &'c Context,
-    psql: &'c Database,
+#[derive(Clone)]
+pub struct ScoresManager {
+    ctx: Arc<Context>,
 }
 
-impl<'c> ScoresManager<'c> {
-    pub fn new(ctx: &'c Context, psql: &'c Database) -> Self {
-        Self { ctx, psql }
+impl ScoresManager {
+    pub fn new(ctx: Arc<Context>) -> Self {
+        Self { ctx }
     }
 
     fn scores_builder<'a>(
@@ -74,7 +72,7 @@ impl<'c> ScoresManager<'c> {
         grade: Option<Grade>,
     ) -> Result<DbScores<IntHasher>> {
         Self::scores_builder(mode, mods, country_code, map_id, grade)
-            .build_discord(self.psql, users)
+            .build_discord(self.ctx.psql(), users)
             .await
             .wrap_err("Failed to select scores")
     }
@@ -90,7 +88,7 @@ impl<'c> ScoresManager<'c> {
         grade: Option<Grade>,
     ) -> Result<DbScores<IntHasher>> {
         Self::scores_builder(mode, mods, country_code, map_id, grade)
-            .build_osu(self.psql, users)
+            .build_osu(self.ctx.psql(), users)
             .await
             .wrap_err("Failed to select scores")
     }
@@ -131,13 +129,14 @@ impl<'c> ScoresManager<'c> {
         user_ids: Option<&[i32]>,
         country_code: Option<&str>,
     ) -> Result<DbTopScores<IntHasher>> {
-        self.psql
+        self.ctx
+            .psql()
             .select_top100_scores(mode, country_code, user_ids)
             .await
             .wrap_err("Failed to fetch top scores")
     }
 
-    pub fn top(self, legacy_scores: bool) -> ScoreArgs<'c> {
+    pub fn top(self, legacy_scores: bool) -> ScoreArgs {
         ScoreArgs {
             manager: self,
             kind: ScoreKind::Top { limit: 100 },
@@ -145,7 +144,7 @@ impl<'c> ScoresManager<'c> {
         }
     }
 
-    pub fn recent(self, legacy_scores: bool) -> ScoreArgs<'c> {
+    pub fn recent(self, legacy_scores: bool) -> ScoreArgs {
         ScoreArgs {
             manager: self,
             kind: ScoreKind::Recent {
@@ -156,7 +155,7 @@ impl<'c> ScoresManager<'c> {
         }
     }
 
-    pub fn pinned(self, legacy_scores: bool) -> ScoreArgs<'c> {
+    pub fn pinned(self, legacy_scores: bool) -> ScoreArgs {
         ScoreArgs {
             manager: self,
             kind: ScoreKind::Pinned { limit: 100 },
@@ -164,7 +163,7 @@ impl<'c> ScoresManager<'c> {
         }
     }
 
-    pub fn user_on_map(self, map_id: u32, legacy_scores: bool) -> ScoreArgs<'c> {
+    pub fn user_on_map(self, map_id: u32, legacy_scores: bool) -> ScoreArgs {
         ScoreArgs {
             manager: self,
             kind: ScoreKind::UserMap { map_id },
@@ -173,16 +172,17 @@ impl<'c> ScoresManager<'c> {
     }
 
     async fn store(self, scores: &[Score]) -> Result<()> {
-        self.psql
+        self.ctx
+            .psql()
             .insert_scores(scores)
             .await
             .wrap_err("Failed to store scores")
     }
 }
 
-#[derive(Copy, Clone)]
-pub struct ScoreArgs<'c> {
-    manager: ScoresManager<'c>,
+#[derive(Clone)]
+pub struct ScoreArgs {
+    manager: ScoresManager,
     kind: ScoreKind,
     legacy_scores: bool,
 }
@@ -195,7 +195,7 @@ enum ScoreKind {
     UserMap { map_id: u32 },
 }
 
-impl<'c> ScoreArgs<'c> {
+impl ScoreArgs {
     pub fn limit(mut self, limit: usize) -> Self {
         match &mut self.kind {
             ScoreKind::Top { limit: limit_ } => *limit_ = limit,
@@ -221,12 +221,13 @@ impl<'c> ScoreArgs<'c> {
 
     pub async fn exec(self, user_args: UserArgsSlim) -> OsuResult<Vec<Score>> {
         let UserArgsSlim { user_id, mode } = user_args;
-        let ctx = self.manager.ctx;
 
         // Retrieve score(s)
         let scores_res = match self.kind {
             ScoreKind::Top { limit } => {
-                ctx.osu()
+                self.manager
+                    .ctx
+                    .osu()
                     .user_scores(user_id)
                     .best()
                     .limit(limit)
@@ -239,7 +240,9 @@ impl<'c> ScoreArgs<'c> {
                 limit,
                 include_fails,
             } => {
-                ctx.osu()
+                self.manager
+                    .ctx
+                    .osu()
                     .user_scores(user_id)
                     .recent()
                     .limit(limit)
@@ -250,7 +253,9 @@ impl<'c> ScoreArgs<'c> {
                     .await
             }
             ScoreKind::Pinned { limit } => {
-                ctx.osu()
+                self.manager
+                    .ctx
+                    .osu()
                     .user_scores(user_id)
                     .pinned()
                     .limit(limit)
@@ -260,7 +265,9 @@ impl<'c> ScoreArgs<'c> {
                     .await
             }
             ScoreKind::UserMap { map_id } => {
-                ctx.osu()
+                self.manager
+                    .ctx
+                    .osu()
                     .beatmap_user_scores(map_id, user_id)
                     .mode(mode)
                     .legacy_only(self.legacy_scores)
@@ -275,7 +282,13 @@ impl<'c> ScoreArgs<'c> {
             Err(OsuError::NotFound) => {
                 // Remove stats of unknown/restricted users so they don't appear in the
                 // leaderboard
-                if let Err(err) = ctx.osu_user().remove_stats_and_scores(user_id).await {
+                if let Err(err) = self
+                    .manager
+                    .ctx
+                    .osu_user()
+                    .remove_stats_and_scores(user_id)
+                    .await
+                {
                     warn!(?err, "Failed to remove stats of unknown user");
                 }
 
@@ -285,13 +298,14 @@ impl<'c> ScoreArgs<'c> {
         };
 
         // Store scores in database
+        let _ctx = self.manager.ctx.cloned();
         let store_fut = self.manager.store(&scores);
 
         // Pass scores to tracking check
         let tracking_fut = async {
             #[cfg(feature = "osutracking")]
             if let ScoreKind::Top { .. } = self.kind {
-                crate::tracking::process_osu_tracking(ctx, &scores, None).await
+                crate::tracking::process_osu_tracking(_ctx, &scores, None).await
             }
         };
 

--- a/bathbot/src/manager/osu_user.rs
+++ b/bathbot/src/manager/osu_user.rs
@@ -88,11 +88,10 @@ impl<'d> OsuUserManager<'d> {
             .wrap_err("Failed to upsert osu username")
     }
 
-    pub async fn store_user(self, user: &UserExtended, mode: GameMode) -> Result<()> {
-        self.psql
-            .upsert_osu_user(user, mode)
-            .await
-            .wrap_err("Failed to upsert osu user")
+    pub async fn store(self, user: &UserExtended, mode: GameMode) {
+        if let Err(err) = self.psql.upsert_osu_user(user, mode).await {
+            warn!(?err, "Failed to upsert osu user");
+        }
     }
 
     pub async fn remove_stats_and_scores(self, user_id: u32) -> Result<()> {

--- a/bathbot/src/manager/redis/mod.rs
+++ b/bathbot/src/manager/redis/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Write};
+use std::{borrow::Cow, fmt::Write, sync::Arc};
 
 use bathbot_cache::{Cache, CacheSerializer};
 use bathbot_model::{
@@ -15,7 +15,7 @@ use rosu_v2::prelude::{GameMode, OsuError, Rankings as RosuRankings};
 pub use self::data::RedisData;
 use crate::{
     commands::osu::MapOrScore,
-    core::{BotMetrics, Context},
+    core::{BotMetrics, Context, ContextExt},
     util::interaction::InteractionCommand,
 };
 
@@ -25,13 +25,13 @@ mod data;
 
 type RedisResult<T, A = T, E = Report> = Result<RedisData<T, A>, E>;
 
-#[derive(Copy, Clone)]
-pub struct RedisManager<'c> {
-    ctx: &'c Context,
+#[derive(Clone)]
+pub struct RedisManager {
+    ctx: Arc<Context>,
 }
 
-impl<'c> RedisManager<'c> {
-    pub fn new(ctx: &'c Context) -> Self {
+impl RedisManager {
+    pub fn new(ctx: Arc<Context>) -> Self {
         Self { ctx }
     }
 

--- a/bathbot/src/manager/redis/osu.rs
+++ b/bathbot/src/manager/redis/osu.rs
@@ -47,9 +47,7 @@ impl UserArgs {
 
         match (ctx.osu().user(name).mode(mode).await, alt_name) {
             (Ok(user), _) => {
-                if let Err(err) = ctx.osu_user().store_user(&user, mode).await {
-                    warn!("{err:?}");
-                }
+                ctx.osu_user().store(&user, mode).await;
 
                 Self::User {
                     user: Box::new(user.into()),
@@ -59,9 +57,7 @@ impl UserArgs {
             (Err(OsuError::NotFound), Some(alt_name)) => {
                 match ctx.osu().user(alt_name).mode(mode).await {
                     Ok(user) => {
-                        if let Err(err) = ctx.osu_user().store_user(&user, mode).await {
-                            warn!("{err:?}");
-                        }
+                        ctx.osu_user().store(&user, mode).await;
 
                         Self::User {
                             user: Box::new(user.into()),
@@ -176,9 +172,7 @@ impl RedisManager {
 
         user.mode = mode;
 
-        if let Err(err) = self.ctx.osu_user().store_user(&user, mode).await {
-            warn!("{err:?}");
-        }
+        self.ctx.osu_user().store(&user, mode).await;
 
         let user = User::from(user);
 

--- a/bathbot/src/manager/redis/osu.rs
+++ b/bathbot/src/manager/redis/osu.rs
@@ -137,7 +137,7 @@ impl TryFrom<UserArgs> for UserArgsSlim {
 
 const EXPIRE: usize = 600;
 
-impl<'c> RedisManager<'c> {
+impl RedisManager {
     fn osu_user_key(user_id: u32, mode: GameMode) -> String {
         format!("osu_user_{user_id}_{}", mode as u8)
     }


### PR DESCRIPTION
- Introduces a `ContextExt` trait specifically for `Arc<Context>`
- Score, beatmap, and redis managers now contain `Arc<Context>` instead of a reference
- After scores, beatmap(set)s, or users are requested, they're no longer stored in-sync but in a new task. This generally does require the data to be cloned beforehand which should still be a worthy tradeoff for a faster respond time of the bot.