### PR TITLE
feat: enable user installs

### DIFF
--- a/bathbot-macros/src/message/mod.rs
+++ b/bathbot-macros/src/message/mod.rs
@@ -60,6 +60,8 @@ pub fn impl_cmd(attrs: CommandAttrs, fun: CommandFun) -> Result<TokenStream> {
                 nsfw: None,
                 options: Vec::new(),
                 version: ::twilight_model::id::Id::new(1),
+                integration_types: Vec::new(),
+                contexts: Vec::new(),
             }
         }
 

--- a/bathbot-macros/src/message/mod.rs
+++ b/bathbot-macros/src/message/mod.rs
@@ -45,8 +45,8 @@ pub fn impl_cmd(attrs: CommandAttrs, fun: CommandFun) -> Result<TokenStream> {
             id: std::sync::OnceLock::new(),
         };
 
-        fn #create() -> ::twilight_model::application::command::Command {
-            ::twilight_model::application::command::Command {
+        fn #create() -> crate::core::commands::interaction::twilight_command::Command {
+            crate::core::commands::interaction::twilight_command::Command {
                 application_id: None,
                 default_member_permissions: None,
                 description: String::new(),

--- a/bathbot/src/active/impls/help/interaction.rs
+++ b/bathbot/src/active/impls/help/interaction.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use futures::future::{ready, BoxFuture};
 use twilight_interactions::command::{ApplicationCommandData, CommandOptionExt};
 use twilight_model::{
-    application::command::{Command, CommandOptionType},
+    application::command::CommandOptionType,
     channel::message::{
         component::{ActionRow, Button, ButtonStyle, SelectMenu, SelectMenuOption},
         embed::EmbedField,
@@ -17,7 +17,9 @@ use twilight_model::{
 use crate::{
     active::{BuildPage, ComponentResult, IActiveMessage},
     core::{
-        commands::interaction::{InteractionCommandKind, InteractionCommands},
+        commands::interaction::{
+            twilight_command::Command, InteractionCommandKind, InteractionCommands,
+        },
         Context,
     },
     util::{interaction::InteractionComponent, Authored},

--- a/bathbot/src/commands/help/interaction.rs
+++ b/bathbot/src/commands/help/interaction.rs
@@ -12,7 +12,7 @@ use eyre::{ContextCompat, Result};
 use metrics::Key;
 use twilight_interactions::command::{AutocompleteValue, CommandModel, CreateCommand};
 use twilight_model::{
-    application::command::{Command, CommandOptionChoice, CommandOptionChoiceValue},
+    application::command::{CommandOptionChoice, CommandOptionChoiceValue},
     channel::message::embed::EmbedField,
 };
 
@@ -20,7 +20,9 @@ use super::failed_message_content;
 use crate::{
     active::{impls::HelpInteractionCommand, ActiveMessages},
     core::{
-        commands::interaction::{InteractionCommandKind, InteractionCommands},
+        commands::interaction::{
+            twilight_command::Command, InteractionCommandKind, InteractionCommands,
+        },
         Context,
     },
     util::{interaction::InteractionCommand, Authored, InteractionCommandExt},

--- a/bathbot/src/core/commands/interaction/command.rs
+++ b/bathbot/src/core/commands/interaction/command.rs
@@ -4,12 +4,9 @@ use std::{
 };
 
 use twilight_interactions::command::ApplicationCommandData;
-use twilight_model::{
-    application::command::Command,
-    id::{marker::CommandMarker, Id},
-};
+use twilight_model::id::{marker::CommandMarker, Id};
 
-use super::CommandResult;
+use super::{twilight_command::Command, CommandResult};
 use crate::{
     core::{buckets::BucketName, commands::flags::CommandFlags, Context},
     util::interaction::InteractionCommand,

--- a/bathbot/src/core/commands/interaction/mod.rs
+++ b/bathbot/src/core/commands/interaction/mod.rs
@@ -5,11 +5,12 @@ use futures::Future;
 use linkme::distributed_slice;
 use once_cell::sync::OnceCell;
 use radix_trie::{iter::Keys, Trie, TrieCommon};
-use twilight_model::application::command::Command;
 
 pub use self::command::{InteractionCommandKind, MessageCommand, SlashCommand};
+use self::twilight_command::Command;
 
 mod command;
+pub mod twilight_command;
 
 #[distributed_slice]
 pub static __SLASH_COMMANDS: [SlashCommand] = [..];
@@ -67,7 +68,7 @@ impl InteractionCommands {
             .map(|sub| sub.keys().copied())
     }
 
-    pub fn set_ids(commands: &[Command]) {
+    pub fn set_ids(commands: &[twilight_model::application::command::Command]) {
         let this = Self::get();
 
         for cmd in commands {

--- a/bathbot/src/core/commands/interaction/twilight_command.rs
+++ b/bathbot/src/core/commands/interaction/twilight_command.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use twilight_interactions::command::ApplicationCommandData;
+use twilight_model::{
+    application::command::{CommandOption, CommandType},
+    guild::Permissions,
+    id::{
+        marker::{ApplicationMarker, CommandMarker, CommandVersionMarker, GuildMarker},
+        Id,
+    },
+};
+
+/// Same as [`twilight_model::application::command::Command`] but extended to
+/// work with the new user installs.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Command {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub application_id: Option<Id<ApplicationMarker>>,
+    pub default_member_permissions: Option<Permissions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dm_permission: Option<bool>,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description_localizations: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guild_id: Option<Id<GuildMarker>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Id<CommandMarker>>,
+    #[serde(rename = "type")]
+    pub kind: CommandType,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name_localizations: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nsfw: Option<bool>,
+    #[serde(default)]
+    pub options: Vec<CommandOption>,
+    pub version: Id<CommandVersionMarker>,
+}
+
+impl From<ApplicationCommandData> for Command {
+    fn from(item: ApplicationCommandData) -> Self {
+        Command {
+            application_id: None,
+            guild_id: None,
+            name: item.name,
+            name_localizations: item.name_localizations,
+            default_member_permissions: item.default_member_permissions,
+            dm_permission: item.dm_permission,
+            description: item.description,
+            description_localizations: item.description_localizations,
+            id: None,
+            kind: CommandType::ChatInput,
+            options: item.options.into_iter().map(CommandOption::from).collect(),
+            version: Id::new(1),
+            nsfw: None,
+        }
+    }
+}

--- a/bathbot/src/core/context/mod.rs
+++ b/bathbot/src/core/context/mod.rs
@@ -54,6 +54,7 @@ mod manager;
 mod matchlive;
 mod messages;
 mod osutrack;
+mod set_commands;
 mod shutdown;
 mod twitch;
 
@@ -81,6 +82,10 @@ pub struct Context {
 impl Context {
     pub fn interaction(&self) -> InteractionClient<'_> {
         self.http.interaction(self.data.application_id)
+    }
+
+    pub fn application_id(&self) -> Id<ApplicationMarker> {
+        self.data.application_id
     }
 
     pub fn osu(&self) -> &Osu {

--- a/bathbot/src/core/context/mod.rs
+++ b/bathbot/src/core/context/mod.rs
@@ -84,10 +84,6 @@ impl Context {
         self.http.interaction(self.data.application_id)
     }
 
-    pub fn application_id(&self) -> Id<ApplicationMarker> {
-        self.data.application_id
-    }
-
     pub fn osu(&self) -> &Osu {
         &self.clients.osu
     }

--- a/bathbot/src/core/context/set_commands.rs
+++ b/bathbot/src/core/context/set_commands.rs
@@ -1,0 +1,47 @@
+use eyre::{Result, WrapErr};
+use twilight_http::{
+    request::{Request, RequestBuilder},
+    routing::Route,
+};
+use twilight_model::application::command::Command as TwilightCommand;
+
+use super::Context;
+use crate::core::{commands::interaction::twilight_command::Command, BotConfig};
+
+impl Context {
+    pub async fn set_global_commands(&self, cmds: &[Command]) -> Result<Vec<TwilightCommand>> {
+        let route = Route::SetGlobalCommands {
+            application_id: self.data.application_id.get(),
+        };
+
+        send_command_request(self, route, cmds).await
+    }
+
+    pub async fn set_guild_commands(&self, cmds: &[Command]) -> Result<Vec<TwilightCommand>> {
+        let route = Route::SetGuildCommands {
+            application_id: self.data.application_id.get(),
+            guild_id: BotConfig::get().dev_guild.get(),
+        };
+
+        send_command_request(self, route, cmds).await
+    }
+}
+
+async fn send_command_request(
+    ctx: &Context,
+    route: Route<'_>,
+    cmds: &[Command],
+) -> Result<Vec<TwilightCommand>> {
+    let req = Request::builder(&route)
+        .json(&cmds)
+        .map(RequestBuilder::build)
+        .wrap_err("Failed to build command request")?;
+
+    ctx.http
+        .request(req)
+        .await
+        .wrap_err("Failed to set commands")?
+        .models()
+        .await
+        .wrap_err("Failed to deserialize commands")
+}

--- a/bathbot/src/main.rs
+++ b/bathbot/src/main.rs
@@ -76,20 +76,20 @@ async fn async_main() -> Result<()> {
 
     #[cfg(feature = "global_slash")]
     {
-        let cmds = ctx.set_global_commands(&slash_commands).await?;
+        let cmds = ctx.set_global_commands(slash_commands).await?;
         InteractionCommands::set_ids(&cmds);
 
-        if let Err(err) = ctx.set_guild_commands(&[]).await {
+        if let Err(err) = ctx.set_guild_commands(Vec::new()).await {
             warn!(?err, "Failed to remove guild commands");
         }
     }
 
     #[cfg(not(feature = "global_slash"))]
     {
-        let cmds = ctx.set_guild_commands(&slash_commands).await?;
+        let cmds = ctx.set_guild_commands(slash_commands).await?;
         InteractionCommands::set_ids(&cmds);
 
-        if let Err(err) = ctx.set_global_commands(&[]).await {
+        if let Err(err) = ctx.set_global_commands(Vec::new()).await {
             warn!(?err, "Failed to remove global commands");
         }
     }


### PR DESCRIPTION
Registers commands in a custom way instead of with the interface as provided by twilight. This should be adjusted once twilight itself supports user installs.

Also, if the flag `--no-user-installs` is specified when running the bot, user installs won't be added. Just so there's a way to boot up the bot when user installs bug out.

Closes #694 