### PR TITLE
Use old preview websites to view other modes (except catch)

### DIFF
--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -254,6 +254,12 @@ impl BookmarksPagination {
                 " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
                 map_id = map.map_id
             );
+        } else if map.mode != GameMode::Catch {
+            let _ = write!(
+                description,
+                " :clapper: [Map preview](https://osu-preview.jmir.xyz/preview#{map_id})",
+                map_id = map.map_id
+            );
         }
 
         let embed = EmbedBuilder::new()

--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -248,18 +248,23 @@ impl BookmarksPagination {
             mapset_id = map.mapset_id
         );
 
-        if map.mode == GameMode::Osu {
-            let _ = write!(
-                description,
-                " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
-                map_id = map.map_id
-            );
-        } else if map.mode != GameMode::Catch {
-            let _ = write!(
-                description,
-                " :clapper: [Map preview](https://osu-preview.jmir.xyz/preview#{map_id})",
-                map_id = map.map_id
-            );
+        match map.mode {
+            GameMode::Osu => {
+                let _ = write!(
+                    description,
+                    " :clapper: [Map preview](http://jmir.xyz/osu/preview.html#{map_id})",
+                    map_id = map.map_id
+                );
+            }
+            GameMode::Mania | GameMode::Taiko => {
+                let _ = write!(
+                    description,
+                    " :clapper: [Map preview](https://osu-preview.jmir.xyz/preview#{map_id})",
+                    map_id = map.map_id
+                );
+            }
+            // Waiting on a preview website that supports catch
+            GameMode::Catch => {}
         }
 
         let embed = EmbedBuilder::new()

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -301,12 +301,6 @@ impl MapPagination {
                 " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
                 map_id = map.map_id
             );
-        } else if map.mode != GameMode::Catch {
-            let _ = write!(
-                description,
-                " :clapper: [Map preview](https://osu-preview.jmir.xyz/preview#{map_id})",
-                map_id = map.map_id
-            );
         }
 
         let embed = EmbedBuilder::new()

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -301,6 +301,12 @@ impl MapPagination {
                 " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
                 map_id = map.map_id
             );
+        } else if map.mode != GameMode::Catch {
+            let _ = write!(
+                description,
+                " :clapper: [Map preview](https://osu-preview.jmir.xyz/preview#{map_id})",
+                map_id = map.map_id
+            );
         }
 
         let embed = EmbedBuilder::new()

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -295,12 +295,23 @@ impl MapPagination {
             mapset_id = self.mapset.mapset_id
         );
 
-        if map.mode == GameMode::Osu {
-            let _ = write!(
-                description,
-                " :clapper: [Map preview](https://preview.tryz.id.vn/?b={map_id})",
-                map_id = map.map_id
-            );
+        match map.mode {
+            GameMode::Osu => {
+                let _ = write!(
+                    description,
+                    " :clapper: [Map preview](http://jmir.xyz/osu/preview.html#{map_id})",
+                    map_id = map.map_id
+                );
+            }
+            GameMode::Mania | GameMode::Taiko => {
+                let _ = write!(
+                    description,
+                    " :clapper: [Map preview](https://osu-preview.jmir.xyz/preview#{map_id})",
+                    map_id = map.map_id
+                );
+            }
+            // Waiting on a preview website that supports catch
+            GameMode::Catch => {}
         }
 
         let embed = EmbedBuilder::new()


### PR DESCRIPTION
Noticed the old website was able to preview taiko and mania while the new one can't, so we should probably use the old one for previewing taiko and mania.