### PR TITLE
fix: use full mods & specify lazer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,9 +2423,9 @@ checksum = "21de4f8c5cd2738e1c9a2ed477aad2579dacd5acf3845d80738fcec160d0bd8a"
 
 [[package]]
 name = "rosu-mods"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0fb1475e860c987673e8abc1df5d23f22c4e1ae62e9459e656cff4d82f603b"
+checksum = "65892bec4e81b3931f3c0b3a646feff0daa78b22dff2b45b157c642f1be14b04"
 dependencies = [
  "paste",
  "rkyv",

--- a/bathbot-cards/src/skills/mod.rs
+++ b/bathbot-cards/src/skills/mod.rs
@@ -73,7 +73,7 @@ impl Skills {
                     }
 
                     let attrs = calc
-                        .mods(score.mods.bits())
+                        .mods(score.mods.clone())
                         .state(state)
                         .lazer(score.set_on_lazer)
                         .calculate()
@@ -126,7 +126,7 @@ impl Skills {
                     }
 
                     let attrs = calc
-                        .mods(score.mods.bits())
+                        .mods(score.mods.clone())
                         .state(state)
                         .calculate()
                         .unwrap();
@@ -178,7 +178,7 @@ impl Skills {
 
                     let od = attrs.od as f64;
                     let attrs = calc
-                        .mods(score.mods.bits())
+                        .mods(score.mods.clone())
                         .state(state)
                         .calculate()
                         .unwrap();
@@ -245,7 +245,7 @@ impl Skills {
                     }
 
                     let attrs = calc
-                        .mods(score.mods.bits())
+                        .mods(score.mods.clone())
                         .state(state)
                         .calculate()
                         .unwrap();

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -121,8 +121,6 @@ impl MapPagination {
 
         let mut rosu_map = map_res.wrap_err("Failed to get pp map")?;
 
-        let mod_bits = self.mods.bits();
-
         if let Some(ar_) = self.attrs.ar {
             rosu_map.ar = ar_ as f32;
         }
@@ -141,12 +139,12 @@ impl MapPagination {
 
         let map_attrs = rosu_map
             .attributes()
-            .mods(mod_bits)
+            .mods(&self.mods)
             .clock_rate(clock_rate)
             .build();
 
         let mut attrs = Difficulty::new()
-            .mods(mod_bits)
+            .mods(&self.mods)
             .clock_rate(clock_rate)
             .calculate(&rosu_map);
 
@@ -157,7 +155,7 @@ impl MapPagination {
         for &acc in ACCS.iter() {
             let pp_result = attrs
                 .performance()
-                .mods(mod_bits)
+                .mods(&self.mods)
                 .accuracy(acc as f64)
                 .clock_rate(clock_rate)
                 .calculate();

--- a/bathbot/src/active/impls/profile/top100_stats.rs
+++ b/bathbot/src/active/impls/profile/top100_stats.rs
@@ -88,11 +88,7 @@ impl Top100Stats {
 
             this.pp.add(pp);
 
-            let map_attrs = map
-                .attributes()
-                .mods(score.mods.bits())
-                .clock_rate(score.mods.clock_rate().unwrap_or(1.0))
-                .build();
+            let map_attrs = map.attributes().mods(score.mods.clone()).build();
 
             this.ar.add(map_attrs.ar);
             this.cs.add(map_attrs.cs);

--- a/bathbot/src/commands/osu/nochoke.rs
+++ b/bathbot/src/commands/osu/nochoke.rs
@@ -425,6 +425,7 @@ async fn process_scores(
         map = map.convert(score.mode);
 
         let attrs = Context::pp(&map)
+            .lazer(score.set_on_lazer)
             .mode(score.mode)
             .mods(score.mods.clone())
             .performance()
@@ -548,7 +549,8 @@ async fn perfect_score(score: &ScoreSlim, map: &OsuMap) -> Unchoked {
     let pp = attrs
         .to_owned()
         .performance()
-        .mods(score.mods.bits())
+        .lazer(score.set_on_lazer)
+        .mods(score.mods.clone())
         .clock_rate(score.mods.clock_rate().unwrap_or(1.0))
         .n_geki(n_geki)
         .n300(stats.perfect)

--- a/bathbot/src/commands/osu/top/if_.rs
+++ b/bathbot/src/commands/osu/top/if_.rs
@@ -351,7 +351,7 @@ impl<'q> Searchable<TopCriteria<'q>> for TopIfEntry {
             matches &= criteria.ranked_date.contains(datetime.date());
         }
 
-        let attrs = self.map.attributes().mods(self.score.mods.bits()).build();
+        let attrs = self.map.attributes().mods(self.score.mods.clone()).build();
 
         matches &= criteria.ar.contains(attrs.ar as f32);
         matches &= criteria.cs.contains(attrs.cs as f32);
@@ -522,13 +522,17 @@ async fn process_scores(
         let mut calc = Context::pp(&map).mode(score.mode).mods(score.mods.clone());
         let attrs = calc.performance().await;
 
-        let old_pp = score.pp.expect("missing pp");
+        let old_pp = score.pp.unwrap_or(0.0);
 
         let new_pp = if changed {
             calc.score(&score).performance().await.pp() as f32
         } else {
             old_pp
         };
+
+        if i == 10 {
+            debug!("[{:?}] {old_pp} -> {new_pp}", score.mods)
+        }
 
         let entry = TopIfEntry {
             original_idx: i,

--- a/bathbot/src/commands/osu/top/old.rs
+++ b/bathbot/src/commands/osu/top/old.rs
@@ -946,6 +946,7 @@ async fn process_scores(scores: Vec<Score>, args: &TopOld<'_>) -> Result<Vec<Top
         async fn use_current_system(score: &Score, map: &OsuMap) -> (f32, f32, f32, u32) {
             let attrs = Context::pp(map)
                 .mode(score.mode)
+                .lazer(score.set_on_lazer)
                 .mods(score.mods.clone())
                 .performance()
                 .await;

--- a/bathbot/src/embeds/osu/attributes.rs
+++ b/bathbot/src/embeds/osu/attributes.rs
@@ -19,7 +19,7 @@ impl AttributesEmbed {
         mods: GameModsIntermode,
         clock_rate: Option<f32>,
     ) -> Self {
-        let mut builder = BeatmapAttributesBuilder::default().mods(mods.bits());
+        let mut builder = BeatmapAttributesBuilder::default().mods(&mods);
 
         builder = match kind {
             AttributeKind::Ar => builder.ar(value, false),

--- a/bathbot/src/manager/guild_config.rs
+++ b/bathbot/src/manager/guild_config.rs
@@ -27,8 +27,6 @@ impl GuildConfigManager {
         F: FnOnce(&GuildConfig) -> O,
     {
         if let Some(config) = self.guild_configs.pin().get(&guild_id) {
-            debug!("found config");
-
             return f(config);
         }
 

--- a/bathbot/src/manager/pp.rs
+++ b/bathbot/src/manager/pp.rs
@@ -22,6 +22,7 @@ pub struct PpManager<'m> {
     mods: Mods,
     state: Option<ScoreState>,
     partial: bool,
+    lazer: bool,
 }
 
 impl<'m> PpManager<'m> {
@@ -36,7 +37,14 @@ impl<'m> PpManager<'m> {
             mods: Mods::default(),
             state: None,
             partial: false,
+            lazer: true,
         }
+    }
+
+    pub fn lazer(mut self, lazer: bool) -> Self {
+        self.lazer = lazer;
+
+        self
     }
 
     pub fn mode(mut self, mode: GameMode) -> Self {
@@ -82,10 +90,12 @@ impl<'m> PpManager<'m> {
                 mods,
                 mode,
                 partial,
+                lazer,
             } = score;
 
             manager.state = Some(state);
             manager.partial = partial;
+            manager.lazer = lazer;
 
             if let Some(mode) = mode {
                 manager = manager.mode(mode);
@@ -125,7 +135,9 @@ impl<'m> PpManager<'m> {
             }
         }
 
-        let mut calc = Difficulty::new().mods(self.mods.inner.clone());
+        let mut calc = Difficulty::new()
+            .mods(self.mods.inner.clone())
+            .lazer(self.lazer);
 
         if let Some(clock_rate) = self.mods.clock_rate {
             calc = calc.clock_rate(clock_rate);
@@ -158,7 +170,8 @@ impl<'m> PpManager<'m> {
             .await
             .to_owned()
             .performance()
-            .mods(self.mods.inner.clone());
+            .mods(self.mods.inner.clone())
+            .lazer(self.lazer);
 
         if let Some(clock_rate) = self.mods.clock_rate {
             calc = calc.clock_rate(clock_rate);
@@ -181,6 +194,7 @@ pub struct ScoreData {
     mods: Mods,
     mode: Option<GameMode>,
     partial: bool,
+    lazer: bool,
 }
 
 impl<'s> From<&'s Score> for ScoreData {
@@ -191,6 +205,7 @@ impl<'s> From<&'s Score> for ScoreData {
             mods: Mods::new(score.mods.clone()),
             mode: Some(score.mode),
             partial: !score.passed,
+            lazer: score.set_on_lazer,
         }
     }
 }
@@ -203,6 +218,7 @@ impl<'s> From<&'s ScoreSlim> for ScoreData {
             mods: Mods::new(score.mods.clone()),
             mode: Some(score.mode),
             partial: score.grade == Grade::F,
+            lazer: score.set_on_lazer,
         }
     }
 }
@@ -225,6 +241,7 @@ impl<'s> From<&'s OsuStatsScore> for ScoreData {
             mods: Mods::new(score.mods.clone()),
             mode: None,
             partial: score.grade == Grade::F,
+            lazer: false,
         }
     }
 }
@@ -236,6 +253,7 @@ impl<'s> From<&'s LeaderboardScore> for ScoreData {
             mods: Mods::new(score.mods.clone()),
             mode: Some(score.mode),
             partial: score.grade == Grade::F,
+            lazer: !score.is_legacy,
         }
     }
 }
@@ -248,6 +266,7 @@ impl<'s> From<&'s ScoreEmbedDataRaw> for ScoreData {
             mods: Mods::new(score.mods.clone()),
             mode: Some(score.mode),
             partial: score.grade == Grade::F,
+            lazer: !score.legacy_scores,
         }
     }
 }

--- a/bathbot/src/util/osu.rs
+++ b/bathbot/src/util/osu.rs
@@ -449,15 +449,17 @@ pub struct IfFc {
 
 impl IfFc {
     pub async fn new(score: &ScoreSlim, map: &OsuMap) -> Option<Self> {
-        let mode = score.mode;
-        let mut calc = Context::pp(map).mods(score.mods.clone()).mode(score.mode);
+        let mut calc = Context::pp(map)
+            .mods(score.mods.clone())
+            .mode(score.mode)
+            .lazer(score.set_on_lazer);
+
         let attrs = calc.difficulty().await;
 
-        if score.is_fc(mode, attrs.max_combo()) {
+        if score.is_fc(score.mode, attrs.max_combo()) {
             return None;
         }
 
-        let mods = score.mods.bits();
         let stats = &score.statistics;
 
         let (pp, statistics) = match attrs {
@@ -476,7 +478,8 @@ impl IfFc {
                 let n50 = stats.meh;
 
                 let attrs = OsuPerformance::from(attrs.to_owned())
-                    .mods(mods)
+                    .lazer(score.set_on_lazer)
+                    .mods(score.mods.clone())
                     .n300(n300)
                     .n100(n100)
                     .n50(n50)
@@ -509,7 +512,7 @@ impl IfFc {
                 let acc = 100.0 * (2 * n300 + n100) as f32 / (2 * total_objects) as f32;
 
                 let attrs = TaikoPerformance::from(attrs.to_owned())
-                    .mods(mods)
+                    .mods(score.mods.clone())
                     .accuracy(acc as f64)
                     .calculate()
                     .unwrap();
@@ -537,7 +540,7 @@ impl IfFc {
                 let n_tiny_droplets = attrs.n_tiny_droplets.saturating_sub(n_tiny_droplet_misses);
 
                 let attrs = CatchPerformance::from(attrs.to_owned())
-                    .mods(mods)
+                    .mods(score.mods.clone())
                     .fruits(n_fruits)
                     .droplets(n_droplets)
                     .tiny_droplets(n_tiny_droplets)

--- a/bathbot/src/util/query/searchable.rs
+++ b/bathbot/src/util/query/searchable.rs
@@ -150,7 +150,7 @@ impl Searchable<RC<'_>> for Score {
                 .cs(map.cs, false)
                 .hp(map.hp, false)
                 .od(map.od, false)
-                .mods(self.mods.bits())
+                .mods(self.mods.clone())
                 .mode((map.mode as u8).into(), map.convert)
                 .build();
 
@@ -215,7 +215,7 @@ impl Searchable<RC<'_>> for (&'_ ScoreSlim, &'_ OsuMap) {
 
         let mut matches = true;
 
-        let attrs = map.attributes().mods(score.mods.bits()).build();
+        let attrs = map.attributes().mods(score.mods.clone()).build();
 
         let clock_rate = attrs.clock_rate as f32;
         let len = map.seconds_drain() as f32 / clock_rate;


### PR DESCRIPTION
Fixes #860

This should actually remove all incorrect usages of mod bitflags rather than full mods. And the lazer status should now also be specified wherever required (hopefully I didn't miss any).