### PR TITLE
refactor(bot): dont check for view channel permission

### DIFF
--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -30,7 +30,7 @@ use crate::{
         },
         MapError, OsuMap,
     },
-    util::{interaction::InteractionCommand, osu::IfFc, CheckPermissions, InteractionCommandExt},
+    util::{interaction::InteractionCommand, osu::IfFc, InteractionCommandExt},
     Context,
 };
 
@@ -241,13 +241,16 @@ async fn fix(orig: CommandOrigin<'_>, args: FixArgs<'_>) -> Result<()> {
 
             return orig.error(content).await;
         }
-        None if orig.can_read_history() => {
+        None => {
             let msgs = match Context::retrieve_channel_history(orig.channel_id()).await {
                 Ok(msgs) => msgs,
-                Err(err) => {
-                    let _ = orig.error(GENERAL_ISSUE).await;
+                Err(_) => {
+                    let content =
+                        "No beatmap specified and lacking permission to search the channel \
+                        history for maps.\nTry specifying a map either by url to the map, or \
+                        just by map id, or give me the \"Read Message History\" permission.";
 
-                    return Err(err);
+                    return orig.error(content).await;
                 }
             };
 
@@ -262,14 +265,6 @@ async fn fix(orig: CommandOrigin<'_>, args: FixArgs<'_>) -> Result<()> {
                     return orig.error(content).await;
                 }
             }
-        }
-        None => {
-            let content =
-                "No beatmap specified and lacking permission to search the channel history for maps.\n\
-                Try specifying a map either by url to the map, or just by map id, \
-                or give me the \"Read Message History\" permission.";
-
-            return orig.error(content).await;
         }
     };
 

--- a/bathbot/src/commands/osu/scores/map.rs
+++ b/bathbot/src/commands/osu/scores/map.rs
@@ -22,7 +22,7 @@ use crate::{
     util::{
         interaction::InteractionCommand,
         query::{FilterCriteria, IFilterCriteria, ScoresCriteria},
-        Authored, CheckPermissions, InteractionCommandExt,
+        Authored, InteractionCommandExt,
     },
 };
 
@@ -124,13 +124,18 @@ pub async fn map_scores(mut command: InteractionCommand, args: MapScores) -> Res
 
             return Ok(());
         }
-        None if command.can_read_history() => {
+        None => {
             let msgs = match Context::retrieve_channel_history(command.channel_id()).await {
                 Ok(msgs) => msgs,
-                Err(err) => {
-                    let _ = command.error(GENERAL_ISSUE).await;
+                Err(_) => {
+                    let content =
+                        "No beatmap specified and lacking permission to search the channel \
+                        history for maps.\nTry specifying a map either by url to the map, or \
+                        just by map id, or give me the \"Read Message History\" permission.";
 
-                    return Err(err.wrap_err("Failed to retrieve channel history"));
+                    command.error(content).await?;
+
+                    return Ok(());
                 }
             };
 
@@ -144,16 +149,6 @@ pub async fn map_scores(mut command: InteractionCommand, args: MapScores) -> Res
                     return Ok(());
                 }
             }
-        }
-        None => {
-            let content =
-                "No beatmap specified and lacking permission to search the channel history for maps.\n\
-                Try specifying a map either by url to the map, or just by map id, \
-                or give me the \"Read Message History\" permission.";
-
-            command.error(content).await?;
-
-            return Ok(());
         }
     };
 

--- a/bathbot/src/util/check_permissions.rs
+++ b/bathbot/src/util/check_permissions.rs
@@ -6,10 +6,6 @@ use crate::core::commands::CommandOrigin;
 pub trait CheckPermissions {
     fn permissions(&self) -> Option<Permissions>;
 
-    fn can_read_history(&self) -> bool {
-        self.has_permission_to(Permissions::READ_MESSAGE_HISTORY)
-    }
-
     fn can_attach_file(&self) -> bool {
         self.has_permission_to(Permissions::ATTACH_FILES)
     }


### PR DESCRIPTION
Permissions of interactions in DMs don't include "View Channel" so the channel history cannot be retrieved for commands like `/map` if we check the permissions. Instead, we just don't check and always try to get the history; worst case we get a 403 error.