### PR TITLE
Swap old map preview site with a new and modern one

### DIFF
--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -251,7 +251,7 @@ impl BookmarksPagination {
         if map.mode == GameMode::Osu {
             let _ = write!(
                 description,
-                " :clapper: [Map preview](http://jmir.xyz/osu/preview.html#{map_id})",
+                " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
                 map_id = map.map_id
             );
         }

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -298,7 +298,7 @@ impl MapPagination {
         if map.mode == GameMode::Osu {
             let _ = write!(
                 description,
-                " :clapper: [Map preview](http://jmir.xyz/osu/preview.html#{map_id})",
+                " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
                 map_id = map.map_id
             );
         }


### PR DESCRIPTION
resolves #793, swaps the old `http://jmir.xyz/osu/preview.html` website with the newer `https://preview.tryz.id.vn`.