### PR TITLE
perf: switch from flurry to papaya

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +364,6 @@ dependencies = [
  "enum_dispatch",
  "eyre",
  "flexmap",
- "flurry",
  "futures",
  "hashbrown 0.14.5",
  "image",
@@ -365,6 +374,7 @@ dependencies = [
  "metrics-util",
  "nom",
  "once_cell",
+ "papaya",
  "plotters",
  "plotters-backend",
  "plotters-skia",
@@ -1000,18 +1010,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "spin 0.9.8",
-]
-
-[[package]]
-name = "flurry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0afc943ef18eebf6bc3335daeb8d338202093d18444a1784ea7f57fe7680f8"
-dependencies = [
- "ahash 0.7.8",
- "num_cpus",
- "parking_lot",
- "seize",
 ]
 
 [[package]]
@@ -1873,6 +1871,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "papaya"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6849519ea101172c731d3cff830d9cabb3324f7127fd15c377f601c352cdc7"
+dependencies = [
+ "atomic-wait",
+ "seize",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,13 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "seize"
-version = "0.2.5"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5739de653b129b0a59da381599cf17caf24bc586f6a797c52d3d6147c5b85a"
-dependencies = [
- "num_cpus",
- "once_cell",
-]
+checksum = "d659fa6f19e82a52ab8d3fff3c380bd8cc16462eaea411395618a38760eb85bc"
 
 [[package]]
 name = "semver"
@@ -4110,6 +4114,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4159,6 +4178,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4171,6 +4196,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4180,6 +4211,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4201,6 +4238,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4210,6 +4253,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4225,6 +4274,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -4234,6 +4289,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/bathbot/Cargo.toml
+++ b/bathbot/Cargo.toml
@@ -22,7 +22,6 @@ enterpolation = { version = "0.2", default-features = false, features = ["std", 
 enum_dispatch = { version = "0.3.11" }
 eyre = { version = "0.6" }
 flexmap = { git = "https://github.com/MaxOhn/flexmap" }
-flurry = { version = "0.4" }
 futures = { version = "0.3", default-features = false }
 hashbrown = { version = "0.14" }
 image = { version = "0.24", default-features = false, features = ["gif", "png"] }
@@ -33,6 +32,7 @@ metrics-exporter-prometheus = { version = "0.15.1", default-features = false }
 metrics-util = { version = "0.17.0" }
 nom = { version = "7.1.3" }
 once_cell = { version = "1.0" }
+papaya = { version = "0.1.2" }
 plotters = { version = "0.3", default-features = false, features = ["ttf", "image", "line_series", "area_series", "histogram", "point_series"] }
 plotters-backend = { version = "0.3" }
 plotters-skia = { git = "https://github.com/MaxOhn/plotters-skia", branch = "main" }

--- a/bathbot/src/core/context/osutrack.rs
+++ b/bathbot/src/core/context/osutrack.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use flurry::HashMap as FlurryMap;
+use papaya::HashMap as PapayaMap;
 use rosu_v2::model::GameMode;
 use time::OffsetDateTime;
 
@@ -8,7 +8,7 @@ use super::Context;
 
 /// Mapping user ids to the last timestamp that osutrack was notified of that
 /// user's activity.
-pub type OsuTrackUserNotifTimestamps = FlurryMap<(u32, GameMode), OffsetDateTime>;
+pub type OsuTrackUserNotifTimestamps = PapayaMap<(u32, GameMode), OffsetDateTime>;
 
 impl Context {
     pub async fn notify_osutrack_of_user_activity(&self, user_id: u32, mode: GameMode) {

--- a/bathbot/src/core/context/shutdown.rs
+++ b/bathbot/src/core/context/shutdown.rs
@@ -131,7 +131,7 @@ impl Context {
         let len = miss_analyzer_guilds.len();
 
         // Serialize data
-        for guild in miss_analyzer_guilds.iter() {
+        for guild in miss_analyzer_guilds.keys() {
             serializer
                 .serialize_value(With::<_, IdRkyv>::cast(guild))
                 .wrap_err("Failed to serialize guild")?;

--- a/bathbot/src/core/context/twitch.rs
+++ b/bathbot/src/core/context/twitch.rs
@@ -1,29 +1,25 @@
+use papaya::Operation;
 use twilight_model::id::{marker::ChannelMarker, Id};
 
 use crate::Context;
 
 impl Context {
     pub fn add_tracking(twitch_id: u64, channel_id: Id<ChannelMarker>) {
-        let streams = &Context::get().data.tracked_streams;
-        let guard = streams.guard();
-
-        let missing = streams
-            .update(
-                twitch_id,
-                |old_channels| {
+        Context::get()
+            .data
+            .tracked_streams
+            .pin()
+            .compute(twitch_id, |entry| match entry {
+                Some((_, channels)) if channels.contains(&channel_id) => Operation::Abort(()),
+                Some((_, old_channels)) => {
                     let mut new_channels = Vec::with_capacity(old_channels.len() + 1);
                     new_channels.extend_from_slice(old_channels);
                     new_channels.push(channel_id);
 
-                    new_channels
-                },
-                &guard,
-            )
-            .is_none();
-
-        if missing {
-            streams.insert(twitch_id, vec![channel_id], &guard);
-        }
+                    Operation::Insert(new_channels)
+                }
+                None => Operation::Insert(vec![channel_id]),
+            });
     }
 
     pub fn remove_tracking(twitch_id: u64, channel_id: u64) {
@@ -32,16 +28,10 @@ impl Context {
             .tracked_streams
             .pin()
             .update(twitch_id, |old_channels| {
-                match old_channels.iter().position(|&id| id == channel_id) {
-                    Some(idx) => {
-                        let mut new_channels = Vec::with_capacity(old_channels.len() - 1);
-                        new_channels.extend_from_slice(&old_channels[..idx]);
-                        new_channels.extend_from_slice(&old_channels[idx + 1..]);
+                let mut new_channels = old_channels.clone();
+                new_channels.retain(|&id| id != channel_id);
 
-                        new_channels
-                    }
-                    None => old_channels.clone(),
-                }
+                new_channels
             });
     }
 

--- a/bathbot/src/core/events/mod.rs
+++ b/bathbot/src/core/events/mod.rs
@@ -224,14 +224,14 @@ async fn handle_event(event: Event, shard_id: u64) -> Result<()> {
         }
         Event::InteractionCreate(e) => handle_interaction(e.0).await,
         Event::MemberAdd(e) if e.member.user.id == MISS_ANALYZER_ID => {
-            Context::miss_analyzer_guilds().pin().insert(e.guild_id);
+            Context::miss_analyzer_guilds().pin().insert(e.guild_id, ());
         }
         Event::MemberChunk(e) => {
             if e.members
                 .iter()
                 .any(|member| member.user.id == MISS_ANALYZER_ID)
             {
-                Context::miss_analyzer_guilds().pin().insert(e.guild_id);
+                Context::miss_analyzer_guilds().pin().insert(e.guild_id, ());
             }
         }
         Event::MemberRemove(e) if e.user.id == MISS_ANALYZER_ID => {

--- a/bathbot/src/manager/guild_config.rs
+++ b/bathbot/src/manager/guild_config.rs
@@ -4,10 +4,10 @@ use bathbot_psql::{
 };
 use bathbot_util::IntHasher;
 use eyre::{Result, WrapErr};
-use flurry::HashMap as FlurryMap;
+use papaya::HashMap as PapayaMap;
 use twilight_model::id::{marker::GuildMarker, Id};
 
-type GuildConfigs = FlurryMap<Id<GuildMarker>, GuildConfig, IntHasher>;
+type GuildConfigs = PapayaMap<Id<GuildMarker>, GuildConfig, IntHasher>;
 
 #[derive(Copy, Clone)]
 pub struct GuildConfigManager {

--- a/bathbot/src/tracking/twitch/online_streams.rs
+++ b/bathbot/src/tracking/twitch/online_streams.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use bathbot_model::TwitchStream;
 use bathbot_util::IntHasher;
-use flurry::{Guard, HashMap as FlurryMap};
+use papaya::{Guard, HashMap as PapayaMap};
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct TwitchUserId(u64);
@@ -32,11 +32,11 @@ impl From<u64> for TwitchStreamId {
 
 #[derive(Default)]
 pub struct OnlineTwitchStreams {
-    user_streams: FlurryMap<TwitchUserId, TwitchStreamId, IntHasher>,
+    user_streams: PapayaMap<TwitchUserId, TwitchStreamId, IntHasher>,
 }
 
 impl OnlineTwitchStreams {
-    pub fn guard(&self) -> Guard<'_> {
+    pub fn guard(&self) -> impl Guard + '_ {
         self.user_streams.guard()
     }
 
@@ -44,12 +44,12 @@ impl OnlineTwitchStreams {
         self.user_streams.pin().contains_key(&user)
     }
 
-    pub fn set_online(&self, stream: &TwitchStream, guard: &Guard<'_>) {
+    pub fn set_online(&self, stream: &TwitchStream, guard: &impl Guard) {
         self.user_streams
             .insert(stream.user_id.into(), stream.stream_id.into(), guard);
     }
 
-    pub fn set_offline(&self, stream: &TwitchStream, guard: &Guard<'_>) {
+    pub fn set_offline(&self, stream: &TwitchStream, guard: &impl Guard) {
         self.user_streams.remove(&stream.user_id, guard);
     }
 


### PR DESCRIPTION
Switches from [flurry](https://github.com/jonhoo/flurry) to [papaya](https://github.com/ibraheemdev/papaya) for read-heavy concurrent maps/sets because of presumable slight performance gains.

Unfortunately, sets are no yet natively supported.