### PR TITLE
perf: immediately request user for correct mode

### DIFF
--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -430,7 +430,7 @@ async fn creator_name(map: &MapBookmark) -> Option<Username> {
         Err(err) => warn!("{err:?}"),
     }
 
-    let args = UserArgs::user_id(map.mapper_id);
+    let args = UserArgs::user_id(map.mapper_id, GameMode::Osu);
 
     match Context::redis().osu_user(args).await {
         Ok(RedisData::Original(user)) => Some(user.username),

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -334,7 +334,7 @@ async fn creator_name(map: &BeatmapExtended, mapset: &BeatmapsetExtended) -> Opt
         Err(err) => warn!("{err:?}"),
     }
 
-    let args = UserArgs::user_id(map.creator_id);
+    let args = UserArgs::user_id(map.creator_id, GameMode::Osu);
 
     match Context::redis().osu_user(args).await {
         Ok(RedisData::Original(user)) => Some(user.username),

--- a/bathbot/src/commands/osu/avatar.rs
+++ b/bathbot/src/commands/osu/avatar.rs
@@ -8,7 +8,7 @@ use bathbot_util::{
     AuthorBuilder, EmbedBuilder, MessageBuilder,
 };
 use eyre::{Report, Result};
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use twilight_interactions::command::{CommandModel, CreateCommand};
 use twilight_model::id::{marker::UserMarker, Id};
 
@@ -80,7 +80,7 @@ async fn avatar(orig: CommandOrigin<'_>, args: Avatar<'_>) -> Result<()> {
         },
     };
 
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/badges/user.rs
+++ b/bathbot/src/commands/osu/badges/user.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
 };
 use eyre::{Report, Result};
 use rkyv::{Deserialize, Infallible};
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 
 use super::BadgesUser;
 use crate::{
@@ -33,7 +33,7 @@ pub(super) async fn user(orig: CommandOrigin<'_>, args: BadgesUser) -> Result<()
         },
     };
 
-    let user_args_fut = UserArgs::rosu_id(&user_id);
+    let user_args_fut = UserArgs::rosu_id(&user_id, GameMode::Osu);
     let badges_fut = Context::redis().badges();
 
     let (user_args_res, badges_res) = tokio::join!(user_args_fut, badges_fut);

--- a/bathbot/src/commands/osu/bws.rs
+++ b/bathbot/src/commands/osu/bws.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
     matcher, MessageBuilder, TourneyBadges,
 };
 use eyre::{Report, Result};
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use twilight_interactions::command::{CommandModel, CreateCommand};
 use twilight_model::id::{marker::UserMarker, Id};
 
@@ -157,7 +157,7 @@ async fn bws(orig: CommandOrigin<'_>, args: Bws<'_>) -> Result<()> {
 
     let Bws { rank, badges, .. } = args;
 
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -125,7 +125,7 @@ async fn slash_card(mut command: InteractionCommand) -> Result<()> {
         },
     };
 
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)
         .limit(100)

--- a/bathbot/src/commands/osu/claim_name.rs
+++ b/bathbot/src/commands/osu/claim_name.rs
@@ -77,7 +77,7 @@ async fn slash_claimname(mut command: InteractionCommand) -> Result<()> {
         return Ok(());
     }
 
