### PR TITLE
Consider TD=NM for card purposes

### DIFF
--- a/bathbot-cards/src/skills/description.rs
+++ b/bathbot-cards/src/skills/description.rs
@@ -118,6 +118,13 @@ impl TitleDescriptions {
                     nomod += 1;
                     continue;
                 }
+            } else if score.mods.contains_intermode(GameModIntermode::TouchDevice) {
+                // IDEA: TD-specific title (Grass-touching?)
+
+                if score.mods.len() == 1 {
+                    nomod += 1;
+                    continue;
+                }
             } else if score.mods.is_empty() {
                 nomod += 1;
                 continue;


### PR DESCRIPTION
Closes #844 

Tested:
![image](https://github.com/user-attachments/assets/51c924d8-3767-4152-98b3-811e7e51f506)

Note:
Considering this is a thing now, adding a TD-specific label could be neat