### PR TITLE
Fix typo in medal stats embed

### DIFF
--- a/bathbot/src/embeds/osu/medal_stats.rs
+++ b/bathbot/src/embeds/osu/medal_stats.rs
@@ -73,7 +73,7 @@ impl MedalStatsEmbed {
                 );
             }
 
-            fields![fields { "Corner stone medals", value, false }];
+            fields![fields { "Cornerstone medals", value, false }];
         }
 
         if !user_medals.is_empty() {


### PR DESCRIPTION
closes #754, corrects 'Corner stone' to 'Cornerstone'

freebie, I know :P