### PR TITLE
feat: hyperlink grade emotes to scores

### DIFF
--- a/bathbot-model/src/osu_stats.rs
+++ b/bathbot-model/src/osu_stats.rs
@@ -294,6 +294,8 @@ impl ScoreExt for OsuStatsScore {
     #[inline] fn score(&self) -> u32 { self.score }
     #[inline] fn pp(&self) -> Option<f32> { self.pp }
     #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+    #[inline] fn score_id(&self) -> Option<u64> { None }
+    #[inline] fn is_legacy(&self) -> bool { false }
 }
 
 #[rustfmt::skip]

--- a/bathbot-model/src/score_slim.rs
+++ b/bathbot-model/src/score_slim.rs
@@ -64,6 +64,11 @@ impl ScoreExt for ScoreSlim {
     #[inline] fn score(&self) -> u32 { self.score }
     #[inline] fn pp(&self) -> Option<f32> { Some(self.pp) }
     #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+    #[inline] fn score_id(&self) -> Option<u64> { Some(self.score_id) }
+
+    fn is_legacy(&self) -> bool {
+        self.legacy_id == Some(self.score_id)
+    }
 }
 
 #[rustfmt::skip]

--- a/bathbot-util/src/ext/score.rs
+++ b/bathbot-util/src/ext/score.rs
@@ -16,6 +16,16 @@ pub trait ScoreExt {
     fn accuracy(&self) -> f32;
     fn grade(&self) -> Grade;
 
+    /// Returns the *new* kind of score id.
+    fn score_id(&self) -> Option<u64>;
+
+    /// Whether the score contains legacy data.
+    ///
+    /// Note that this does *not* mean whether the score was set on stable,
+    /// but whether the score was set on stable *and* was request as legacy
+    /// data.
+    fn is_legacy(&self) -> bool;
+
     // Optional to implement
     #[inline]
     fn total_hits(&self, mode: u8) -> u32 {
@@ -110,6 +120,11 @@ impl ScoreExt for Score {
     #[inline] fn score(&self) -> u32 { self.score }
     #[inline] fn pp(&self) -> Option<f32> { self.pp }
     #[inline] fn accuracy(&self) -> f32 { self.accuracy }
+    #[inline] fn score_id(&self) -> Option<u64> { Some(self.id) }
+
+    fn is_legacy(&self) -> bool {
+        self.legacy_score_id == Some(self.id)
+    }
 }
 
 pub trait ScoreHasMode {

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -27,7 +27,7 @@ use crate::{
     manager::{redis::RedisData, OsuMap},
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::PersonalBestIndex,
+        osu::{GradeFormatter, PersonalBestIndex},
         Emote,
     },
 };
@@ -278,14 +278,15 @@ fn write_compact_entry(
     map: &OsuMap,
     origin: &MessageOrigin,
 ) {
-    let config = BotConfig::get();
-
     let _ = write!(
         args.description,
-        "[{grade}]({OSU_BASE}scores/{score_id}) **+{mods}** [{stars:.2}★] {pp_format}{pp:.2}pp{pp_format} \
+        "{grade} **+{mods}** [{stars:.2}★] {pp_format}{pp:.2}pp{pp_format} \
         ({acc}%) {combo}x • {miss} {timestamp}",
-        grade = config.grade(entry.score.grade),
-        score_id = entry.score.score_id,
+        grade = GradeFormatter::new(
+            entry.score.grade,
+            Some(entry.score.score_id),
+            entry.score.is_legacy()
+        ),
         mods = ModsFormatter::new(&entry.score.mods),
         stars = entry.stars,
         pp_format = if args.pp_idx == Some(i) { "**" } else { "~~" },

--- a/bathbot/src/active/impls/higherlower/score_pp.rs
+++ b/bathbot/src/active/impls/higherlower/score_pp.rs
@@ -190,6 +190,8 @@ impl ScorePp {
             "**{map} +{mods}**\n{grade} {score} • **{acc}%** • **{combo}x**{max_combo} {miss}• **{pp}pp**",
             map = self.map_string,
             mods = ModsFormatter::new(&self.mods),
+            // No `GradeFormatter` here because we don't want to hyperlink to
+            // the score for obvious reasons.
             grade = grade_emote(self.grade),
             score = WithComma::new(self.score),
             acc = self.acc,

--- a/bathbot/src/active/impls/leaderboard.rs
+++ b/bathbot/src/active/impls/leaderboard.rs
@@ -23,7 +23,7 @@ use crate::{
     manager::OsuMap,
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::grade_emote,
+        osu::GradeFormatter,
         Emote,
     },
 };
@@ -242,7 +242,7 @@ impl Display for ScoreFormatter<'_> {
             underline = if self.found_author { "__" } else { "" },
             username = self.score.username,
             user_id = self.score.user_id,
-            grade = grade_emote(self.score.grade),
+            grade = GradeFormatter::new(self.score.grade, Some(self.score.score_id), self.score.is_legacy),
             score = WithComma::new(self.score.score),
             combo = self.combo,
             mods = ModsFormatter::new(&self.score.mods),

--- a/bathbot/src/active/impls/nochoke.rs
+++ b/bathbot/src/active/impls/nochoke.rs
@@ -4,6 +4,7 @@ use bathbot_macros::PaginationBuilder;
 use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     constants::OSU_BASE, numbers::WithComma, CowUtils, EmbedBuilder, FooterBuilder, ModsFormatter,
+    ScoreExt,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -21,7 +22,7 @@ use crate::{
     manager::redis::RedisData,
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::grade_emote,
+        osu::GradeFormatter,
         Emote,
     },
 };
@@ -77,7 +78,7 @@ impl IActiveMessage for NoChokePagination {
                 version = map.version().cow_escape_markdown(),
                 id = map.map_id(),
                 mods = ModsFormatter::new(&original_score.mods),
-                grade = grade_emote(entry.unchoked_grade()),
+                grade = GradeFormatter::new(entry.unchoked_grade(), Some(entry.original_score.score_id), entry.original_score.is_legacy()),
                 old_pp = original_score.pp,
                 new_pp = entry.unchoked_pp(),
                 old_acc = original_score.accuracy,

--- a/bathbot/src/active/impls/recent_list.rs
+++ b/bathbot/src/active/impls/recent_list.rs
@@ -24,7 +24,7 @@ use crate::{
     manager::{redis::RedisData, OsuMap},
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::grade_completion_mods,
+        osu::GradeCompletionFormatter,
     },
 };
 
@@ -67,7 +67,7 @@ impl IActiveMessage for RecentListPagination {
                 description,
                 "**#{i} {grade}\t[{title} [{version}]]({OSU_BASE}b/{map_id})** [{stars:.2}★]",
                 i = *idx + 1,
-                grade = grade_completion_mods(score, self.user.mode(), map.n_objects()),
+                grade = GradeCompletionFormatter::new(score, self.user.mode(), map.n_objects()),
                 title = map.title().cow_escape_markdown(),
                 version = map.version().cow_escape_markdown(),
                 map_id = map.map_id(),

--- a/bathbot/src/active/impls/region_top.rs
+++ b/bathbot/src/active/impls/region_top.rs
@@ -27,9 +27,9 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::{RegionTopKind, ScoresOrder},
-    core::BotConfig,
     util::{
         interaction::{InteractionComponent, InteractionModal},
+        osu::GradeFormatter,
         Emote,
     },
 };
@@ -92,7 +92,6 @@ impl IActiveMessage for RegionTopPagination {
             }
         };
 
-        let config = BotConfig::get();
         let mut description = String::with_capacity(scores.len() * 160);
 
         if scores.is_empty() {
@@ -114,7 +113,7 @@ impl IActiveMessage for RegionTopPagination {
                 mods = GameModsIntermode::from_bits(score.mods),
                 user = score.username.cow_escape_markdown(),
                 user_id = score.user_id,
-                grade = config.grade(score.grade),
+                grade = GradeFormatter::new(score.grade, None, false),
                 pp = round(score.pp),
                 stars = StarsFormatter::new(score.stars),
                 acc = round(score.statistics.accuracy(self.mode)),

--- a/bathbot/src/active/impls/scores/map.rs
+++ b/bathbot/src/active/impls/scores/map.rs
@@ -28,9 +28,9 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::ScoresOrder,
-    core::BotConfig,
     util::{
         interaction::{InteractionComponent, InteractionModal},
+        osu::GradeFormatter,
         Emote,
     },
 };
@@ -86,7 +86,6 @@ impl IActiveMessage for ScoresMapPagination {
         let idx = pages.index();
         let scores = &data.scores()[idx..data.len().min(idx + pages.per_page())];
 
-        let config = BotConfig::get();
         let mut description = String::with_capacity(scores.len() * 160);
 
         for (score, i) in scores.iter().zip(idx + 1..) {
@@ -101,7 +100,7 @@ impl IActiveMessage for ScoresMapPagination {
                 "**#{i} [{user}]({OSU_BASE}u/{user_id})**: \
                 {score} [ **{combo}x** ] **+{mods}**{stars}\n\
                 {grade} **{pp}pp** • {acc}% {mode}{miss} {appendix}",
-                grade = config.grade(score.grade),
+                grade = GradeFormatter::new(score.grade, None, false),
                 user = UserFormatter::new(data.user(score.user_id)),
                 user_id = score.user_id,
                 score = WithComma::new(score.score),

--- a/bathbot/src/active/impls/scores/server.rs
+++ b/bathbot/src/active/impls/scores/server.rs
@@ -29,9 +29,9 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::ScoresOrder,
-    core::BotConfig,
     util::{
         interaction::{InteractionComponent, InteractionModal},
+        osu::GradeFormatter,
         Emote,
     },
 };
@@ -112,7 +112,6 @@ impl IActiveMessage for ScoresServerPagination {
         let idx = pages.index();
         let scores = &data.scores()[idx..data.len().min(idx + pages.per_page())];
 
-        let config = BotConfig::get();
         let mut description = String::with_capacity(scores.len() * 160);
 
         for (score, i) in scores.iter().zip(idx + 1..) {
@@ -137,7 +136,7 @@ impl IActiveMessage for ScoresServerPagination {
                 stars = StarsFormatter::new(score.stars),
                 user = UserFormatter::new(user),
                 user_id = score.user_id,
-                grade = config.grade(score.grade),
+                grade = GradeFormatter::new(score.grade, None, false),
                 pp = PpFormatter::new(score.pp),
                 acc = round(score.statistics.accuracy(score.mode)),
                 mode = GameModeFormatter::new(mode),

--- a/bathbot/src/active/impls/scores/user.rs
+++ b/bathbot/src/active/impls/scores/user.rs
@@ -27,10 +27,10 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::ScoresOrder,
-    core::BotConfig,
     manager::redis::RedisData,
     util::{
         interaction::{InteractionComponent, InteractionModal},
+        osu::GradeFormatter,
         Emote,
     },
 };
@@ -87,7 +87,6 @@ impl IActiveMessage for ScoresUserPagination {
         let idx = pages.index();
         let scores = &data.scores()[idx..data.len().min(idx + pages.per_page())];
 
-        let config = BotConfig::get();
         let mut description = String::with_capacity(scores.len() * 160);
 
         for (score, i) in scores.iter().zip(idx + 1..) {
@@ -108,7 +107,7 @@ impl IActiveMessage for ScoresUserPagination {
                 map = MapFormatter::new(map, mapset),
                 map_id = score.map_id,
                 stars = StarsFormatter::new(score.stars),
-                grade = config.grade(score.grade),
+                grade = GradeFormatter::new(score.grade, None, false),
                 pp = PpFormatter::new(score.pp),
                 acc = round(score.statistics.accuracy(score.mode)),
                 combo = score.max_combo,

--- a/bathbot/src/active/impls/simulate/mod.rs
+++ b/bathbot/src/active/impls/simulate/mod.rs
@@ -207,7 +207,13 @@ impl IActiveMessage for SimulateComponents {
         };
 
         let n_objects = self.map.n_objects();
-        let grade = GradeCompletionFormatter::new_without_score(&mods, grade, n_objects, self.map.mode(), n_objects);
+        let grade = GradeCompletionFormatter::new_without_score(
+            &mods,
+            grade,
+            n_objects,
+            self.map.mode(),
+            n_objects,
+        );
         let mut fields = fields!["Grade", grade.to_string(), true;];
 
         if let Some(acc) = acc {

--- a/bathbot/src/active/impls/simulate/mod.rs
+++ b/bathbot/src/active/impls/simulate/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     manager::OsuMap,
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::{grade_completion_mods_raw, MapInfo},
+        osu::{GradeCompletionFormatter, MapInfo},
         Authored, ComponentExt, Emote, ModalExt,
     },
 };
@@ -207,8 +207,8 @@ impl IActiveMessage for SimulateComponents {
         };
 
         let n_objects = self.map.n_objects();
-        let grade = grade_completion_mods_raw(&mods, grade, n_objects, self.map.mode(), n_objects);
-        let mut fields = fields!["Grade", grade.into_owned(), true;];
+        let grade = GradeCompletionFormatter::new_without_score(&mods, grade, n_objects, self.map.mode(), n_objects);
+        let mut fields = fields!["Grade", grade.to_string(), true;];
 
         if let Some(acc) = acc {
             fields.push(acc);

--- a/bathbot/src/active/impls/top_if.rs
+++ b/bathbot/src/active/impls/top_if.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
     numbers::{round, WithComma},
-    CowUtils, EmbedBuilder, FooterBuilder, ModsFormatter,
+    CowUtils, EmbedBuilder, FooterBuilder, ModsFormatter, ScoreExt,
 };
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -26,7 +26,7 @@ use crate::{
     manager::redis::RedisData,
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::grade_emote,
+        osu::GradeFormatter,
     },
 };
 
@@ -72,7 +72,7 @@ impl IActiveMessage for TopIfPagination {
                 version = map.version().cow_escape_markdown(),
                 id = map.map_id(),
                 mods = ModsFormatter::new(&score.mods),
-                grade = grade_emote(score.grade),
+                grade = GradeFormatter::new(score.grade, Some(score.score_id), entry.score.is_legacy()),
                 pp = PpFormatter::new(Some(score.pp), Some(*max_pp)),
                 acc = round(score.accuracy),
                 score = WithComma::new(score.score),

--- a/bathbot/src/commands/osu/leaderboard.rs
+++ b/bathbot/src/commands/osu/leaderboard.rs
@@ -10,7 +10,7 @@ use bathbot_util::{
     constants::{AVATAR_URL, GENERAL_ISSUE, OSU_WEB_ISSUE},
     matcher,
     osu::{MapIdType, ModSelection},
-    IntHasher,
+    IntHasher, ScoreExt,
 };
 use eyre::{Report, Result};
 use rosu_pp::any::{DifficultyAttributes, ScoreState};
@@ -485,6 +485,8 @@ pub struct LeaderboardScore {
     pub combo: u32,
     pub score: u32,
     pub ended_at: OffsetDateTime,
+    pub score_id: u64,
+    pub is_legacy: bool,
 }
 
 impl LeaderboardScore {
@@ -493,6 +495,7 @@ impl LeaderboardScore {
             user_id,
             username,
             pos,
+            is_legacy: score.is_legacy(),
             grade: if score.passed { score.grade } else { Grade::F },
             accuracy: score.accuracy,
             statistics: score.statistics.as_legacy(score.mode),
@@ -501,6 +504,7 @@ impl LeaderboardScore {
             combo: score.max_combo,
             score: score.score,
             ended_at: score.ended_at,
+            score_id: score.id,
         }
     }
 }

--- a/bathbot/src/embeds/osu/player_snipe_stats.rs
+++ b/bathbot/src/embeds/osu/player_snipe_stats.rs
@@ -17,7 +17,7 @@ use crate::{
     core::Context,
     embeds::{attachment, osu},
     manager::{redis::RedisData, OsuMap},
-    util::osu::grade_completion_mods,
+    util::osu::GradeCompletionFormatter,
 };
 
 #[derive(EmbedData)]
@@ -84,7 +84,7 @@ impl PlayerSnipeStatsEmbed {
                     title = oldest_map.title().cow_escape_markdown(),
                     version = oldest_map.version().cow_escape_markdown(),
                     id = oldest_map.map_id(),
-                    grade = grade_completion_mods(
+                    grade = GradeCompletionFormatter::new(
                         oldest_score,
                         oldest_map.mode(),
                         oldest_map.n_objects(),

--- a/bathbot/src/embeds/tracking/notification.rs
+++ b/bathbot/src/embeds/tracking/notification.rs
@@ -15,7 +15,7 @@ use crate::{
     core::Context,
     embeds::osu,
     manager::{redis::RedisData, OsuMap},
-    util::{osu::grade_completion_mods, Emote},
+    util::{osu::GradeCompletionFormatter, Emote},
 };
 
 #[derive(EmbedData)]
@@ -67,7 +67,16 @@ impl TrackNotificationEmbed {
 
         let name = format!(
             "{}\t{score}\t({acc}%)",
-            grade_completion_mods(score, map.mode(), map.n_objects()),
+            // We don't use `GradeCompletionFormatter::new` so that it doesn't
+            // use the score id to hyperlink the grade because those don't
+            // work in embed field names.
+            grade_completion_mods = GradeCompletionFormatter::new_without_score(
+                &score.mods,
+                score.grade,
+                score.total_hits(),
+                map.mode(),
+                map.n_objects()
+            ),
             score = WithComma::new(score.score),
             acc = round(score.accuracy)
         );


### PR DESCRIPTION
Closes #745

Wherever applicable, grade emotes now hyperlink to their corresponding score.

This doesn't work for:
- Scores requested as legacy data because they don't have the new kind of score id (i.e. when the config is set to `Stable`)
- Scores coming from the DB because as of now it only stores the legacy id
- Grades in embed field names because hyperlinks aren't allowed there