### PR TITLE
fix: handle cors for link redirects

### DIFF
--- a/bathbot-server/Cargo.toml
+++ b/bathbot-server/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = { version = "1.0" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.0", default-features = false, features = ["sync"] }
 tower = { version = "0.4", default-features = false }
-tower-http = { version = "0.4.4", features = ["fs", "trace"] }
+tower-http = { version = "0.4.4", features = ["cors", "fs", "trace"] }
 tracing = { version = "0.1" }

--- a/bathbot-server/src/server.rs
+++ b/bathbot-server/src/server.rs
@@ -10,7 +10,7 @@ use axum::{
 use eyre::Result;
 use hyper::Request;
 use tokio::sync::oneshot::{channel, Receiver, Sender};
-use tower_http::{services::ServeDir, trace::TraceLayer};
+use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
 use tracing::Span;
 
 use crate::{
@@ -88,6 +88,7 @@ impl Server {
             .route("/guild_count", get(get_guild_count))
             .nest("/auth", Self::auth_app(website_path))
             .route("/osudirect/:mapset_id", get(redirect_osudirect))
+            .layer(CorsLayer::permissive())
             .layer(middleware::from_fn_with_state(state, track_metrics))
             .layer(trace)
     }

--- a/bathbot-server/src/standby.rs
+++ b/bathbot-server/src/standby.rs
@@ -78,14 +78,14 @@ impl AuthenticationStandby {
         self.current_state.fetch_add(1, Ordering::SeqCst)
     }
 
-    pub(super) fn process_osu(&self, user: UserExtended, id: u8) {
-        if let Some(tx) = self.osu.lock(&id).remove() {
+    pub(super) fn process_osu(&self, user: UserExtended, state: u8) {
+        if let Some(tx) = self.osu.lock(&state).remove() {
             let _ = tx.send(user);
         }
     }
 
-    pub(super) fn process_twitch(&self, user: TwitchUser, id: u8) {
-        if let Some(tx) = self.twitch.lock(&id).remove() {
+    pub(super) fn process_twitch(&self, user: TwitchUser, state: u8) {
+        if let Some(tx) = self.twitch.lock(&state).remove() {
             let _ = tx.send(user);
         }
     }


### PR DESCRIPTION
Linking was no longer working due to "CORS Missing Allow Origin" when being redirected from osu!.