### PR TITLE
perf(bot): request multiple mapper names at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "rosu-v2"
 version = "0.8.0"
-source = "git+https://github.com/MaxOhn/rosu-v2?branch=lazer#085ebf24017868ad578e9980977e4b46844dc7c8"
+source = "git+https://github.com/MaxOhn/rosu-v2?branch=lazer#2322d72e98c9ea838ed6adb488437d1f267272f3"
 dependencies = [
  "bytes",
  "futures",

--- a/bathbot/src/active/impls/profile/top100_mappers.rs
+++ b/bathbot/src/active/impls/profile/top100_mappers.rs
@@ -43,8 +43,7 @@ impl Top100Mappers {
 
         entries.truncate(10);
 
-        let mode = menu.user.mode();
-        let MapperNames(mapper_names) = menu.mapper_names.get(ctx, mode, &entries).await?;
+        let MapperNames(mapper_names) = menu.mapper_names.get(ctx, &entries).await?;
 
         let mappers = entries
             .into_iter()


### PR DESCRIPTION
Uses the recently de-deprecated method `Osu::users`