-    let user_id = match UserArgs::username(&name).await {
+    let user_id = match UserArgs::username(&name, GameMode::Osu).await {
         UserArgs::Args(args) => args.user_id,
         UserArgs::User { user, .. } => user.user_id,
         UserArgs::Err(OsuError::NotFound) => {
@@ -106,7 +106,7 @@ async fn slash_claimname(mut command: InteractionCommand) -> Result<()> {
         GameMode::Catch,
         GameMode::Mania,
     ]
-    .map(|mode| UserArgs::user_id(user_id).mode(mode));
+    .map(|mode| UserArgs::user_id(user_id, mode));
 
     let user_fut = args
         .into_iter()

--- a/bathbot/src/commands/osu/compare/common.rs
+++ b/bathbot/src/commands/osu/compare/common.rs
@@ -338,7 +338,7 @@ async fn get_user_and_scores(
     user_id: &UserId,
     mode: GameMode,
 ) -> OsuResult<(RedisData<User>, Vec<Score>)> {
-    let args = UserArgs::rosu_id(user_id).await.mode(mode);
+    let args = UserArgs::rosu_id(user_id, mode).await;
 
     Context::osu_scores()
         .top(false)

--- a/bathbot/src/commands/osu/compare/most_played.rs
+++ b/bathbot/src/commands/osu/compare/most_played.rs
@@ -8,7 +8,10 @@ use bathbot_util::{
 };
 use eyre::{Report, Result};
 use rosu_v2::{
-    model::GameMode, prelude::{MostPlayedMap, OsuError}, request::UserId, OsuResult
+    model::GameMode,
+    prelude::{MostPlayedMap, OsuError},
+    request::UserId,
+    OsuResult,
 };
 
 use super::{CompareMostPlayed, AT_LEAST_ONE};

--- a/bathbot/src/commands/osu/compare/most_played.rs
+++ b/bathbot/src/commands/osu/compare/most_played.rs
@@ -8,9 +8,7 @@ use bathbot_util::{
 };
 use eyre::{Report, Result};
 use rosu_v2::{
-    prelude::{MostPlayedMap, OsuError},
-    request::UserId,
-    OsuResult,
+    model::GameMode, prelude::{MostPlayedMap, OsuError}, request::UserId, OsuResult
 };
 
 use super::{CompareMostPlayed, AT_LEAST_ONE};
@@ -189,7 +187,7 @@ pub(super) async fn mostplayed(
 }
 
 async fn get_user_and_scores(user_id: &UserId) -> OsuResult<(RedisData<User>, Vec<MostPlayedMap>)> {
-    match UserArgs::rosu_id(user_id).await {
+    match UserArgs::rosu_id(user_id, GameMode::Osu).await {
         UserArgs::Args(args) => {
             let score_fut = Context::osu().user_most_played(args.user_id).limit(100);
             let user_fut = Context::redis().osu_user_from_args(args);

--- a/bathbot/src/commands/osu/compare/profile.rs
+++ b/bathbot/src/commands/osu/compare/profile.rs
@@ -139,8 +139,8 @@ pub(super) async fn profile(orig: CommandOrigin<'_>, mut args: CompareProfile<'_
     };
 
     // Retrieve all users and their scores
-    let user_args1 = UserArgs::rosu_id(&user_id1).await.mode(mode);
-    let user_args2 = UserArgs::rosu_id(&user_id2).await.mode(mode);
+    let user_args1 = UserArgs::rosu_id(&user_id1, mode).await;
+    let user_args2 = UserArgs::rosu_id(&user_id2, mode).await;
     let score_args = Context::osu_scores().top(false).limit(100);
 
     let fut1 = score_args.clone().exec_with_user(user_args1);

--- a/bathbot/src/commands/osu/compare/score.rs
+++ b/bathbot/src/commands/osu/compare/score.rs
@@ -447,7 +447,7 @@ pub(super) async fn score(orig: CommandOrigin<'_>, args: CompareScoreArgs<'_>) -
     };
 
     let mode = map.mode();
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let (user_res, score_res) = match user_args {
         UserArgs::Args(args) => {
@@ -748,7 +748,7 @@ async fn compare_from_score(
     let map = score.map.take().expect("missing map");
     let map_fut = Context::osu_map().map(map.map_id, map.checksum.as_deref());
 
-    let user_args = UserArgs::user_id(score.user_id).mode(mode);
+    let user_args = UserArgs::user_id(score.user_id, mode);
     let user_fut = Context::redis().osu_user(user_args);
 
     let user_args = UserArgsSlim::user_id(score.user_id).mode(mode);

--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -331,7 +331,7 @@ async fn request_by_map(
         }
     };
 
-    let (user_res, scores_res) = match UserArgs::rosu_id(&user_id).await.mode(map.mode()) {
+    let (user_res, scores_res) = match UserArgs::rosu_id(&user_id, map.mode()).await {
         UserArgs::Args(args) => {
             let user_fut = Context::redis().osu_user_from_args(args);
             let scores_fut = Context::osu_scores()
@@ -441,7 +441,7 @@ async fn request_by_score(
     legacy_scores: bool,
 ) -> ScoreResult {
     let score_fut = Context::osu().score(score_id).mode(mode);
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let user_fut = Context::redis().osu_user(user_args);
 
     let (user, score) = match tokio::join!(user_fut, score_fut) {

--- a/bathbot/src/commands/osu/graphs/medals.rs
+++ b/bathbot/src/commands/osu/graphs/medals.rs
@@ -10,7 +10,7 @@ use rkyv::{
     with::{DeserializeWith, Map},
     Infallible,
 };
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 
 use super::{H, W};
 use crate::{
@@ -23,7 +23,7 @@ pub async fn medals_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
 
     let mut user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -254,7 +254,7 @@ async fn graph(orig: CommandOrigin<'_>, args: Graph) -> Result<()> {
         }
         Graph::Rank(args) => {
             let (user_id, mode) = user_id_mode!(orig, args);
-            let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
             rank_graph(&orig, user_id, user_args)
                 .await
@@ -300,7 +300,7 @@ async fn graph(orig: CommandOrigin<'_>, args: Graph) -> Result<()> {
                 },
             };
 
-            let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
             let tz = args
                 .timezone

--- a/bathbot/src/commands/osu/graphs/playcount_replays.rs
+++ b/bathbot/src/commands/osu/graphs/playcount_replays.rs
@@ -29,8 +29,7 @@ use rkyv::{
     Infallible,
 };
 use rosu_v2::{
-    prelude::{MonthlyCount, OsuError},
-    request::UserId,
+    model::GameMode, prelude::{MonthlyCount, OsuError}, request::UserId
 };
 use skia_safe::{surfaces, EncodedImageFormat, Surface};
 use time::{Date, Month, OffsetDateTime};
@@ -48,7 +47,7 @@ pub async fn playcount_replays_graph(
     user_id: UserId,
     flags: ProfileGraphFlags,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
 
     let mut user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/playcount_replays.rs
+++ b/bathbot/src/commands/osu/graphs/playcount_replays.rs
@@ -29,7 +29,9 @@ use rkyv::{
     Infallible,
 };
 use rosu_v2::{
-    model::GameMode, prelude::{MonthlyCount, OsuError}, request::UserId
+    model::GameMode,
+    prelude::{MonthlyCount, OsuError},
+    request::UserId,
 };
 use skia_safe::{surfaces, EncodedImageFormat, Surface};
 use time::{Date, Month, OffsetDateTime};

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -18,7 +18,7 @@ pub async fn snipe_count_graph(
     user_id: UserId,
     mode: GameMode,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -18,7 +18,7 @@ pub async fn sniped_graph(
     user_id: UserId,
     mode: GameMode,
 ) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/leaderboard.rs
+++ b/bathbot/src/commands/osu/leaderboard.rs
@@ -475,7 +475,7 @@ async fn get_user_score(
         return Ok(None);
     };
 
-    let user_args = UserArgs::user_id(user_id).mode(mode);
+    let user_args = UserArgs::user_id(user_id, mode);
     let user_fut = Context::redis().osu_user(user_args);
 
     let score_fut =

--- a/bathbot/src/commands/osu/mapper.rs
+++ b/bathbot/src/commands/osu/mapper.rs
@@ -246,11 +246,11 @@ async fn mapper(orig: CommandOrigin<'_>, args: Mapper<'_>) -> Result<()> {
     let legacy_scores = score_data.is_legacy();
 
     let mapper = args.mapper.cow_to_ascii_lowercase();
-    let mapper_args = UserArgs::username(mapper.as_ref()).await.mode(mode);
+    let mapper_args = UserArgs::username(mapper.as_ref(), mode).await;
     let mapper_fut = Context::redis().osu_user(mapper_args);
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)
         .limit(100)

--- a/bathbot/src/commands/osu/medals/common.rs
+++ b/bathbot/src/commands/osu/medals/common.rs
@@ -15,7 +15,9 @@ use eyre::{Report, Result};
 use hashbrown::HashMap;
 use rkyv::{with::DeserializeWith, Infallible};
 use rosu_v2::{
-    model::GameMode, prelude::{OsuError, Username}, request::UserId
+    model::GameMode,
+    prelude::{OsuError, Username},
+    request::UserId,
 };
 use time::OffsetDateTime;
 

--- a/bathbot/src/commands/osu/medals/common.rs
+++ b/bathbot/src/commands/osu/medals/common.rs
@@ -15,8 +15,7 @@ use eyre::{Report, Result};
 use hashbrown::HashMap;
 use rkyv::{with::DeserializeWith, Infallible};
 use rosu_v2::{
-    prelude::{OsuError, Username},
-    request::UserId,
+    model::GameMode, prelude::{OsuError, Username}, request::UserId
 };
 use time::OffsetDateTime;
 
@@ -125,10 +124,10 @@ pub(super) async fn common(orig: CommandOrigin<'_>, mut args: MedalCommon<'_>) -
     let MedalCommon { sort, filter, .. } = args;
 
     // Retrieve all users and their scores
-    let user_args = UserArgs::rosu_id(&user_id1).await;
+    let user_args = UserArgs::rosu_id(&user_id1, GameMode::Osu).await;
     let user_fut1 = Context::redis().osu_user(user_args);
 
-    let user_args = UserArgs::rosu_id(&user_id2).await;
+    let user_args = UserArgs::rosu_id(&user_id2, GameMode::Osu).await;
     let user_fut2 = Context::redis().osu_user(user_args);
 
     let medals_fut = Context::redis().medals();

--- a/bathbot/src/commands/osu/medals/list.rs
+++ b/bathbot/src/commands/osu/medals/list.rs
@@ -8,7 +8,7 @@ use bathbot_util::{
 use eyre::{Report, Result};
 use hashbrown::HashMap;
 use rkyv::{with::DeserializeWith, Infallible};
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use time::OffsetDateTime;
 
 use super::{MedalList, MedalListOrder};
@@ -43,7 +43,7 @@ pub(super) async fn list(orig: CommandOrigin<'_>, args: MedalList<'_>) -> Result
         ..
     } = args;
 
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
     let user_fut = Context::redis().osu_user(user_args);
     let medals_fut = Context::redis().medals();
     let ranking_fut = Context::redis().osekai_ranking::<Rarity>();

--- a/bathbot/src/commands/osu/medals/missing.rs
+++ b/bathbot/src/commands/osu/medals/missing.rs
@@ -9,7 +9,7 @@ use bathbot_util::{
 use eyre::{Report, Result};
 use hashbrown::HashSet;
 use rkyv::{Deserialize, Infallible};
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 
 use super::{MedalMissing, MedalMissingOrder};
 use crate::{
@@ -62,7 +62,7 @@ pub(super) async fn missing(orig: CommandOrigin<'_>, args: MedalMissing<'_>) -> 
         },
     };
 
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
     let user_fut = Context::redis().osu_user(user_args);
     let medals_fut = Context::redis().medals();
 

--- a/bathbot/src/commands/osu/medals/recent.rs
+++ b/bathbot/src/commands/osu/medals/recent.rs
@@ -14,8 +14,7 @@ use rkyv::{
     Infallible,
 };
 use rosu_v2::{
-    prelude::{MedalCompact, OsuError},
-    request::UserId,
+    model::GameMode, prelude::{MedalCompact, OsuError}, request::UserId
 };
 use time::OffsetDateTime;
 
@@ -71,7 +70,7 @@ pub(super) async fn recent(orig: CommandOrigin<'_>, args: MedalRecent<'_>) -> Re
         },
     };
 
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
     let user_fut = Context::redis().osu_user(user_args);
     let medals_fut = Context::redis().medals();
 

--- a/bathbot/src/commands/osu/medals/recent.rs
+++ b/bathbot/src/commands/osu/medals/recent.rs
@@ -14,7 +14,9 @@ use rkyv::{
     Infallible,
 };
 use rosu_v2::{
-    model::GameMode, prelude::{MedalCompact, OsuError}, request::UserId
+    model::GameMode,
+    prelude::{MedalCompact, OsuError},
+    request::UserId,
 };
 use time::OffsetDateTime;
 

--- a/bathbot/src/commands/osu/medals/stats.rs
+++ b/bathbot/src/commands/osu/medals/stats.rs
@@ -15,8 +15,7 @@ use rkyv::{
     Deserialize, Infallible,
 };
 use rosu_v2::{
-    prelude::{MedalCompact, OsuError},
-    request::UserId,
+    model::GameMode, prelude::{MedalCompact, OsuError}, request::UserId
 };
 use skia_safe::{surfaces, EncodedImageFormat};
 use time::OffsetDateTime;
@@ -74,7 +73,7 @@ pub(super) async fn stats(orig: CommandOrigin<'_>, args: MedalStats<'_>) -> Resu
         },
     };
 
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
     let user_fut = Context::redis().osu_user(user_args);
     let medals_fut = Context::redis().medals();
 

--- a/bathbot/src/commands/osu/medals/stats.rs
+++ b/bathbot/src/commands/osu/medals/stats.rs
@@ -15,7 +15,9 @@ use rkyv::{
     Deserialize, Infallible,
 };
 use rosu_v2::{
-    model::GameMode, prelude::{MedalCompact, OsuError}, request::UserId
+    model::GameMode,
+    prelude::{MedalCompact, OsuError},
+    request::UserId,
 };
 use skia_safe::{surfaces, EncodedImageFormat};
 use time::OffsetDateTime;

--- a/bathbot/src/commands/osu/most_played.rs
+++ b/bathbot/src/commands/osu/most_played.rs
@@ -6,7 +6,7 @@ use bathbot_util::{
     matcher,
 };
 use eyre::{Report, Result};
-use rosu_v2::{prelude::OsuError, request::UserId};
+use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use twilight_interactions::command::{CommandModel, CreateCommand};
 use twilight_model::id::{marker::UserMarker, Id};
 
@@ -80,7 +80,7 @@ async fn mostplayed(orig: CommandOrigin<'_>, args: MostPlayed<'_>) -> Result<()>
     };
 
     // Retrieve the user and their most played maps
-    let user_args = UserArgs::rosu_id(&user_id).await;
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/nochoke.rs
+++ b/bathbot/src/commands/osu/nochoke.rs
@@ -231,7 +231,7 @@ async fn nochoke(orig: CommandOrigin<'_>, args: Nochoke<'_>) -> Result<()> {
     } = args;
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)
         .limit(100)

--- a/bathbot/src/commands/osu/osustats/counts.rs
+++ b/bathbot/src/commands/osu/osustats/counts.rs
@@ -152,7 +152,7 @@ async fn slash_osc(mut command: InteractionCommand) -> Result<()> {
 
 pub(super) async fn count(orig: CommandOrigin<'_>, args: OsuStatsCount<'_>) -> Result<()> {
     let (user_id, mode) = user_id_mode!(orig, args);
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -173,7 +173,7 @@ pub(super) async fn scores(orig: CommandOrigin<'_>, args: OsuStatsScores<'_>) ->
     };
 
     let (user_id, mode) = user_id_mode!(orig, args);
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     // Retrieve user
     let user = match Context::redis().osu_user(user_args).await {

--- a/bathbot/src/commands/osu/pinned.rs
+++ b/bathbot/src/commands/osu/pinned.rs
@@ -164,7 +164,7 @@ async fn pinned(orig: CommandOrigin<'_>, args: Pinned) -> Result<()> {
         },
     };
 
-    let (user_args, user_opt) = match UserArgs::rosu_id(&user_id).await.mode(mode) {
+    let (user_args, user_opt) = match UserArgs::rosu_id(&user_id, mode).await {
         UserArgs::Args(args) => (args, None),
         UserArgs::User { user, mode } => (
             UserArgsSlim::user_id(user.user_id).mode(mode),

--- a/bathbot/src/commands/osu/pp.rs
+++ b/bathbot/src/commands/osu/pp.rs
@@ -198,7 +198,7 @@ async fn pp(orig: CommandOrigin<'_>, args: Pp<'_>) -> Result<()> {
     }
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(false)
         .limit(100)

--- a/bathbot/src/commands/osu/profile.rs
+++ b/bathbot/src/commands/osu/profile.rs
@@ -213,7 +213,7 @@ async fn profile(orig: CommandOrigin<'_>, args: Profile<'_>) -> Result<()> {
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/rank/pp.rs
+++ b/bathbot/src/commands/osu/rank/pp.rs
@@ -66,7 +66,7 @@ pub(super) async fn pp(orig: CommandOrigin<'_>, args: RankPp<'_>) -> Result<()> 
         return orig.error("Delta must be greater than zero :clown:").await;
     }
 
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let user_fut = Context::redis().osu_user(user_args);
 
     let mut user = match user_fut.await {
@@ -91,7 +91,7 @@ pub(super) async fn pp(orig: CommandOrigin<'_>, args: RankPp<'_>) -> Result<()> 
         RankValue::Raw(rank) => RankOrHolder::Rank(rank),
         RankValue::Name(name) => {
             let user_id = UserId::from(name);
-            let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
             match Context::redis().osu_user(user_args).await {
                 Ok(target_user) => {

--- a/bathbot/src/commands/osu/rank/score.rs
+++ b/bathbot/src/commands/osu/rank/score.rs
@@ -154,7 +154,7 @@ pub(super) async fn score(orig: CommandOrigin<'_>, args: RankScore<'_>) -> Resul
         return orig.error("Delta must be greater than zero :clown:").await;
     }
 
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let mut user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
@@ -204,7 +204,7 @@ pub(super) async fn score(orig: CommandOrigin<'_>, args: RankScore<'_>) -> Resul
         RankValue::Raw(rank) => rank,
         RankValue::Name(name) => {
             let user_id = UserId::from(name);
-            let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+            let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
             let user_id = match Context::redis().osu_user(user_args).await {
                 Ok(user) => {

--- a/bathbot/src/commands/osu/ranking/players.rs
+++ b/bathbot/src/commands/osu/ranking/players.rs
@@ -91,7 +91,7 @@ async fn pp_author_idx(
     mode: GameMode,
     country: Option<&CountryCode>,
 ) -> Option<usize> {
-    let user_args = UserArgs::user_id(author_id?).mode(mode);
+    let user_args = UserArgs::user_id(author_id?, mode);
 
     match Context::redis().osu_user(user_args).await {
         Ok(user) => {

--- a/bathbot/src/commands/osu/ratios.rs
+++ b/bathbot/src/commands/osu/ratios.rs
@@ -105,7 +105,7 @@ async fn ratios(orig: CommandOrigin<'_>, args: Ratios<'_>) -> Result<()> {
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(GameMode::Mania);
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Mania).await;
 
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)

--- a/bathbot/src/commands/osu/recent/fix.rs
+++ b/bathbot/src/commands/osu/recent/fix.rs
@@ -52,7 +52,7 @@ pub(super) async fn fix(orig: CommandOrigin<'_>, args: RecentFix) -> Result<()> 
     };
 
     // Retrieve the user and their recent scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let scores_fut = Context::osu_scores()
         .recent(legacy_scores)

--- a/bathbot/src/commands/osu/recent/leaderboard.rs
+++ b/bathbot/src/commands/osu/recent/leaderboard.rs
@@ -208,7 +208,7 @@ pub(super) async fn leaderboard(
     let legacy_scores = score_data.is_legacy();
 
     // Retrieve the recent scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let scores_fut = Context::osu_scores()
         .recent(legacy_scores)

--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -363,7 +363,7 @@ pub(super) async fn list(orig: CommandOrigin<'_>, args: RecentList<'_>) -> Resul
     let grade = grade.map(Grade::from);
 
     // Retrieve the user and their recent scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let include_fails = match (grade, passes) {
         (Some(Grade::F), Some(true)) => return orig.error(":clown:").await,

--- a/bathbot/src/commands/osu/recent/score.rs
+++ b/bathbot/src/commands/osu/recent/score.rs
@@ -385,7 +385,7 @@ pub(super) async fn score(orig: CommandOrigin<'_>, args: RecentScore<'_>) -> Res
     let grade = grade.map(Grade::from);
 
     // Retrieve the user and their recent scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let include_fails = match (grade, passes) {
         (Some(Grade::F), Some(true)) => return orig.error(":clown:").await,

--- a/bathbot/src/commands/osu/scores/server.rs
+++ b/bathbot/src/commands/osu/scores/server.rs
@@ -8,6 +8,7 @@ use bathbot_util::{
 };
 use eyre::{Report, Result};
 use rosu_v2::{
+    model::GameMode,
     prelude::{Grade, OsuError},
     request::UserId,
 };
@@ -113,7 +114,7 @@ pub async fn server_scores(mut command: InteractionCommand, args: ServerScores) 
     };
 
     let creator_id = match args.mapper {
-        Some(ref mapper) => match UserArgs::username(mapper).await {
+        Some(ref mapper) => match UserArgs::username(mapper, GameMode::Osu).await {
             UserArgs::Args(args) => Some(args.user_id),
             UserArgs::User { user, .. } => Some(user.user_id),
             UserArgs::Err(OsuError::NotFound) => {

--- a/bathbot/src/commands/osu/scores/user.rs
+++ b/bathbot/src/commands/osu/scores/user.rs
@@ -87,7 +87,7 @@ pub async fn user_scores(mut command: InteractionCommand, args: UserScores) -> R
     };
 
     let creator_id = match args.mapper {
-        Some(ref mapper) => match UserArgs::username(mapper).await {
+        Some(ref mapper) => match UserArgs::username(mapper, GameMode::Osu).await {
             UserArgs::Args(args) => Some(args.user_id),
             UserArgs::User { user, .. } => Some(user.user_id),
             UserArgs::Err(OsuError::NotFound) => {
@@ -150,11 +150,7 @@ pub async fn user_scores(mut command: InteractionCommand, args: UserScores) -> R
 }
 
 async fn get_user(user_id: &UserId, mode: Option<GameMode>) -> Result<RedisData<User>, OsuError> {
-    let mut args = UserArgs::rosu_id(user_id).await;
-
-    if let Some(mode) = mode {
-        args = args.mode(mode);
-    }
+    let args = UserArgs::rosu_id(user_id, mode.unwrap_or(GameMode::Osu)).await;
 
     Context::redis().osu_user(args).await
 }

--- a/bathbot/src/commands/osu/snipe/country_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_list.rs
@@ -140,7 +140,7 @@ pub(super) async fn country_list(
 
             match config.osu {
                 Some(user_id) => {
-                    let user_args = UserArgs::user_id(user_id).mode(mode);
+                    let user_args = UserArgs::user_id(user_id, mode);
 
                     match Context::redis().osu_user(user_args).await {
                         Ok(user) => (Some(user), mode),

--- a/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
@@ -136,7 +136,7 @@ pub(super) async fn country_stats(
         },
         None => match config.osu {
             Some(user_id) => {
-                let user_args = UserArgs::user_id(user_id).mode(mode);
+                let user_args = UserArgs::user_id(user_id, mode);
 
                 let user = match Context::redis().osu_user(user_args).await {
                     Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/player_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_list.rs
@@ -133,7 +133,7 @@ pub(super) async fn player_list(orig: CommandOrigin<'_>, args: SnipePlayerList<'
     let owner = orig.user_id()?;
 
     let (user_id, mode) = user_id_mode!(orig, args);
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -121,7 +121,7 @@ pub(super) async fn player_stats(
         },
     };
 
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/sniped.rs
+++ b/bathbot/src/commands/osu/snipe/sniped.rs
@@ -98,7 +98,7 @@ pub(super) async fn player_sniped(
     args: SnipePlayerSniped<'_>,
 ) -> Result<()> {
     let (user_id, mode) = user_id_mode!(orig, args);
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/snipe/sniped_difference.rs
+++ b/bathbot/src/commands/osu/snipe/sniped_difference.rs
@@ -173,7 +173,7 @@ async fn sniped_diff(
     let owner = orig.user_id()?;
 
     // Request the user
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,

--- a/bathbot/src/commands/osu/top/if_.rs
+++ b/bathbot/src/commands/osu/top/if_.rs
@@ -237,7 +237,7 @@ async fn topif(orig: CommandOrigin<'_>, args: TopIf<'_>) -> Result<()> {
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)
         .limit(100)

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -785,7 +785,7 @@ pub(super) async fn top(orig: CommandOrigin<'_>, args: TopArgs<'_>) -> Result<()
     let legacy_scores = score_data.is_legacy();
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)
         .limit(100)

--- a/bathbot/src/commands/osu/top/old.rs
+++ b/bathbot/src/commands/osu/top/old.rs
@@ -762,7 +762,7 @@ async fn topold(orig: CommandOrigin<'_>, args: TopOld<'_>) -> Result<()> {
     };
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(legacy_scores)
         .limit(100)

--- a/bathbot/src/commands/osu/whatif.rs
+++ b/bathbot/src/commands/osu/whatif.rs
@@ -203,7 +203,7 @@ async fn whatif(orig: CommandOrigin<'_>, args: WhatIf<'_>) -> Result<()> {
     }
 
     // Retrieve the user and their top scores
-    let user_args = UserArgs::rosu_id(&user_id).await.mode(mode);
+    let user_args = UserArgs::rosu_id(&user_id, mode).await;
     let scores_fut = Context::osu_scores()
         .top(false)
         .limit(100)

--- a/bathbot/src/commands/tracking/mod.rs
+++ b/bathbot/src/commands/tracking/mod.rs
@@ -132,7 +132,7 @@ async fn get_names(
             let name = name.cow_to_ascii_lowercase();
 
             if entries.keys().all(|n| name != n.cow_to_ascii_lowercase()) {
-                let args = UserArgs::username(name.as_ref()).await.mode(mode);
+                let args = UserArgs::username(name.as_ref(), mode).await;
 
                 match Context::redis().osu_user(args).await {
                     Ok(user) => entries.insert(user.username().into(), user.user_id()),

--- a/bathbot/src/commands/tracking/track_list.rs
+++ b/bathbot/src/commands/tracking/track_list.rs
@@ -95,7 +95,7 @@ async fn get_users(
                 limit,
             },
             None => {
-                let user_args = UserArgs::user_id(user_id).mode(mode);
+                let user_args = UserArgs::user_id(user_id, mode);
 
                 match Context::redis().osu_user(user_args).await {
                     Ok(user) => TracklistUserEntry {

--- a/bathbot/src/tracking/osu/osu_loop.rs
+++ b/bathbot/src/tracking/osu/osu_loop.rs
@@ -225,7 +225,7 @@ impl<'u> TrackUser<'u> {
             TrackNotificationEmbed::new(user, score, map, idx).await
         } else {
             let TrackedOsuUserKey { user_id, mode } = self.key;
-            let args = UserArgs::user_id(user_id).mode(mode);
+            let args = UserArgs::user_id(user_id, mode);
             let user = Context::redis().osu_user(args).await?;
             let user = self.user.get_or_insert(Cow::Owned(user));
 


### PR DESCRIPTION
Closes a long-standing TODO.

Users requested by name were always requested for `GameMode::Osu` and then re-requested for a different mode if required; now it immediately requests users for the correct mode.