### PR TITLE
fix(bot): update via interaction token

### DIFF
--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -25,15 +25,13 @@ use twilight_model::{
         component::{ActionRow, Button, ButtonStyle},
         Component,
     },
-    id::{
-        marker::{ChannelMarker, MessageMarker, UserMarker},
-        Id,
-    },
+    id::{marker::UserMarker, Id},
 };
 
 use crate::{
     active::{
         pagination::{handle_pagination_component, Pages},
+        response::ActiveResponse,
         BuildPage, ComponentResult, IActiveMessage,
     },
     core::Context,
@@ -406,11 +404,7 @@ impl IActiveMessage for BookmarksPagination {
         (!self.bookmarks.is_empty()).then_some(Duration::from_secs(60))
     }
 
-    fn on_timeout(
-        &mut self,
-        _: Id<MessageMarker>,
-        _: Id<ChannelMarker>,
-    ) -> BoxFuture<'_, Result<()>> {
+    fn on_timeout(&mut self, _: ActiveResponse) -> BoxFuture<'_, Result<()>> {
         let fut = async move {
             Context::interaction()
                 .update_response(&self.token)

--- a/bathbot/src/active/impls/render/cached.rs
+++ b/bathbot/src/active/impls/render/cached.rs
@@ -12,14 +12,11 @@ use twilight_model::{
         component::{ActionRow, Button, ButtonStyle},
         Component,
     },
-    id::{
-        marker::{ChannelMarker, MessageMarker, UserMarker},
-        Id,
-    },
+    id::{marker::UserMarker, Id},
 };
 
 use crate::{
-    active::{BuildPage, ComponentResult, IActiveMessage},
+    active::{response::ActiveResponse, BuildPage, ComponentResult, IActiveMessage},
     commands::osu::{OngoingRender, RenderStatus, RenderStatusInner, RENDERER_NAME},
     core::{buckets::BucketName, Context},
     manager::{OwnedReplayScore, ReplayScore},
@@ -296,11 +293,7 @@ impl IActiveMessage for CachedRender {
         Box::pin(self.async_handle_component(component))
     }
 
-    fn on_timeout(
-        &mut self,
-        msg: Id<MessageMarker>,
-        channel: Id<ChannelMarker>,
-    ) -> BoxFuture<'_, Result<()>> {
+    fn on_timeout(&mut self, response: ActiveResponse) -> BoxFuture<'_, Result<()>> {
         if self.done {
             return Box::pin(ready(Ok(())));
         }
@@ -313,7 +306,7 @@ impl IActiveMessage for CachedRender {
             .embed(None)
             .components(Vec::new());
 
-        let Some(fut) = (msg, channel).update(builder, None) else {
+        let Some(fut) = response.update(builder) else {
             return Box::pin(ready(Err(eyre!(
                 "Lacking permissions to handle cached render timeout"
             ))));

--- a/bathbot/src/active/response.rs
+++ b/bathbot/src/active/response.rs
@@ -1,0 +1,57 @@
+use bathbot_util::MessageBuilder;
+use twilight_http::response::ResponseFuture;
+use twilight_model::{
+    channel::Message,
+    id::{
+        marker::{ChannelMarker, MessageMarker},
+        Id,
+    },
+};
+
+use super::origin::ActiveMessageOrigin;
+use crate::{
+    core::commands::CommandOrigin,
+    util::{InteractionToken, MessageExt},
+};
+
+pub struct ActiveResponse {
+    pub msg: Id<MessageMarker>,
+    pub inner: ActiveResponseInner,
+}
+
+pub enum ActiveResponseInner {
+    Message { channel: Id<ChannelMarker> },
+    Interaction { token: Box<str> },
+}
+
+impl ActiveResponse {
+    pub fn new(orig: &ActiveMessageOrigin, response: &Message) -> Self {
+        let inner = match orig {
+            ActiveMessageOrigin::Channel(_)
+            | ActiveMessageOrigin::Command(CommandOrigin::Message { .. }) => {
+                ActiveResponseInner::Message {
+                    channel: response.channel_id,
+                }
+            }
+            ActiveMessageOrigin::Command(CommandOrigin::Interaction { command }) => {
+                ActiveResponseInner::Interaction {
+                    token: command.token.as_str().into(),
+                }
+            }
+        };
+
+        Self {
+            msg: response.id,
+            inner,
+        }
+    }
+
+    pub fn update(self, builder: MessageBuilder<'_>) -> Option<ResponseFuture<Message>> {
+        match self.inner {
+            ActiveResponseInner::Message { channel } => (self.msg, channel).update(builder, None),
+            ActiveResponseInner::Interaction { token } => {
+                Some(InteractionToken(&token).update(builder, None))
+            }
+        }
+    }
+}

--- a/bathbot/src/core/commands/origin.rs
+++ b/bathbot/src/core/commands/origin.rs
@@ -140,9 +140,6 @@ impl CommandOrigin<'_> {
     }
 
     /// Update a response and return the resulting response message.
-    ///
-    /// In case of an interaction, be sure this is the first and only time you
-    /// call this. Afterwards, you must update the resulting message.
     pub async fn update(&self, builder: MessageBuilder<'_>) -> Result<Response<Message>> {
         match self {
             Self::Message { msg, permissions } => msg

--- a/bathbot/src/util/ext/mod.rs
+++ b/bathbot/src/util/ext/mod.rs
@@ -1,6 +1,10 @@
 pub use self::{
-    authored::Authored, channel::ChannelExt, component::ComponentExt,
-    interaction_command::InteractionCommandExt, message::MessageExt, modal::*,
+    authored::Authored,
+    channel::ChannelExt,
+    component::ComponentExt,
+    interaction_command::{InteractionCommandExt, InteractionToken},
+    message::MessageExt,
+    modal::*,
 };
 
 mod authored;


### PR DESCRIPTION
Instead of literally editing the message for interaction responses, use the interaction token instead to update via interaction api.
This fixes permission issues when editing messages in DMs and the like.