### PR TITLE
refactor: new CachedArchive for osu users

### DIFF
--- a/bathbot-cache/src/model/archive.rs
+++ b/bathbot-cache/src/model/archive.rs
@@ -59,6 +59,10 @@ impl<T: ?Sized> CachedArchive<T> {
             phantom: PhantomData,
         }
     }
+
+    pub fn into_bytes(self) -> AlignedVec<8> {
+        self.bytes
+    }
 }
 
 impl<T: Archive + ?Sized> Deref for CachedArchive<T> {

--- a/bathbot-util/src/osu.rs
+++ b/bathbot-util/src/osu.rs
@@ -312,7 +312,7 @@ impl BonusPP {
         self.avg_y += self.ys[idx] * weight;
     }
 
-    pub fn calculate(self, stats: impl UserStats) -> f32 {
+    pub fn calculate(self, stats: &impl UserStats) -> f32 {
         fn inner(bonus_pp: BonusPP, stats_pp: f32, grade_counts_sum: i32, playcount: u32) -> f32 {
             let BonusPP {
                 mut pp,

--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -35,7 +35,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     core::Context,
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::osu::UserArgs,
     util::{interaction::InteractionComponent, Authored, ComponentExt, Emote},
 };
 
@@ -444,8 +444,7 @@ async fn creator_name(map: &MapBookmark) -> Option<Username> {
     let args = UserArgs::user_id(map.mapper_id, GameMode::Osu);
 
     match Context::redis().osu_user(args).await {
-        Ok(RedisData::Original(user)) => Some(user.username),
-        Ok(RedisData::Archive(user)) => Some(user.username.as_str().into()),
+        Ok(user) => Some(user.username.as_str().into()),
         Err(err) => {
             warn!(?err, "Failed to get user");
 

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -24,7 +24,9 @@ use crate::{
     commands::utility::ScoreEmbedData,
     manager::{redis::osu::CachedUser, OsuMap},
     util::{
-        interaction::{InteractionComponent, InteractionModal}, osu::GradeFormatter, CachedUserExt, Emote
+        interaction::{InteractionComponent, InteractionModal},
+        osu::GradeFormatter,
+        CachedUserExt, Emote,
     },
 };
 

--- a/bathbot/src/active/impls/compare/scores.rs
+++ b/bathbot/src/active/impls/compare/scores.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter, Result as FmtResult, Write};
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{embed_builder::ScoreEmbedSettings, rosu_v2::user::User, ScoreSlim};
+use bathbot_model::{embed_builder::ScoreEmbedSettings, ScoreSlim};
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
     constants::OSU_BASE, datetime::HowLongAgoDynamic, numbers::round, CowUtils, EmbedBuilder,
@@ -22,17 +22,15 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::utility::ScoreEmbedData,
-    manager::{redis::RedisData, OsuMap},
+    manager::{redis::osu::CachedUser, OsuMap},
     util::{
-        interaction::{InteractionComponent, InteractionModal},
-        osu::GradeFormatter,
-        Emote,
+        interaction::{InteractionComponent, InteractionModal}, osu::GradeFormatter, CachedUserExt, Emote
     },
 };
 
 #[derive(PaginationBuilder)]
 pub struct CompareScoresPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     map: OsuMap,
     settings: ScoreEmbedSettings,
     #[pagination(per_page = 10)]

--- a/bathbot/src/active/impls/embed_builder.rs
+++ b/bathbot/src/active/impls/embed_builder.rs
@@ -3,11 +3,9 @@ use std::{
     future::ready,
 };
 
-use bathbot_model::{
-    embed_builder::{
-        ComboValue, EmoteTextValue, HitresultsValue, MapperValue, PpValue, ScoreEmbedSettings,
-        SettingValue, SettingsButtons, SettingsImage, Value,
-    },
+use bathbot_model::embed_builder::{
+    ComboValue, EmoteTextValue, HitresultsValue, MapperValue, PpValue, ScoreEmbedSettings,
+    SettingValue, SettingsButtons, SettingsImage, Value,
 };
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::MessageBuilder;

--- a/bathbot/src/active/impls/embed_builder.rs
+++ b/bathbot/src/active/impls/embed_builder.rs
@@ -8,7 +8,6 @@ use bathbot_model::{
         ComboValue, EmoteTextValue, HitresultsValue, MapperValue, PpValue, ScoreEmbedSettings,
         SettingValue, SettingsButtons, SettingsImage, Value,
     },
-    rosu_v2::user::User,
 };
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::MessageBuilder;
@@ -27,7 +26,7 @@ use crate::{
     active::{response::ActiveResponse, BuildPage, ComponentResult, IActiveMessage},
     commands::utility::ScoreEmbedDataWrap,
     core::Context,
-    manager::redis::RedisData,
+    manager::redis::osu::CachedUser,
     util::{interaction::InteractionComponent, Authored, Emote},
 };
 
@@ -41,7 +40,7 @@ pub struct ScoreEmbedBuilderActive {
 
 impl ScoreEmbedBuilderActive {
     pub fn new(
-        user: &RedisData<User>,
+        user: &CachedUser,
         data: ScoreEmbedDataWrap,
         settings: ScoreEmbedSettings,
         score_data: ScoreData,

--- a/bathbot/src/active/impls/leaderboard.rs
+++ b/bathbot/src/active/impls/leaderboard.rs
@@ -37,7 +37,7 @@ pub struct LeaderboardPagination {
     stars: f32,
     max_combo: u32,
     author_data: Option<LeaderboardUserScore>,
-    first_place_icon: Option<String>,
+    first_place_icon: Option<Box<str>>,
     score_data: ScoreData,
     content: Box<str>,
     msg_owner: Id<UserMarker>,

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -27,7 +27,7 @@ use crate::{
     commands::osu::CustomAttrs,
     core::Context,
     embeds::attachment,
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::osu::UserArgs,
     util::{
         interaction::{InteractionComponent, InteractionModal},
         Emote,
@@ -346,8 +346,7 @@ async fn creator_name(map: &BeatmapExtended, mapset: &BeatmapsetExtended) -> Opt
     let args = UserArgs::user_id(map.creator_id, GameMode::Osu);
 
     match Context::redis().osu_user(args).await {
-        Ok(RedisData::Original(user)) => Some(user.username),
-        Ok(RedisData::Archive(user)) => Some(user.username.as_str().into()),
+        Ok(user) => Some(user.username.as_str().into()),
         Err(err) => {
             warn!(?err, "Failed to get user");
 

--- a/bathbot/src/active/impls/medals/list.rs
+++ b/bathbot/src/active/impls/medals/list.rs
@@ -17,7 +17,7 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::MedalEntryList,
-    manager::redis::{ osu::CachedUser},
+    manager::redis::osu::CachedUser,
     util::interaction::{InteractionComponent, InteractionModal},
 };
 

--- a/bathbot/src/active/impls/medals/recent.rs
+++ b/bathbot/src/active/impls/medals/recent.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{rosu_v2::user::User, OsekaiMedal};
+use bathbot_model::OsekaiMedal;
 use bathbot_psql::model::configs::HideSolutions;
 use bathbot_util::IntHasher;
 use eyre::Result;
@@ -18,13 +18,13 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::{MedalAchieved, MedalEmbed},
-    manager::redis::RedisData,
+    manager::redis::osu::CachedUser,
     util::interaction::{InteractionComponent, InteractionModal},
 };
 
 #[derive(PaginationBuilder)]
 pub struct MedalsRecentPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     medals: HashMap<u32, OsekaiMedal, IntHasher>,
     #[pagination(per_page = 1)]
     achieved_medals: Box<[MedalCompact]>,

--- a/bathbot/src/active/impls/most_played.rs
+++ b/bathbot/src/active/impls/most_played.rs
@@ -16,7 +16,10 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     manager::redis::osu::CachedUser,
-    util::{interaction::{InteractionComponent, InteractionModal}, CachedUserExt},
+    util::{
+        interaction::{InteractionComponent, InteractionModal},
+        CachedUserExt,
+    },
 };
 
 #[derive(PaginationBuilder)]

--- a/bathbot/src/active/impls/most_played.rs
+++ b/bathbot/src/active/impls/most_played.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{constants::OSU_BASE, CowUtils, EmbedBuilder, FooterBuilder};
 use eyre::Result;
 use futures::future::BoxFuture;
@@ -16,13 +15,13 @@ use crate::{
         pagination::{handle_pagination_component, handle_pagination_modal, Pages},
         BuildPage, ComponentResult, IActiveMessage,
     },
-    manager::redis::RedisData,
-    util::interaction::{InteractionComponent, InteractionModal},
+    manager::redis::osu::CachedUser,
+    util::{interaction::{InteractionComponent, InteractionModal}, CachedUserExt},
 };
 
 #[derive(PaginationBuilder)]
 pub struct MostPlayedPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     #[pagination(per_page = 10)]
     maps: Box<[MostPlayedMap]>,
     msg_owner: Id<UserMarker>,
@@ -61,7 +60,7 @@ impl IActiveMessage for MostPlayedPagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(FooterBuilder::new(footer_text))
-            .thumbnail(self.user.avatar_url())
+            .thumbnail(self.user.avatar_url.as_ref())
             .title("Most played maps:");
 
         BuildPage::new(embed, false).boxed()

--- a/bathbot/src/active/impls/nochoke.rs
+++ b/bathbot/src/active/impls/nochoke.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Display, Formatter, Result as FmtResult, Write};
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     constants::OSU_BASE, datetime::HowLongAgoDynamic, numbers::WithComma, CowUtils, EmbedBuilder,
     FooterBuilder, ModsFormatter, ScoreExt,
@@ -19,17 +18,17 @@ use crate::{
         BuildPage, ComponentResult, IActiveMessage,
     },
     commands::osu::NochokeEntry,
-    manager::redis::RedisData,
+    manager::redis::osu::CachedUser,
     util::{
         interaction::{InteractionComponent, InteractionModal},
         osu::GradeFormatter,
-        Emote,
+        CachedUserExt, Emote,
     },
 };
 
 #[derive(PaginationBuilder)]
 pub struct NoChokePagination {
-    user: RedisData<User>,
+    user: CachedUser,
     #[pagination(per_page = 5)]
     entries: Box<[NochokeEntry]>,
     unchoked_pp: f32,
@@ -45,7 +44,14 @@ impl IActiveMessage for NoChokePagination {
         let end_idx = self.entries.len().min(pages.index() + pages.per_page());
         let entries = &self.entries[pages.index()..end_idx];
 
-        let pp_raw = self.user.stats().pp();
+        let pp_raw = self
+            .user
+            .statistics
+            .as_ref()
+            .expect("missing stats")
+            .pp
+            .to_native();
+
         let pp_diff = (100.0 * (self.unchoked_pp - pp_raw)).round() / 100.0;
         let mut description = String::with_capacity(512);
 
@@ -111,7 +117,7 @@ impl IActiveMessage for NoChokePagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(FooterBuilder::new(footer_text))
-            .thumbnail(self.user.avatar_url())
+            .thumbnail(self.user.avatar_url.as_ref())
             .title(title);
 
         BuildPage::new(embed, false)

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt::Write};
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{rosu_v2::user::User, OsuStatsParams, OsuStatsScoresRaw, ScoreSlim};
+use bathbot_model::{OsuStatsParams, OsuStatsScoresRaw, ScoreSlim};
 use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
@@ -24,16 +24,17 @@ use crate::{
     commands::osu::OsuStatsEntry,
     core::Context,
     embeds::{ComboFormatter, HitResultFormatter, PpFormatter},
-    manager::redis::RedisData,
+    manager::redis::osu::CachedUser,
     util::{
         interaction::{InteractionComponent, InteractionModal},
         osu::grade_emote,
+        CachedUserExt,
     },
 };
 
 #[derive(PaginationBuilder)]
 pub struct OsuStatsScoresPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     #[pagination(per_page = 5, len = "total")]
     entries: BTreeMap<usize, OsuStatsEntry>,
     total: usize,
@@ -157,7 +158,7 @@ impl OsuStatsScoresPagination {
                 .author(self.user.author_builder())
                 .description("No scores with these parameters were found")
                 .footer(FooterBuilder::new("Page 1/1 • Total scores: 0"))
-                .thumbnail(self.user.avatar_url());
+                .thumbnail(self.user.avatar_url.as_ref());
 
             return Ok(BuildPage::new(embed, true).content(self.content.clone()));
         }
@@ -209,7 +210,7 @@ impl OsuStatsScoresPagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(footer)
-            .thumbnail(self.user.avatar_url());
+            .thumbnail(self.user.avatar_url.as_ref());
 
         Ok(BuildPage::new(embed, true).content(self.content.clone()))
     }

--- a/bathbot/src/active/impls/profile/top100_mappers.rs
+++ b/bathbot/src/active/impls/profile/top100_mappers.rs
@@ -10,8 +10,8 @@ pub(super) struct Top100Mappers;
 impl Top100Mappers {
     pub(super) async fn prepare(menu: &mut ProfileMenu) -> Option<Vec<MapperEntry<'_>>> {
         let mut entries: Vec<_> = {
-            let user_id = menu.user.user_id();
-            let mode = menu.user.mode();
+            let user_id = menu.user.user_id.to_native();
+            let mode = menu.user.mode;
             let scores = menu.scores.get(user_id, mode, menu.legacy_scores).await?;
             let mut entries = HashMap::with_capacity_and_hasher(32, IntHasher);
 

--- a/bathbot/src/active/impls/profile/top100_mods.rs
+++ b/bathbot/src/active/impls/profile/top100_mods.rs
@@ -13,8 +13,8 @@ pub(super) struct Top100Mods {
 
 impl Top100Mods {
     pub(super) async fn prepare(menu: &mut ProfileMenu) -> Option<Self> {
-        let user_id = menu.user.user_id();
-        let mode = menu.user.mode();
+        let user_id = menu.user.user_id.to_native();
+        let mode = menu.user.mode;
 
         menu.scores
             .get(user_id, mode, menu.legacy_scores)

--- a/bathbot/src/active/impls/profile/top100_stats.rs
+++ b/bathbot/src/active/impls/profile/top100_stats.rs
@@ -25,8 +25,8 @@ impl Top100Stats {
             return Some(stats);
         }
 
-        let user_id = menu.user.user_id();
-        let mode = menu.user.mode();
+        let user_id = menu.user.user_id.to_native();
+        let mode = menu.user.mode;
         let scores = menu.scores.get(user_id, mode, menu.legacy_scores).await?;
 
         match Self::new(scores).await {

--- a/bathbot/src/active/impls/recent_list.rs
+++ b/bathbot/src/active/impls/recent_list.rs
@@ -20,10 +20,11 @@ use crate::{
     },
     commands::osu::RecentListEntry,
     embeds::{ComboFormatter, KeyFormatter, PpFormatter},
-    manager::{ redis::osu::CachedUser, OsuMap},
+    manager::{redis::osu::CachedUser, OsuMap},
     util::{
         interaction::{InteractionComponent, InteractionModal},
-        osu::GradeCompletionFormatter, CachedUserExt,
+        osu::GradeCompletionFormatter,
+        CachedUserExt,
     },
 };
 

--- a/bathbot/src/active/impls/single_score.rs
+++ b/bathbot/src/active/impls/single_score.rs
@@ -1,11 +1,8 @@
 use std::{borrow::Cow, fmt::Write, time::Duration};
 
-use bathbot_model::{
-    embed_builder::{
-        EmoteTextValue, HitresultsValue, MapperValue, ScoreEmbedSettings, SettingValue,
-        SettingsImage, Value,
-    },
-    rosu_v2::user::User,
+use bathbot_model::embed_builder::{
+    EmoteTextValue, HitresultsValue, MapperValue, ScoreEmbedSettings, SettingValue, SettingsImage,
+    Value,
 };
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
@@ -47,11 +44,11 @@ use crate::{
     },
     core::{buckets::BucketName, Context},
     embeds::{attachment, HitResultFormatter},
-    manager::{redis::RedisData, OwnedReplayScore, ReplayScore},
+    manager::{redis::osu::CachedUser, OwnedReplayScore, ReplayScore},
     util::{
         interaction::{InteractionComponent, InteractionModal},
         osu::{GradeFormatter, ScoreFormatter},
-        Authored, Emote, MessageExt,
+        Authored, CachedUserExt, Emote, MessageExt,
     },
 };
 
@@ -71,7 +68,7 @@ impl SingleScorePagination {
     pub const IMAGE_NAME: &'static str = "map_graph.png";
 
     pub fn new(
-        user: &RedisData<User>,
+        user: &CachedUser,
         scores: Box<[ScoreEmbedDataWrap]>,
         settings: ScoreEmbedSettings,
         score_data: ScoreData,
@@ -84,7 +81,7 @@ impl SingleScorePagination {
             settings,
             scores,
             score_data,
-            username: Box::from(user.username()),
+            username: Box::from(user.username.as_ref()),
             msg_owner,
             pages,
             author: user.author_builder(),

--- a/bathbot/src/active/impls/snipe/difference.rs
+++ b/bathbot/src/active/impls/snipe/difference.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{rosu_v2::user::User, SnipeRecent};
+use bathbot_model::{ SnipeRecent};
 use bathbot_util::{
     constants::OSU_BASE, datetime::HowLongAgoDynamic, numbers::round, CowUtils, EmbedBuilder,
     FooterBuilder, IntHasher,
@@ -26,13 +26,13 @@ use crate::{
     commands::osu::Difference,
     core::Context,
     embeds::ModsFormatter,
-    manager::redis::RedisData,
-    util::interaction::{InteractionComponent, InteractionModal},
+    manager::redis::osu::CachedUser,
+    util::{interaction::{InteractionComponent, InteractionModal}, CachedUserExt},
 };
 
 #[derive(PaginationBuilder)]
 pub struct SnipeDifferencePagination {
-    user: RedisData<User>,
+    user: CachedUser,
     diff: Difference,
     #[pagination(per_page = 10)]
     scores: Box<[SnipeRecent]>,
@@ -167,7 +167,7 @@ impl SnipeDifferencePagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(footer)
-            .thumbnail(self.user.avatar_url())
+            .thumbnail(self.user.avatar_url.as_ref())
             .title(title);
 
         Ok(BuildPage::new(embed, true))

--- a/bathbot/src/active/impls/snipe/difference.rs
+++ b/bathbot/src/active/impls/snipe/difference.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{ SnipeRecent};
+use bathbot_model::SnipeRecent;
 use bathbot_util::{
     constants::OSU_BASE, datetime::HowLongAgoDynamic, numbers::round, CowUtils, EmbedBuilder,
     FooterBuilder, IntHasher,
@@ -27,7 +27,10 @@ use crate::{
     core::Context,
     embeds::ModsFormatter,
     manager::redis::osu::CachedUser,
-    util::{interaction::{InteractionComponent, InteractionModal}, CachedUserExt},
+    util::{
+        interaction::{InteractionComponent, InteractionModal},
+        CachedUserExt,
+    },
 };
 
 #[derive(PaginationBuilder)]

--- a/bathbot/src/active/impls/snipe/player_list.rs
+++ b/bathbot/src/active/impls/snipe/player_list.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{ SnipeScore, SnipeScoreParams};
+use bathbot_model::{SnipeScore, SnipeScoreParams};
 use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
@@ -28,7 +28,8 @@ use crate::{
     embeds::PpFormatter,
     manager::{redis::osu::CachedUser, OsuMap},
     util::{
-        interaction::{InteractionComponent, InteractionModal}, CachedUserExt, Emote
+        interaction::{InteractionComponent, InteractionModal},
+        CachedUserExt, Emote,
     },
 };
 

--- a/bathbot/src/active/impls/snipe/player_list.rs
+++ b/bathbot/src/active/impls/snipe/player_list.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::{rosu_v2::user::User, SnipeScore, SnipeScoreParams};
+use bathbot_model::{ SnipeScore, SnipeScoreParams};
 use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
@@ -26,16 +26,15 @@ use crate::{
     },
     core::Context,
     embeds::PpFormatter,
-    manager::{redis::RedisData, OsuMap},
+    manager::{redis::osu::CachedUser, OsuMap},
     util::{
-        interaction::{InteractionComponent, InteractionModal},
-        Emote,
+        interaction::{InteractionComponent, InteractionModal}, CachedUserExt, Emote
     },
 };
 
 #[derive(PaginationBuilder)]
 pub struct SnipePlayerListPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     #[pagination(per_page = 5, len = "total")]
     scores: BTreeMap<usize, SnipeScore>,
     maps: HashMap<u32, OsuMap, IntHasher>,
@@ -130,7 +129,7 @@ impl SnipePlayerListPagination {
                 .author(self.user.author_builder())
                 .description("No scores were found")
                 .footer(FooterBuilder::new("Page 1/1 • Total #1 scores: 0"))
-                .thumbnail(self.user.avatar_url());
+                .thumbnail(self.user.avatar_url.as_ref());
 
             return Ok(BuildPage::new(embed, true).content(self.content.clone()));
         }
@@ -190,7 +189,7 @@ impl SnipePlayerListPagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(footer)
-            .thumbnail(self.user.avatar_url());
+            .thumbnail(self.user.avatar_url.as_ref());
 
         Ok(BuildPage::new(embed, true).content(self.content.clone()))
     }

--- a/bathbot/src/active/impls/top.rs
+++ b/bathbot/src/active/impls/top.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Display, Formatter, Result as FmtResult, Write};
 
-use bathbot_model::rosu_v2::user::User;
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
     constants::OSU_BASE,
@@ -27,16 +26,16 @@ use crate::{
         utility::{ScoreEmbedDataHalf, ScoreEmbedDataWrap},
     },
     embeds::{ComboFormatter, HitResultFormatter, PpFormatter},
-    manager::{redis::RedisData, OsuMap},
+    manager::{redis::osu::CachedUser, OsuMap},
     util::{
         interaction::{InteractionComponent, InteractionModal},
         osu::{GradeFormatter, ScoreFormatter},
-        Emote,
+        CachedUserExt, Emote,
     },
 };
 
 pub struct TopPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     mode: GameMode,
     entries: Box<[ScoreEmbedDataWrap]>,
     sort_by: TopScoreOrder,
@@ -84,7 +83,7 @@ impl TopPagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(FooterBuilder::new(footer_text))
-            .thumbnail(self.user.avatar_url());
+            .thumbnail(self.user.avatar_url.as_ref());
 
         BuildPage::new(embed, false).content(self.content.clone())
     }
@@ -230,7 +229,7 @@ impl TopPagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(FooterBuilder::new(footer_text))
-            .thumbnail(self.user.avatar_url());
+            .thumbnail(self.user.avatar_url.as_ref());
 
         BuildPage::new(embed, false).content(self.content.clone())
     }
@@ -265,7 +264,7 @@ impl IActiveMessage for TopPagination {
 }
 
 pub struct TopPaginationBuilder {
-    user: Option<RedisData<User>>,
+    user: Option<CachedUser>,
     mode: Option<GameMode>,
     entries: Option<Box<[ScoreEmbedDataWrap]>>,
     sort_by: Option<TopScoreOrder>,
@@ -305,7 +304,7 @@ impl TopPaginationBuilder {
         }
     }
 
-    pub fn user(&mut self, user: RedisData<User>) -> &mut Self {
+    pub fn user(&mut self, user: CachedUser) -> &mut Self {
         self.user = Some(user);
 
         self

--- a/bathbot/src/active/impls/top_if.rs
+++ b/bathbot/src/active/impls/top_if.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use bathbot_macros::PaginationBuilder;
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
@@ -23,16 +22,17 @@ use crate::{
     },
     commands::osu::TopIfEntry,
     embeds::{ComboFormatter, HitResultFormatter, PpFormatter},
-    manager::redis::RedisData,
+    manager::redis::osu::CachedUser,
     util::{
         interaction::{InteractionComponent, InteractionModal},
         osu::GradeFormatter,
+        CachedUserExt,
     },
 };
 
 #[derive(PaginationBuilder)]
 pub struct TopIfPagination {
-    user: RedisData<User>,
+    user: CachedUser,
     #[pagination(per_page = 5)]
     entries: Box<[TopIfEntry]>,
     mode: GameMode,
@@ -106,7 +106,7 @@ impl IActiveMessage for TopIfPagination {
             .author(self.user.author_builder())
             .description(description)
             .footer(FooterBuilder::new(footer_text))
-            .thumbnail(self.user.avatar_url())
+            .thumbnail(self.user.avatar_url.as_ref())
             .title(title);
 
         BuildPage::new(embed, false)

--- a/bathbot/src/commands/osu/avatar.rs
+++ b/bathbot/src/commands/osu/avatar.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE, OSU_BASE},
+    constants::{GENERAL_ISSUE,  OSU_BASE},
     matcher,
     osu::flag_url,
     AuthorBuilder, EmbedBuilder, MessageBuilder,
@@ -15,7 +15,10 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::{require_link, user_not_found};
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{UserArgs, UserArgsError},
+        
+    },
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,
 };
@@ -84,37 +87,26 @@ async fn avatar(orig: CommandOrigin<'_>, args: Avatar<'_>) -> Result<()> {
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user");
 
             return Err(err);
         }
     };
 
-    let embed = match user {
-        RedisData::Original(user) => {
-            let author = AuthorBuilder::new(user.username.into_string())
-                .url(format!("{OSU_BASE}u/{}", user.user_id))
-                .icon_url(flag_url(&user.country_code));
+    let author = AuthorBuilder::new(user.username.as_str())
+        .url(format!("{OSU_BASE}u/{}", user.user_id))
+        .icon_url(flag_url(user.country_code.as_str()));
 
-            EmbedBuilder::new().author(author).image(user.avatar_url)
-        }
-        RedisData::Archive(user) => {
-            let author = AuthorBuilder::new(user.username.as_str())
-                .url(format!("{OSU_BASE}u/{}", user.user_id))
-                .icon_url(flag_url(user.country_code.as_str()));
-
-            EmbedBuilder::new()
-                .author(author)
-                .image(user.avatar_url.as_ref())
-        }
-    };
+    let embed = EmbedBuilder::new()
+        .author(author)
+        .image(user.avatar_url.as_ref());
 
     let builder = MessageBuilder::new().embed(embed);
     orig.create_message(builder).await?;

--- a/bathbot/src/commands/osu/avatar.rs
+++ b/bathbot/src/commands/osu/avatar.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE,  OSU_BASE},
+    constants::{GENERAL_ISSUE, OSU_BASE},
     matcher,
     osu::flag_url,
     AuthorBuilder, EmbedBuilder, MessageBuilder,
@@ -15,10 +15,7 @@ use twilight_model::id::{marker::UserMarker, Id};
 use super::{require_link, user_not_found};
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{
-        osu::{UserArgs, UserArgsError},
-        
-    },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,
 };

--- a/bathbot/src/commands/osu/badges/user.rs
+++ b/bathbot/src/commands/osu/badges/user.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use bathbot_util::{
-    constants::{AVATAR_URL, GENERAL_ISSUE, OSEKAI_ISSUE, OSU_API_ISSUE},
+    constants::{AVATAR_URL, GENERAL_ISSUE, OSEKAI_ISSUE},
     MessageBuilder,
 };
 use eyre::{Report, Result};
@@ -16,7 +16,10 @@ use crate::{
     active::{impls::BadgesPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
     core::{commands::CommandOrigin, Context},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{UserArgs, UserArgsError},
+        RedisData,
+    },
     util::osu::get_combined_thumbnail,
 };
 
@@ -39,19 +42,22 @@ pub(super) async fn user(orig: CommandOrigin<'_>, args: BadgesUser) -> Result<()
     let user_args_fut = UserArgs::rosu_id(&user_id, GameMode::Osu);
     let badges_fut = Context::redis().badges();
 
-    let (user_args_res, badges_res) = tokio::join!(user_args_fut, badges_fut);
+    let (user_args, badges_res) = tokio::join!(user_args_fut, badges_fut);
 
-    let (user_id_raw, user_id) = match user_args_res {
+    let (user_id_raw, user_id) = match user_args {
         UserArgs::Args(args) => (args.user_id, user_id),
-        UserArgs::User { user, .. } => (user.user_id, UserId::Name(user.username)),
-        UserArgs::Err(OsuError::NotFound) => {
+        UserArgs::User { user, .. } => (
+            user.user_id.to_native(),
+            UserId::Name(user.username.as_str().into()),
+        ),
+        UserArgs::Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         UserArgs::Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user");
 
             return Err(err);
         }
@@ -62,7 +68,7 @@ pub(super) async fn user(orig: CommandOrigin<'_>, args: BadgesUser) -> Result<()
         Err(err) => {
             let _ = orig.error(OSEKAI_ISSUE).await;
 
-            return Err(err.wrap_err("failed to get badges"));
+            return Err(err.wrap_err("Failed to get badges"));
         }
     };
 

--- a/bathbot/src/commands/osu/bws.rs
+++ b/bathbot/src/commands/osu/bws.rs
@@ -1,10 +1,7 @@
 use std::{borrow::Cow, mem};
 
 use bathbot_macros::{command, HasName, SlashCommand};
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher, MessageBuilder, TourneyBadges,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder, TourneyBadges};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use twilight_interactions::command::{CommandModel, CreateCommand};
@@ -14,10 +11,7 @@ use super::{require_link, user_not_found};
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{BWSEmbed, EmbedData},
-    manager::redis::{
-        osu::{UserArgs, UserArgsError},
-        
-    },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,
 };

--- a/bathbot/src/commands/osu/compare/profile.rs
+++ b/bathbot/src/commands/osu/compare/profile.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, io::Cursor};
 use bathbot_macros::{command, SlashCommand};
 use bathbot_model::{command_fields::GameModeOption, RankAccPeaks, RespektiveUser};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::GENERAL_ISSUE,
     matcher,
     numbers::MinMaxAvg,
     osu::{BonusPP, UserStats},
@@ -31,7 +31,7 @@ use crate::{
     commands::osu::UserExtraction,
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, ProfileCompareEmbed},
-    manager::redis::osu::UserArgs,
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,
 };
@@ -148,29 +148,35 @@ pub(super) async fn profile(orig: CommandOrigin<'_>, mut args: CompareProfile<'_
 
     let (user1, user2, scores1, scores2) = match tokio::try_join!(fut1, fut2) {
         Ok(((user1, scores1), (user2, scores2))) => (user1, user2, scores1, scores2),
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = "At least one of the players was not found";
 
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
+            let _ = orig.error(GENERAL_ISSUE).await;
             let err = Report::new(err).wrap_err("Failed to get user and scores");
 
             return Err(err);
         }
     };
 
-    if user1.user_id() == user2.user_id() {
+    if user1.user_id == user2.user_id {
         let content = "Give two different users";
 
         return orig.error(content).await;
     }
 
     let content = if scores1.is_empty() {
-        Some(format!("No scores data for user `{}`", user1.username()))
+        Some(format!(
+            "No scores data for user `{}`",
+            user1.username.as_str()
+        ))
     } else if scores2.is_empty() {
-        Some(format!("No scores data for user `{}`", user2.username()))
+        Some(format!(
+            "No scores data for user `{}`",
+            user2.username.as_str()
+        ))
     } else {
         None
     };
@@ -180,12 +186,14 @@ pub(super) async fn profile(orig: CommandOrigin<'_>, mut args: CompareProfile<'_
     }
 
     let client = Context::client();
-    let thumbnail_fut = get_combined_thumbnail(user1.avatar_url(), user2.avatar_url());
+    let thumbnail_fut =
+        get_combined_thumbnail(user1.avatar_url.as_ref(), user2.avatar_url.as_ref());
 
-    let score_ranks_fut = client.get_respektive_users([user1.user_id(), user2.user_id()], mode);
+    let score_ranks_fut =
+        client.get_respektive_users([user1.user_id.to_native(), user2.user_id.to_native()], mode);
 
-    let osutrack_fut1 = client.osu_user_rank_acc_peak(user1.user_id(), mode);
-    let osutrack_fut2 = client.osu_user_rank_acc_peak(user2.user_id(), mode);
+    let osutrack_fut1 = client.osu_user_rank_acc_peak(user1.user_id.to_native(), mode);
+    let osutrack_fut2 = client.osu_user_rank_acc_peak(user2.user_id.to_native(), mode);
 
     let (thumbnail_res, score_ranks_res, osutrack_res1, osutrack_res2) =
         tokio::join!(thumbnail_fut, score_ranks_fut, osutrack_fut1, osutrack_fut2);
@@ -218,7 +226,7 @@ pub(super) async fn profile(orig: CommandOrigin<'_>, mut args: CompareProfile<'_
         Ok(peaks) => peaks,
         Err(err) => {
             warn!(
-                user_id = user1.user_id(),
+                user_id = user1.user_id.to_native(),
                 ?mode,
                 ?err,
                 "Failed to get osutrack peaks"
@@ -232,7 +240,7 @@ pub(super) async fn profile(orig: CommandOrigin<'_>, mut args: CompareProfile<'_
         Ok(peaks) => peaks,
         Err(err) => {
             warn!(
-                user_id = user2.user_id(),
+                user_id = user2.user_id.to_native(),
                 ?mode,
                 ?err,
                 "Failed to get osutrack peaks"
@@ -242,10 +250,18 @@ pub(super) async fn profile(orig: CommandOrigin<'_>, mut args: CompareProfile<'_
         }
     };
 
-    let profile_result1 =
-        CompareResult::calc(&scores1, user1.stats(), score_rank_data1, osutrack_peaks1);
-    let profile_result2 =
-        CompareResult::calc(&scores2, user2.stats(), score_rank_data2, osutrack_peaks2);
+    let profile_result1 = CompareResult::calc(
+        &scores1,
+        user1.statistics.as_ref().expect("missing stats"),
+        score_rank_data1,
+        osutrack_peaks1,
+    );
+    let profile_result2 = CompareResult::calc(
+        &scores2,
+        user2.statistics.as_ref().expect("missing stats"),
+        score_rank_data2,
+        osutrack_peaks2,
+    );
 
     // Creating the embed
     let embed_data =
@@ -368,7 +384,7 @@ pub struct CompareResult {
 impl CompareResult {
     fn calc(
         scores: &[Score],
-        stats: impl UserStats,
+        stats: &impl UserStats,
         score_rank_data: Option<RespektiveUser>,
         osutrack_peaks: Option<RankAccPeaks>,
     ) -> Self {

--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use bathbot_macros::{command, HasMods, HasName, SlashCommand};
-use bathbot_model::{rosu_v2::user::User, ScoreSlim};
+use bathbot_model::{ScoreSlim};
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
@@ -26,8 +26,8 @@ use crate::{
     embeds::{EmbedData, FixScoreEmbed},
     manager::{
         redis::{
-            osu::{UserArgs, UserArgsSlim},
-            RedisData,
+            osu::{CachedUser, UserArgs, UserArgsError, UserArgsSlim},
+            
         },
         MapError, OsuMap,
     },
@@ -278,7 +278,7 @@ enum ScoreResult {
 }
 
 pub struct FixEntry {
-    pub user: RedisData<User>,
+    pub user: CachedUser,
     pub map: OsuMap,
     pub score: Option<FixScore>,
 }
@@ -328,20 +328,20 @@ async fn request_by_map(
             tokio::join!(user_fut, scores_fut)
         }
         UserArgs::User { user, .. } => {
-            let args = UserArgsSlim::user_id(user.user_id).mode(map.mode());
+            let args = UserArgsSlim::user_id(user.user_id.to_native()).mode(map.mode());
             let scores_res = Context::osu_scores()
                 .user_on_map(map_id, legacy_scores)
                 .exec(args)
                 .await;
 
-            (Ok(RedisData::Original(*user)), scores_res)
+            (Ok(user), scores_res)
         }
         UserArgs::Err(err) => (Err(err), Ok(Vec::new())),
     };
 
     let user = match user_res {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return match orig.error(content).await {
@@ -350,7 +350,7 @@ async fn request_by_map(
             };
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
+            let _ = orig.error(GENERAL_ISSUE).await;
             let wrap = "Failed to get user";
 
             return ScoreResult::Error(Report::new(err).wrap_err(wrap));
@@ -380,7 +380,7 @@ async fn request_by_map(
 
     let score = match score_opt {
         Some(score) => {
-            let user_args = UserArgsSlim::user_id(user.user_id()).mode(score.mode);
+            let user_args = UserArgsSlim::user_id(user.user_id.to_native()).mode(score.mode);
 
             let top_fut = Context::osu_scores()
                 .top(legacy_scores)
@@ -475,7 +475,7 @@ async fn request_by_score(
 
     let (user, map, top) = match tokio::join!(user_fut, map_fut, best_fut) {
         (Ok(user), Ok(map), Ok(best)) => (user, map, best),
-        (Err(OsuError::NotFound), ..) => {
+        (Err(UserArgsError::Osu(OsuError::NotFound)), ..) => {
             let content = user_not_found(user_id).await;
 
             return match orig.error(content).await {
@@ -497,7 +497,7 @@ async fn request_by_score(
             return ScoreResult::Error(err);
         }
         (Err(err), ..) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
+            let _ = orig.error(GENERAL_ISSUE).await;
             let err = Report::new(err).wrap_err("Failed to get user");
 
             return ScoreResult::Error(err);

--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use bathbot_macros::{command, HasMods, HasName, SlashCommand};
-use bathbot_model::{ScoreSlim};
+use bathbot_model::ScoreSlim;
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
@@ -25,10 +25,7 @@ use crate::{
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, FixScoreEmbed},
     manager::{
-        redis::{
-            osu::{CachedUser, UserArgs, UserArgsError, UserArgsSlim},
-            
-        },
+        redis::osu::{CachedUser, UserArgs, UserArgsError, UserArgsSlim},
         MapError, OsuMap,
     },
     util::{

--- a/bathbot/src/commands/osu/graphs/medals.rs
+++ b/bathbot/src/commands/osu/graphs/medals.rs
@@ -1,10 +1,5 @@
-use std::mem;
-
-use bathbot_model::rosu_v2::user::{MedalCompactRkyv, User};
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
-    MessageBuilder,
-};
+use bathbot_model::rosu_v2::user::MedalCompactRkyv;
+use bathbot_util::{constants::GENERAL_ISSUE, MessageBuilder};
 use eyre::{Report, Result};
 use rkyv::{
     rancor::{Panic, ResultExt},
@@ -16,46 +11,43 @@ use super::{H, W};
 use crate::{
     commands::osu::{medals::stats as medals_stats, user_not_found},
     core::{commands::CommandOrigin, Context},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
 
 pub async fn medals_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
-) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
+) -> Result<Option<(CachedUser, Vec<u8>)>> {
     let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
 
-    let mut user = match Context::redis().osu_user(user_args).await {
+    let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
             orig.error(content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let report = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let report = Report::new(err).wrap_err("Failed to get user");
 
             return Err(report);
         }
     };
 
-    let mut medals = match user {
-        RedisData::Original(ref mut user) => mem::take(&mut user.medals),
-        RedisData::Archive(ref user) => rkyv::api::deserialize_using::<_, _, Panic>(
-            With::<_, Map<MedalCompactRkyv>>::cast(&user.medals),
-            &mut (),
-        )
-        .always_ok(),
-    };
+    let mut medals = rkyv::api::deserialize_using::<_, _, Panic>(
+        With::<_, Map<MedalCompactRkyv>>::cast(&user.medals),
+        &mut (),
+    )
+    .always_ok();
 
     medals.sort_unstable_by_key(|medal| medal.achieved_at);
 
     let bytes = match medals_stats::graph(&medals, W, H) {
         Ok(Some(graph)) => graph,
         Ok(None) => {
-            let content = format!("`{}` does not have any medals", user.username());
+            let content = format!("`{}` does not have any medals", user.username.as_str());
             let builder = MessageBuilder::new().embed(content);
             orig.create_message(builder).await?;
 

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -1,7 +1,4 @@
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    MessageBuilder,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 
@@ -9,9 +6,7 @@ use super::{H, W};
 use crate::{
     commands::osu::{player_snipe_stats, user_not_found},
     core::{commands::CommandOrigin, Context},
-    manager::redis::{
-        osu::{CachedUser, UserArgs, UserArgsError},
-    },
+    manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
 
 pub async fn snipe_count_graph(

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -1,6 +1,5 @@
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, },
     MessageBuilder,
 };
 use eyre::{Report, Result};
@@ -10,48 +9,37 @@ use super::{H, W};
 use crate::{
     commands::osu::{player_snipe_stats, user_not_found},
     core::{commands::CommandOrigin, Context},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{CachedUser, UserArgs, UserArgsError},
+    },
 };
 
 pub async fn snipe_count_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
     mode: GameMode,
-) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
+) -> Result<Option<(CachedUser, Vec<u8>)>> {
     let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
             orig.error(content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user");
 
             return Err(err);
         }
     };
 
-    let (country_code, username, user_id) = match &user {
-        RedisData::Original(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
-
-            (country_code, username, user_id)
-        }
-        RedisData::Archive(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
-
-            (country_code, username, user_id.to_native())
-        }
-    };
+    let country_code = user.country_code.as_str();
+    let username = user.username.as_str();
+    let user_id = user.user_id.to_native();
 
     let (player, history) = if Context::huismetbenen()
         .is_supported(country_code, mode)

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -1,7 +1,4 @@
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    MessageBuilder,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 
@@ -9,9 +6,7 @@ use super::{H, W};
 use crate::{
     commands::osu::{sniped, user_not_found},
     core::{commands::CommandOrigin, Context},
-    manager::redis::{
-        osu::{CachedUser, UserArgs, UserArgsError},
-    },
+    manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
 
 pub async fn sniped_graph(

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -1,6 +1,5 @@
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, },
     MessageBuilder,
 };
 use eyre::{Report, Result};
@@ -10,48 +9,37 @@ use super::{H, W};
 use crate::{
     commands::osu::{sniped, user_not_found},
     core::{commands::CommandOrigin, Context},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{CachedUser, UserArgs, UserArgsError},
+    },
 };
 
 pub async fn sniped_graph(
     orig: &CommandOrigin<'_>,
     user_id: UserId,
     mode: GameMode,
-) -> Result<Option<(RedisData<User>, Vec<u8>)>> {
+) -> Result<Option<(CachedUser, Vec<u8>)>> {
     let user_args = UserArgs::rosu_id(&user_id, mode).await;
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
             orig.error(content).await?;
 
             return Ok(None);
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user");
 
             return Err(err);
         }
     };
 
-    let (country_code, username, user_id) = match &user {
-        RedisData::Original(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
-
-            (country_code, username, user_id)
-        }
-        RedisData::Archive(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
-
-            (country_code, username, user_id.to_native())
-        }
-    };
+    let country_code = user.country_code.as_str();
+    let username = user.username.as_str();
+    let user_id = user.user_id.to_native();
 
     let (mut sniper, mut snipee) = if Context::huismetbenen()
         .is_supported(country_code, mode)

--- a/bathbot/src/commands/osu/leaderboard.rs
+++ b/bathbot/src/commands/osu/leaderboard.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, cmp::Reverse, collections::HashMap};
 
 use bathbot_macros::{command, HasMods, SlashCommand};
-use bathbot_model::rosu_v2::user::User;
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
     constants::{GENERAL_ISSUE, OSU_API_ISSUE},
@@ -27,7 +26,7 @@ use crate::{
     active::{impls::LeaderboardPagination, ActiveMessages},
     core::commands::{prefix::Args, CommandOrigin},
     manager::{
-        redis::{osu::UserArgs, RedisData},
+        redis::osu::{CachedUser, UserArgs, UserArgsError},
         MapError, Mods, OsuMap,
     },
     util::{interaction::InteractionCommand, osu::MapOrScore, ChannelExt, InteractionCommandExt},
@@ -336,7 +335,7 @@ async fn leaderboard(orig: CommandOrigin<'_>, args: LeaderboardArgs<'_>) -> Resu
             .map(|(i, mut score)| {
                 let username = match score.user.take() {
                     Some(user) => {
-                        avatar_urls.insert(score.id, user.avatar_url);
+                        avatar_urls.insert(score.id, user.avatar_url.into_boxed_str());
 
                         user.username
                     }
@@ -362,8 +361,8 @@ async fn leaderboard(orig: CommandOrigin<'_>, args: LeaderboardArgs<'_>) -> Resu
         .map(|(user, score)| LeaderboardUserScore {
             discord_id: owner,
             score: LeaderboardScore::new(
-                user.user_id(),
-                user.username().into(),
+                user.user_id.to_native(),
+                user.username.as_str().into(),
                 score.score,
                 score.pos,
             ),
@@ -457,7 +456,7 @@ async fn get_user_score(
     mode: GameMode,
     mods: Option<GameModsIntermode>,
     legacy_scores: bool,
-) -> Result<Option<(RedisData<User>, BeatmapUserScore)>> {
+) -> Result<Option<(CachedUser, BeatmapUserScore)>> {
     let Some(user_id) = osu_id else {
         return Ok(None);
     };
@@ -468,11 +467,21 @@ async fn get_user_score(
     let score_fut =
         Context::osu_scores().user_on_map_single(user_id, map_id, mode, mods, legacy_scores);
 
-    match tokio::try_join!(user_fut, score_fut) {
-        Ok(tuple) => Ok(Some(tuple)),
-        Err(OsuError::NotFound) => Ok(None),
-        Err(err) => Err(Report::new(err).wrap_err("Failed to get score or user")),
-    }
+    let (user_res, score_res) = tokio::join!(user_fut, score_fut);
+
+    let user = match user_res {
+        Ok(user) => user,
+        Err(UserArgsError::Osu(OsuError::NotFound)) => return Ok(None),
+        Err(err) => return Err(Report::new(err).wrap_err("Failed to get user")),
+    };
+
+    let score = match score_res {
+        Ok(score) => score,
+        Err(OsuError::NotFound) => return Ok(None),
+        Err(err) => return Err(Report::new(err).wrap_err("Failed to get score")),
+    };
+
+    Ok(Some((user, score)))
 }
 
 pub struct LeaderboardScore {

--- a/bathbot/src/commands/osu/mapper.rs
+++ b/bathbot/src/commands/osu/mapper.rs
@@ -6,10 +6,7 @@ use std::{
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::{command_fields::GameModeOption, embed_builder::SettingsImage};
 use bathbot_psql::model::configs::{GuildConfig, ListSize, ScoreData};
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher, CowUtils,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, CowUtils};
 use eyre::{Report, Result};
 use rosu_v2::{
     prelude::{GameMode, OsuError, Score},
@@ -29,10 +26,7 @@ use crate::{
     },
     commands::utility::{MissAnalyzerCheck, ScoreEmbedDataPersonalBest, ScoreEmbedDataWrap},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{
-        osu::{UserArgs, UserArgsError},
-        
-    },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, ChannelExt, CheckPermissions, InteractionCommandExt},
     Context,
 };

--- a/bathbot/src/commands/osu/mapper.rs
+++ b/bathbot/src/commands/osu/mapper.rs
@@ -7,7 +7,7 @@ use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::{command_fields::GameModeOption, embed_builder::SettingsImage};
 use bathbot_psql::model::configs::{GuildConfig, ListSize, ScoreData};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, },
     matcher, CowUtils,
 };
 use eyre::{Report, Result};
@@ -29,7 +29,10 @@ use crate::{
     },
     commands::utility::{MissAnalyzerCheck, ScoreEmbedDataPersonalBest, ScoreEmbedDataWrap},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{UserArgs, UserArgsError},
+        
+    },
     util::{interaction::InteractionCommand, ChannelExt, CheckPermissions, InteractionCommandExt},
     Context,
 };
@@ -267,30 +270,28 @@ async fn mapper(orig: CommandOrigin<'_>, args: Mapper<'_>) -> Result<()> {
 
     let (mapper, user, scores) = match tokio::join!(mapper_fut, scores_fut) {
         (Ok(mapper), Ok((user, scores))) => (mapper, user, scores),
-        (Err(OsuError::NotFound), _) => {
+        (Err(UserArgsError::Osu(OsuError::NotFound)), _) => {
             let content = format!("Mapper with username `{mapper}` was not found");
 
             return orig.error(content).await;
         }
-        (_, Err(OsuError::NotFound)) => {
+        (_, Err(UserArgsError::Osu(OsuError::NotFound))) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         (Err(err), _) | (_, Err(err)) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get mapper, user, or scores");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get mapper, user, or scores");
 
             return Err(err);
         }
     };
 
-    let (mapper_name, mapper_id) = match &mapper {
-        RedisData::Original(mapper) => (mapper.username.as_str(), mapper.user_id),
-        RedisData::Archive(mapper) => (mapper.username.as_str(), mapper.user_id.to_native()),
-    };
+    let mapper_name = mapper.username.as_str();
+    let mapper_id = mapper.user_id.to_native();
 
-    let username = user.username();
+    let username = user.username.as_str();
     let settings = config.score_embed.unwrap_or_default();
 
     let mut with_render = match (guild_render_button, config.render_button) {

--- a/bathbot/src/commands/osu/medals/common.rs
+++ b/bathbot/src/commands/osu/medals/common.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use bathbot_macros::command;
-use bathbot_model::{ MedalGroup, OsekaiMedal, Rarity};
+use bathbot_model::{MedalGroup, OsekaiMedal, Rarity};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSEKAI_ISSUE, },
+    constants::{GENERAL_ISSUE, OSEKAI_ISSUE},
     matcher, IntHasher,
 };
 use eyre::{Report, Result};

--- a/bathbot/src/commands/osu/medals/medal.rs
+++ b/bathbot/src/commands/osu/medals/medal.rs
@@ -397,22 +397,9 @@ impl MedalEmbed {
         let achieved = achieved.map(|achieved| {
             let user = achieved.user;
 
-            let (country_code, username, user_id) = match &user {
-                RedisData::Original(user) => {
-                    let country_code = user.country_code.as_str();
-                    let username = user.username.as_str();
-                    let user_id = user.user_id;
-
-                    (country_code, username, user_id)
-                }
-                RedisData::Archive(user) => {
-                    let country_code = user.country_code.as_str();
-                    let username = user.username.as_str();
-                    let user_id = user.user_id;
-
-                    (country_code, username, user_id.to_native())
-                }
-            };
+            let country_code = user.country_code.as_str();
+            let username = user.username.as_str();
+            let user_id = user.user_id.to_native();
 
             let mut author_url = format!("{OSU_BASE}users/{user_id}");
 

--- a/bathbot/src/commands/osu/medals/missing.rs
+++ b/bathbot/src/commands/osu/medals/missing.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cmp::Ordering};
 use bathbot_macros::command;
 use bathbot_model::{MedalGroup, OsekaiMedal, MEDAL_GROUPS};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSEKAI_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, OSEKAI_ISSUE},
     matcher, IntHasher,
 };
 use eyre::{Report, Result};
@@ -16,7 +16,10 @@ use crate::{
     active::{impls::MedalsMissingPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
     core::commands::CommandOrigin,
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{UserArgs, UserArgsError},
+        RedisData,
+    },
     Context,
 };
 
@@ -68,7 +71,7 @@ pub(super) async fn missing(orig: CommandOrigin<'_>, args: MedalMissing<'_>) -> 
 
     let (user, all_medals) = match tokio::join!(user_fut, medals_fut) {
         (Ok(user), Ok(medals)) => (user, medals),
-        (Err(OsuError::NotFound), _) => {
+        (Err(UserArgsError::Osu(OsuError::NotFound)), _) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
@@ -79,29 +82,20 @@ pub(super) async fn missing(orig: CommandOrigin<'_>, args: MedalMissing<'_>) -> 
             return Err(err.wrap_err("failed to get cached medals"));
         }
         (Err(err), _) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let report = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let report = Report::new(err).wrap_err("Failed to get user");
 
             return Err(report);
         }
     };
 
-    let (user_medals_count, owned): (_, HashSet<_, IntHasher>) = match &user {
-        RedisData::Original(user) => {
-            let owned = user.medals.iter().map(|medal| medal.medal_id).collect();
+    let user_medals_count = user.medals.len();
 
-            (user.medals.len(), owned)
-        }
-        RedisData::Archive(user) => {
-            let owned = user
-                .medals
-                .iter()
-                .map(|medal| medal.medal_id.to_native())
-                .collect();
-
-            (user.medals.len(), owned)
-        }
-    };
+    let owned: HashSet<_, IntHasher> = user
+        .medals
+        .iter()
+        .map(|medal| medal.medal_id.to_native())
+        .collect();
 
     let (medal_count, mut medals): (_, Vec<_>) = match all_medals {
         RedisData::Original(all_medals) => {

--- a/bathbot/src/commands/osu/most_played.rs
+++ b/bathbot/src/commands/osu/most_played.rs
@@ -97,7 +97,9 @@ async fn mostplayed(orig: CommandOrigin<'_>, args: MostPlayed<'_>) -> Result<()>
         }
     };
 
-    let maps_fut = Context::osu().user_most_played(user.user_id.to_native()).limit(100);
+    let maps_fut = Context::osu()
+        .user_most_played(user.user_id.to_native())
+        .limit(100);
 
     let maps = match maps_fut.await {
         Ok(maps) => maps,

--- a/bathbot/src/commands/osu/nochoke.rs
+++ b/bathbot/src/commands/osu/nochoke.rs
@@ -3,11 +3,7 @@ use std::borrow::Cow;
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::ScoreSlim;
 use bathbot_psql::model::configs::ScoreData;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher,
-    osu::calculate_grade,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, osu::calculate_grade};
 use eyre::{Report, Result};
 use rosu_pp::any::DifficultyAttributes;
 use rosu_v2::{
@@ -21,7 +17,10 @@ use super::{require_link, user_not_found};
 use crate::{
     active::{impls::NoChokePagination, ActiveMessages},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::{redis::osu::{UserArgs, UserArgsError}, OsuMap},
+    manager::{
+        redis::osu::{UserArgs, UserArgsError},
+        OsuMap,
+    },
     util::{interaction::InteractionCommand, osu::IfFc, InteractionCommandExt},
     Context,
 };
@@ -269,7 +268,13 @@ async fn nochoke(orig: CommandOrigin<'_>, args: Nochoke<'_>) -> Result<()> {
         .zip(0..)
         .fold(0.0, |sum, (pp, i)| sum + pp * 0.95_f32.powi(i));
 
-    let bonus_pp = user.statistics.as_ref().expect("missing stats").pp.to_native() - actual_pp;
+    let bonus_pp = user
+        .statistics
+        .as_ref()
+        .expect("missing stats")
+        .pp
+        .to_native()
+        - actual_pp;
 
     // Sort by unchoked pp
     entries.sort_unstable_by(|a, b| b.unchoked_pp().total_cmp(&a.unchoked_pp()));

--- a/bathbot/src/commands/osu/pp.rs
+++ b/bathbot/src/commands/osu/pp.rs
@@ -2,10 +2,7 @@ use std::borrow::Cow;
 
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::command_fields::GameModeOption;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher, MessageBuilder,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::prelude::OsuError;
 use twilight_interactions::command::{CommandModel, CreateCommand};
@@ -15,10 +12,7 @@ use super::user_not_found;
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, PpMissingEmbed},
-    manager::redis::{
-        osu::{UserArgs, UserArgsError},
-        
-    },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,
 };

--- a/bathbot/src/commands/osu/pp.rs
+++ b/bathbot/src/commands/osu/pp.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::command_fields::GameModeOption;
-use bathbot_util::{constants::OSU_API_ISSUE, matcher, MessageBuilder};
+use bathbot_util::{
+    constants::{GENERAL_ISSUE, },
+    matcher, MessageBuilder,
+};
 use eyre::{Report, Result};
 use rosu_v2::prelude::OsuError;
 use twilight_interactions::command::{CommandModel, CreateCommand};
@@ -12,7 +15,10 @@ use super::user_not_found;
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, PpMissingEmbed},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{
+        osu::{UserArgs, UserArgsError},
+        
+    },
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,
 };
@@ -206,13 +212,13 @@ async fn pp(orig: CommandOrigin<'_>, args: Pp<'_>) -> Result<()> {
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
+            let _ = orig.error(GENERAL_ISSUE).await;
             let err = Report::new(err).wrap_err("Failed to get user or scores");
 
             return Err(err);
@@ -221,16 +227,10 @@ async fn pp(orig: CommandOrigin<'_>, args: Pp<'_>) -> Result<()> {
 
     let target_pp = match pp {
         PpValue::Raw(value) => value,
-        PpValue::Delta(value) => match user {
-            RedisData::Original(ref user) => user
-                .statistics
-                .as_ref()
-                .map_or(value, |stats| stats.pp + value),
-            RedisData::Archive(ref user) => user
-                .statistics
-                .as_ref()
-                .map_or(value, |stats| stats.pp + value),
-        },
+        PpValue::Delta(value) => user
+            .statistics
+            .as_ref()
+            .map_or(value, |stats| stats.pp + value),
     };
 
     let rank = match Context::approx().rank(target_pp, mode).await {

--- a/bathbot/src/commands/osu/profile.rs
+++ b/bathbot/src/commands/osu/profile.rs
@@ -3,10 +3,7 @@ use std::borrow::Cow;
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::command_fields::GameModeOption;
 use bathbot_psql::model::configs::ScoreData;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher, CowUtils, MessageOrigin,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, CowUtils, MessageOrigin};
 use eyre::{Report, Result};
 use rosu_v2::{
     prelude::{GameMode, OsuError},

--- a/bathbot/src/commands/osu/ranking/players.rs
+++ b/bathbot/src/commands/osu/ranking/players.rs
@@ -87,13 +87,13 @@ async fn pp_author_idx(
         Ok(user) => {
             let idx = match country {
                 Some(code) => {
-                    if user.country_code() == code.as_str() {
-                        Some(user.stats().country_rank())
+                    if user.country_code.as_str() == code.as_str() {
+                        Some(user.statistics.as_ref().expect("missing stats").country_rank.to_native())
                     } else {
                         None
                     }
                 }
-                None => Some(user.stats().global_rank()),
+                None => Some(user.statistics.as_ref().expect("missing stats").global_rank.to_native()),
             };
 
             idx.filter(|n| (1..=10_000).contains(n))

--- a/bathbot/src/commands/osu/ranking/players.rs
+++ b/bathbot/src/commands/osu/ranking/players.rs
@@ -88,12 +88,24 @@ async fn pp_author_idx(
             let idx = match country {
                 Some(code) => {
                     if user.country_code.as_str() == code.as_str() {
-                        Some(user.statistics.as_ref().expect("missing stats").country_rank.to_native())
+                        Some(
+                            user.statistics
+                                .as_ref()
+                                .expect("missing stats")
+                                .country_rank
+                                .to_native(),
+                        )
                     } else {
                         None
                     }
                 }
-                None => Some(user.statistics.as_ref().expect("missing stats").global_rank.to_native()),
+                None => Some(
+                    user.statistics
+                        .as_ref()
+                        .expect("missing stats")
+                        .global_rank
+                        .to_native(),
+                ),
             };
 
             idx.filter(|n| (1..=10_000).contains(n))

--- a/bathbot/src/commands/osu/ratios.rs
+++ b/bathbot/src/commands/osu/ratios.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_psql::model::configs::ScoreData;
-use bathbot_util::{constants::OSU_API_ISSUE, matcher, MessageBuilder};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::{
     prelude::{GameMode, OsuError},
@@ -15,7 +15,7 @@ use super::{require_link, user_not_found};
 use crate::{
     core::commands::CommandOrigin,
     embeds::{EmbedData, RatioEmbed},
-    manager::redis::osu::UserArgs,
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, InteractionCommandExt},
     Context,
 };
@@ -114,14 +114,14 @@ async fn ratios(orig: CommandOrigin<'_>, args: Ratios<'_>) -> Result<()> {
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get user or scores");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user or scores");
 
             return Err(err);
         }
@@ -132,7 +132,7 @@ async fn ratios(orig: CommandOrigin<'_>, args: Ratios<'_>) -> Result<()> {
 
     let content = format!(
         "Average ratios of `{}`'s top 100 in mania:",
-        user.username()
+        user.username.as_str()
     );
 
     // Creating the embed

--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -11,12 +11,7 @@ use bathbot_model::{
     ScoreSlim,
 };
 use bathbot_psql::model::configs::ScoreData;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher,
-    osu::ModSelection,
-    CowUtils, IntHasher,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, osu::ModSelection, CowUtils, IntHasher};
 use eyre::{Report, Result};
 use rosu_v2::{
     prelude::{GameMode, Grade, OsuError, Score},
@@ -28,7 +23,10 @@ use crate::{
     active::{impls::RecentListPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found, HasMods, ModsResult, ScoreOrder},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::{redis::osu::{UserArgs, UserArgsError}, OsuMap},
+    manager::{
+        redis::osu::{UserArgs, UserArgsError},
+        OsuMap,
+    },
     util::{
         query::{IFilterCriteria, RegularCriteria, Searchable},
         ChannelExt,

--- a/bathbot/src/commands/osu/recent/score.rs
+++ b/bathbot/src/commands/osu/recent/score.rs
@@ -6,10 +6,7 @@ use bathbot_model::{
     embed_builder::SettingsImage,
 };
 use bathbot_psql::model::configs::{GuildConfig, Retries, ScoreData};
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher, CowUtils, MessageOrigin,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, CowUtils, MessageOrigin};
 use eyre::{Report, Result};
 use rand::{thread_rng, Rng};
 use rosu_v2::{

--- a/bathbot/src/commands/osu/snipe/country_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_list.rs
@@ -2,10 +2,7 @@ use std::borrow::Cow;
 
 use bathbot_macros::command;
 use bathbot_model::{Countries, SnipeCountryListOrder};
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    CowUtils,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, CowUtils};
 use eyre::{Report, Result};
 use rosu_v2::{
     model::GameMode,
@@ -18,7 +15,7 @@ use crate::{
     active::{impls::SnipeCountryListPagination, ActiveMessages},
     commands::osu::user_not_found,
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{osu::{UserArgs, UserArgsError}, },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::ChannelExt,
     Context,
 };

--- a/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
@@ -2,10 +2,7 @@ use std::{borrow::Cow, cmp::Ordering::Equal};
 
 use bathbot_macros::command;
 use bathbot_model::{Countries, SnipeCountryListOrder, SnipeCountryPlayer};
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    MessageBuilder,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, MessageBuilder};
 use eyre::{ContextCompat, Report, Result, WrapErr};
 use plotters::prelude::*;
 use plotters_skia::SkiaBackend;
@@ -22,7 +19,7 @@ use crate::{
     commands::osu::user_not_found,
     core::commands::CommandOrigin,
     embeds::{CountrySnipeStatsEmbed, EmbedData},
-    manager::redis::{osu::{UserArgs, UserArgsError}, },
+    manager::redis::osu::{UserArgs, UserArgsError},
     Context,
 };
 

--- a/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/country_snipe_stats.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cmp::Ordering::Equal};
 use bathbot_macros::command;
 use bathbot_model::{Countries, SnipeCountryListOrder, SnipeCountryPlayer};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, },
     MessageBuilder,
 };
 use eyre::{ContextCompat, Report, Result, WrapErr};
@@ -22,7 +22,7 @@ use crate::{
     commands::osu::user_not_found,
     core::commands::CommandOrigin,
     embeds::{CountrySnipeStatsEmbed, EmbedData},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{osu::{UserArgs, UserArgsError}, },
     Context,
 };
 
@@ -140,23 +140,20 @@ pub(super) async fn country_stats(
 
                 let user = match Context::redis().osu_user(user_args).await {
                     Ok(user) => user,
-                    Err(OsuError::NotFound) => {
+                    Err(UserArgsError::Osu(OsuError::NotFound)) => {
                         let content = user_not_found(UserId::Id(user_id)).await;
 
                         return orig.error(content).await;
                     }
                     Err(err) => {
-                        let _ = orig.error(OSU_API_ISSUE).await;
+                        let _ = orig.error(GENERAL_ISSUE).await;
                         let err = Report::new(err).wrap_err("Failed to get user");
 
                         return Err(err);
                     }
                 };
 
-                match &user {
-                    RedisData::Original(user) => user.country_code.as_str().into(),
-                    RedisData::Archive(user) => user.country_code.as_str().into(),
-                }
+                user.country_code.as_str().into()
             }
             None => {
                 let content = "Since you're not linked, you must specify a country (code)";

--- a/bathbot/src/commands/osu/snipe/player_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_list.rs
@@ -7,7 +7,7 @@ use std::{
 use bathbot_macros::command;
 use bathbot_model::SnipeScoreParams;
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, },
     matcher,
     osu::ModSelection,
     CowUtils,
@@ -20,7 +20,7 @@ use crate::{
     active::{impls::SnipePlayerListPagination, ActiveMessages},
     commands::osu::{HasMods, ModsResult},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{osu::{UserArgs, UserArgsError}, },
     util::ChannelExt,
     Context,
 };
@@ -137,7 +137,7 @@ pub(super) async fn player_list(orig: CommandOrigin<'_>, args: SnipePlayerList<'
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = match user_id {
                 UserId::Id(user_id) => format!("User with id {user_id} was not found"),
                 UserId::Name(name) => format!("User `{name}` was not found"),
@@ -146,29 +146,17 @@ pub(super) async fn player_list(orig: CommandOrigin<'_>, args: SnipePlayerList<'
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let report = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let report = Report::new(err).wrap_err("Failed to get user");
 
             return Err(report);
         }
     };
 
-    let (country_code, username, user_id) = match &user {
-        RedisData::Original(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
 
-            (country_code, username, user_id)
-        }
-        RedisData::Archive(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
-
-            (country_code, username, user_id.to_native())
-        }
-    };
+    let country_code = user.country_code.as_str();
+    let username = user.username.as_str();
+    let user_id = user.user_id.to_native();
 
     let country = if Context::huismetbenen()
         .is_supported(country_code, mode)

--- a/bathbot/src/commands/osu/snipe/player_snipe_list.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_list.rs
@@ -6,12 +6,7 @@ use std::{
 
 use bathbot_macros::command;
 use bathbot_model::SnipeScoreParams;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher,
-    osu::ModSelection,
-    CowUtils,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, osu::ModSelection, CowUtils};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 
@@ -20,7 +15,7 @@ use crate::{
     active::{impls::SnipePlayerListPagination, ActiveMessages},
     commands::osu::{HasMods, ModsResult},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{osu::{UserArgs, UserArgsError}, },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::ChannelExt,
     Context,
 };
@@ -152,7 +147,6 @@ pub(super) async fn player_list(orig: CommandOrigin<'_>, args: SnipePlayerList<'
             return Err(report);
         }
     };
-
 
     let country_code = user.country_code.as_str();
     let username = user.username.as_str();

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -19,7 +19,7 @@ use crate::{
     commands::osu::require_link,
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, PlayerSnipeStatsEmbed},
-    manager::redis::{osu::UserArgs, RedisData},
+    manager::redis::{osu::{UserArgs, UserArgsError}, },
     util::Monthly,
     Context,
 };
@@ -125,7 +125,7 @@ pub(super) async fn player_stats(
 
     let user = match Context::redis().osu_user(user_args).await {
         Ok(user) => user,
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = match user_id {
                 UserId::Id(user_id) => format!("User with id {user_id} was not found"),
                 UserId::Name(name) => format!("User `{name}` was not found"),
@@ -134,29 +134,17 @@ pub(super) async fn player_stats(
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let report = Report::new(err).wrap_err("failed to get user");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let report = Report::new(err).wrap_err("Failed to get user");
 
             return Err(report);
         }
     };
 
-    let (country_code, username, user_id) = match &user {
-        RedisData::Original(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
 
-            (country_code, username, user_id)
-        }
-        RedisData::Archive(user) => {
-            let country_code = user.country_code.as_str();
-            let username = user.username.as_str();
-            let user_id = user.user_id;
-
-            (country_code, username, user_id.to_native())
-        }
-    };
+    let country_code = user.country_code.as_str();
+    let username = user.username.as_str();
+    let user_id = user.user_id.to_native();
 
     let client = Context::client();
 

--- a/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
+++ b/bathbot/src/commands/osu/snipe/player_snipe_stats.rs
@@ -19,7 +19,7 @@ use crate::{
     commands::osu::require_link,
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, PlayerSnipeStatsEmbed},
-    manager::redis::{osu::{UserArgs, UserArgsError}, },
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::Monthly,
     Context,
 };
@@ -140,7 +140,6 @@ pub(super) async fn player_stats(
             return Err(report);
         }
     };
-
 
     let country_code = user.country_code.as_str();
     let username = user.username.as_str();

--- a/bathbot/src/commands/osu/snipe/sniped.rs
+++ b/bathbot/src/commands/osu/snipe/sniped.rs
@@ -2,11 +2,7 @@ use std::ops;
 
 use bathbot_macros::command;
 use bathbot_model::SnipedWeek;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    datetime::DATE_FORMAT,
-    matcher, MessageBuilder,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, datetime::DATE_FORMAT, matcher, MessageBuilder};
 use eyre::{ContextCompat, Report, Result, WrapErr};
 use plotters::{
     coord::{
@@ -26,10 +22,7 @@ use super::{SnipeGameMode, SnipePlayerSniped};
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, SnipedEmbed},
-    manager::redis::{
-        osu::{UserArgs, UserArgsError},
-        
-    },
+    manager::redis::osu::{UserArgs, UserArgsError},
     Context,
 };
 

--- a/bathbot/src/commands/osu/snipe/sniped_difference.rs
+++ b/bathbot/src/commands/osu/snipe/sniped_difference.rs
@@ -1,10 +1,7 @@
 use std::{cmp::Reverse, collections::HashMap};
 
 use bathbot_macros::command;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher, IntHasher, MessageBuilder,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, IntHasher, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use time::{Duration, OffsetDateTime};
@@ -13,10 +10,7 @@ use super::{SnipeGameMode, SnipePlayerGain, SnipePlayerLoss};
 use crate::{
     active::{impls::SnipeDifferencePagination, ActiveMessages},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::{
-        osu::{UserArgs, UserArgsError},
-        
-    },
+    manager::redis::osu::{UserArgs, UserArgsError},
     Context,
 };
 

--- a/bathbot/src/commands/osu/top/if_.rs
+++ b/bathbot/src/commands/osu/top/if_.rs
@@ -4,11 +4,7 @@ use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::{command_fields::GameModeOption, ScoreSlim};
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher,
-    numbers::round,
-    osu::ModSelection,
-    CowUtils,
+    constants::GENERAL_ISSUE, matcher, numbers::round, osu::ModSelection, CowUtils,
 };
 use eyre::{Report, Result};
 use rosu_v2::{
@@ -22,7 +18,10 @@ use crate::{
     active::{impls::TopIfPagination, ActiveMessages},
     commands::osu::{require_link, user_not_found},
     core::commands::{prefix::Args, CommandOrigin},
-    manager::{redis::osu::{UserArgs, UserArgsError}, OsuMap},
+    manager::{
+        redis::osu::{UserArgs, UserArgsError},
+        OsuMap,
+    },
     util::{
         interaction::InteractionCommand,
         query::{FilterCriteria, IFilterCriteria, Searchable, TopCriteria},
@@ -261,9 +260,21 @@ async fn topif(orig: CommandOrigin<'_>, args: TopIf<'_>) -> Result<()> {
         .filter_map(|s| s.weight)
         .fold(0.0, |sum, weight| sum + weight.pp);
 
-    let bonus_pp = user.statistics.as_ref().expect("missing stats").pp.to_native() - actual_pp;
+    let bonus_pp = user
+        .statistics
+        .as_ref()
+        .expect("missing stats")
+        .pp
+        .to_native()
+        - actual_pp;
     let sort = args.sort.unwrap_or_default();
-    let content = get_content(user.username.as_str(), mode, &mods, args.query.as_deref(), sort);
+    let content = get_content(
+        user.username.as_str(),
+        mode,
+        &mods,
+        args.query.as_deref(),
+        sort,
+    );
 
     let mut entries = match process_scores(scores, mods, mode, sort, legacy_scores).await {
         Ok(scores) => scores,
@@ -297,7 +308,12 @@ async fn topif(orig: CommandOrigin<'_>, args: TopIf<'_>) -> Result<()> {
     };
 
     // Accumulate all necessary data
-    let pre_pp = user.statistics.as_ref().expect("missing stats").pp.to_native();
+    let pre_pp = user
+        .statistics
+        .as_ref()
+        .expect("missing stats")
+        .pp
+        .to_native();
 
     let pagination = TopIfPagination::builder()
         .user(user)

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -7,11 +7,7 @@ use bathbot_model::{
 };
 use bathbot_psql::model::configs::{GuildConfig, ListSize, ScoreData};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher,
-    numbers::round,
-    osu::ModSelection,
-    CowUtils,
+    constants::GENERAL_ISSUE, matcher, numbers::round, osu::ModSelection, CowUtils,
 };
 use eyre::{Report, Result};
 use rand::{thread_rng, Rng};

--- a/bathbot/src/commands/osu/top/mod.rs
+++ b/bathbot/src/commands/osu/top/mod.rs
@@ -7,7 +7,7 @@ use bathbot_model::{
 };
 use bathbot_psql::model::configs::{GuildConfig, ListSize, ScoreData};
 use bathbot_util::{
-    constants::{GENERAL_ISSUE, OSU_API_ISSUE},
+    constants::{GENERAL_ISSUE, },
     matcher,
     numbers::round,
     osu::ModSelection,
@@ -36,7 +36,7 @@ use crate::{
         MissAnalyzerCheck, ScoreEmbedDataHalf, ScoreEmbedDataPersonalBest, ScoreEmbedDataWrap,
     },
     core::commands::{prefix::Args, CommandOrigin},
-    manager::redis::osu::UserArgs,
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{
         interaction::InteractionCommand,
         query::{IFilterCriteria, Searchable, TopCriteria},
@@ -796,14 +796,14 @@ pub(super) async fn top(orig: CommandOrigin<'_>, args: TopArgs<'_>) -> Result<()
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
-            let err = Report::new(err).wrap_err("failed to get user or scores");
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user or scores");
 
             return Err(err);
         }
@@ -834,7 +834,7 @@ pub(super) async fn top(orig: CommandOrigin<'_>, args: TopArgs<'_>) -> Result<()
     };
 
     let post_len = entries.len();
-    let username = user.username();
+    let username = user.username.as_str();
 
     let index = match args.index.as_deref() {
         Some("random" | "?") => (post_len > 0).then(|| thread_rng().gen_range(1..=post_len)),

--- a/bathbot/src/commands/osu/top/old.rs
+++ b/bathbot/src/commands/osu/top/old.rs
@@ -3,12 +3,7 @@ use std::{borrow::Cow, cmp::Ordering};
 use bathbot_macros::{command, HasMods, HasName, SlashCommand};
 use bathbot_model::ScoreSlim;
 use bathbot_psql::model::configs::ScoreData;
-use bathbot_util::{
-    constants::{GENERAL_ISSUE, },
-    matcher,
-    numbers::round,
-    osu::ModSelection,
-};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, numbers::round, osu::ModSelection};
 use eyre::{Report, Result};
 use rosu_pp_older::*;
 use rosu_v2::{

--- a/bathbot/src/commands/osu/whatif.rs
+++ b/bathbot/src/commands/osu/whatif.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, iter};
 use bathbot_macros::{command, HasName, SlashCommand};
 use bathbot_model::command_fields::GameModeOption;
 use bathbot_util::{
-    constants::OSU_API_ISSUE,
+    constants::GENERAL_ISSUE,
     matcher,
     osu::{approx_more_pp, ExtractablePp, PpListUtil},
     MessageBuilder,
@@ -17,7 +17,7 @@ use super::user_not_found;
 use crate::{
     core::commands::{prefix::Args, CommandOrigin},
     embeds::{EmbedData, WhatIfEmbed},
-    manager::redis::osu::UserArgs,
+    manager::redis::osu::{UserArgs, UserArgsError},
     util::{interaction::InteractionCommand, ChannelExt, InteractionCommandExt},
     Context,
 };
@@ -211,13 +211,13 @@ async fn whatif(orig: CommandOrigin<'_>, args: WhatIf<'_>) -> Result<()> {
 
     let (user, scores) = match scores_fut.await {
         Ok((user, scores)) => (user, scores),
-        Err(OsuError::NotFound) => {
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
             let content = user_not_found(user_id).await;
 
             return orig.error(content).await;
         }
         Err(err) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
+            let _ = orig.error(GENERAL_ISSUE).await;
             let err = Report::new(err).wrap_err("Failed to get user or scores");
 
             return Err(err);
@@ -247,7 +247,12 @@ async fn whatif(orig: CommandOrigin<'_>, args: WhatIf<'_>) -> Result<()> {
         let max_pp = pps.first().copied().unwrap_or(0.0);
         approx_more_pp(&mut pps, 50);
         let actual = pps.accum_weighted();
-        let total = user.stats().pp();
+        let total = user
+            .statistics
+            .as_ref()
+            .expect("missing stats")
+            .pp
+            .to_native();
         let bonus_pp = (total - actual).max(0.0);
 
         let idx = pps

--- a/bathbot/src/commands/tracking/track.rs
+++ b/bathbot/src/commands/tracking/track.rs
@@ -1,14 +1,14 @@
 use std::fmt::Write;
 
 use bathbot_macros::command;
-use bathbot_util::{constants::OSU_API_ISSUE, fields, EmbedBuilder, FooterBuilder, MessageBuilder};
+use bathbot_util::{constants::GENERAL_ISSUE, fields, EmbedBuilder, FooterBuilder, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::prelude::{GameMode, OsuError};
 
 use super::TrackArgs;
 use crate::{
     core::commands::CommandOrigin,
-    manager::redis::osu::UserArgsSlim,
+    manager::redis::osu::{UserArgsError, UserArgsSlim},
     tracking::{OsuTracking, TrackEntryParams},
     util::{ChannelExt, Emote},
     Context,
@@ -39,13 +39,13 @@ pub(super) async fn track(orig: CommandOrigin<'_>, args: TrackArgs) -> Result<()
 
     let users = match super::get_names(&more_names, mode).await {
         Ok(users) => users,
-        Err((OsuError::NotFound, name)) => {
+        Err((UserArgsError::Osu(OsuError::NotFound), name)) => {
             let content = format!("User `{name}` was not found");
 
             return orig.error(content).await;
         }
         Err((err, _)) => {
-            let _ = orig.error(OSU_API_ISSUE).await;
+            let _ = orig.error(GENERAL_ISSUE).await;
             let err = Report::new(err).wrap_err("Failed to get names");
 
             return Err(err);

--- a/bathbot/src/embeds/osu/fix_score.rs
+++ b/bathbot/src/embeds/osu/fix_score.rs
@@ -1,7 +1,6 @@
 use std::{cmp::Ordering, convert::identity, fmt::Write};
 
 use bathbot_macros::EmbedData;
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     constants::OSU_BASE,
     numbers::{round, WithComma},
@@ -13,7 +12,8 @@ use time::OffsetDateTime;
 
 use crate::{
     commands::osu::{FixEntry, FixScore},
-    manager::redis::RedisData,
+    manager::redis::osu::CachedUser,
+    util::CachedUserExt,
 };
 
 #[derive(EmbedData)]
@@ -147,7 +147,7 @@ struct NewPp {
 }
 
 impl NewPp {
-    fn new(pp: f32, user: &RedisData<User>, scores: &[Score], datetime: OffsetDateTime) -> NewPp {
+    fn new(pp: f32, user: &CachedUser, scores: &[Score], datetime: OffsetDateTime) -> NewPp {
         let datetime = datetime.unix_timestamp();
 
         let old_idx = scores
@@ -172,7 +172,12 @@ impl NewPp {
         }
 
         let new_weighted = extracted_pp.accum_weighted();
-        let total = user.stats().pp();
+        let total = user
+            .statistics
+            .as_ref()
+            .expect("missing stats")
+            .pp
+            .to_native();
         let new_total = total - old_weighted + new_weighted;
 
         NewPp {

--- a/bathbot/src/embeds/osu/osustats_counts.rs
+++ b/bathbot/src/embeds/osu/osustats_counts.rs
@@ -1,14 +1,16 @@
 use std::fmt::Write;
 
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{AuthorBuilder, CowUtils, EmbedBuilder, FooterBuilder};
 use rosu_v2::prelude::GameMode;
 use time::OffsetDateTime;
 
 use crate::{
     embeds::EmbedData,
-    manager::redis::RedisData,
-    util::osu::{TopCount, TopCounts},
+    manager::redis::osu::CachedUser,
+    util::{
+        osu::{TopCount, TopCounts},
+        CachedUserExt,
+    },
 };
 
 pub struct OsuStatsCountsEmbed {
@@ -20,7 +22,7 @@ pub struct OsuStatsCountsEmbed {
 }
 
 impl OsuStatsCountsEmbed {
-    pub fn new(user: &RedisData<User>, mode: GameMode, counts: TopCounts) -> Self {
+    pub fn new(user: &CachedUser, mode: GameMode, counts: TopCounts) -> Self {
         let count_len = counts.count_len();
 
         let footer_timestamp = counts
@@ -52,11 +54,11 @@ impl OsuStatsCountsEmbed {
         Self {
             description,
             author: user.author_builder(),
-            thumbnail: user.avatar_url().to_owned(),
+            thumbnail: user.avatar_url.as_ref().to_owned(),
             footer_timestamp,
             title: format!(
                 "In how many top X {mode}map leaderboards is {}?",
-                user.username().cow_escape_markdown()
+                user.username.as_str().cow_escape_markdown()
             ),
         }
     }

--- a/bathbot/src/embeds/osu/player_snipe_stats.rs
+++ b/bathbot/src/embeds/osu/player_snipe_stats.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use bathbot_macros::EmbedData;
-use bathbot_model::{rosu_v2::user::User, SnipePlayer};
+use bathbot_model::SnipePlayer;
 use bathbot_util::{
     constants::OSU_BASE,
     datetime::HowLongAgoDynamic,
@@ -16,8 +16,8 @@ use twilight_model::channel::message::embed::EmbedField;
 use crate::{
     core::Context,
     embeds::{attachment, osu},
-    manager::{redis::RedisData, OsuMap},
-    util::osu::GradeCompletionFormatter,
+    manager::{redis::osu::CachedUser, OsuMap},
+    util::{osu::GradeCompletionFormatter, CachedUserExt},
 };
 
 #[derive(EmbedData)]
@@ -34,7 +34,7 @@ pub struct PlayerSnipeStatsEmbed {
 
 impl PlayerSnipeStatsEmbed {
     pub async fn new(
-        user: &RedisData<User>,
+        user: &CachedUser,
         player: SnipePlayer,
         oldest: Option<&(Score, OsuMap)>,
     ) -> Self {
@@ -128,22 +128,9 @@ impl PlayerSnipeStatsEmbed {
             (description, fields)
         };
 
-        let (user_id, country_code, avatar_url) = match user {
-            RedisData::Original(user) => {
-                let user_id = user.user_id;
-                let country_code = user.country_code.as_str();
-                let avatar_url = user.avatar_url.as_ref();
-
-                (user_id, country_code, avatar_url)
-            }
-            RedisData::Archive(user) => {
-                let user_id = user.user_id;
-                let country_code = user.country_code.as_str();
-                let avatar_url = user.avatar_url.as_ref();
-
-                (user_id.to_native(), country_code, avatar_url)
-            }
-        };
+        let user_id = user.user_id.to_native();
+        let country_code = user.country_code.as_str();
+        let avatar_url = user.avatar_url.as_ref();
 
         let url = match oldest.map_or(GameMode::Osu, |(score, _)| score.mode) {
             GameMode::Osu => format!(

--- a/bathbot/src/embeds/osu/pp_missing.rs
+++ b/bathbot/src/embeds/osu/pp_missing.rs
@@ -5,7 +5,6 @@ use std::{
     iter,
 };
 
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::{
     numbers::WithComma,
     osu::{approx_more_pp, pp_missing, ExtractablePp, PpListUtil},
@@ -13,7 +12,7 @@ use bathbot_util::{
 };
 use rosu_v2::prelude::Score;
 
-use crate::{embeds::EmbedData, manager::redis::RedisData};
+use crate::{embeds::EmbedData, manager::redis::osu::CachedUser, util::CachedUserExt};
 
 fn idx_suffix(idx: usize) -> &'static str {
     match idx % 100 {
@@ -37,16 +36,21 @@ pub struct PpMissingEmbed {
 
 impl PpMissingEmbed {
     pub fn new(
-        user: &RedisData<User>,
+        user: &CachedUser,
         scores: &[Score],
         goal_pp: f32,
         rank: Option<u32>,
         each: Option<f32>,
         amount: Option<u8>,
     ) -> Self {
-        let stats_pp = user.stats().pp();
+        let stats_pp = user
+            .statistics
+            .as_ref()
+            .expect("missing stats")
+            .pp
+            .to_native();
 
-        let username = user.username();
+        let username = user.username.as_str();
 
         let title = format!(
             "What scores is {name} missing to reach {goal_pp}pp?",
@@ -278,7 +282,7 @@ impl PpMissingEmbed {
             author: user.author_builder(),
             description,
             footer,
-            thumbnail: user.avatar_url().to_owned(),
+            thumbnail: user.avatar_url.as_ref().to_owned(),
             title,
         }
     }

--- a/bathbot/src/embeds/osu/ratio.rs
+++ b/bathbot/src/embeds/osu/ratio.rs
@@ -1,14 +1,13 @@
 use std::{collections::BTreeMap, fmt::Write};
 
 use bathbot_macros::EmbedData;
-use bathbot_model::rosu_v2::user::User;
 use bathbot_util::AuthorBuilder;
 use rosu_v2::{
     model::GameMode,
     prelude::{Grade, Score},
 };
 
-use crate::manager::redis::RedisData;
+use crate::{manager::redis::osu::CachedUser, util::CachedUserExt};
 
 #[derive(EmbedData)]
 pub struct RatioEmbed {
@@ -18,7 +17,7 @@ pub struct RatioEmbed {
 }
 
 impl RatioEmbed {
-    pub fn new(user: &RedisData<User>, scores: Vec<Score>) -> Self {
+    pub fn new(user: &CachedUser, scores: Vec<Score>) -> Self {
         let accs = [0, 90, 95, 97, 99];
         let mut categories: BTreeMap<u8, RatioCategory> = BTreeMap::new();
 
@@ -42,7 +41,7 @@ impl RatioEmbed {
             }
         }
 
-        let thumbnail = user.avatar_url().to_owned();
+        let thumbnail = user.avatar_url.as_ref().to_owned();
         let mut description = String::with_capacity(256);
 
         let _ = writeln!(

--- a/bathbot/src/embeds/osu/sniped.rs
+++ b/bathbot/src/embeds/osu/sniped.rs
@@ -1,9 +1,9 @@
 use bathbot_macros::EmbedData;
-use bathbot_model::{rosu_v2::user::User, SnipedWeek};
+use bathbot_model::SnipedWeek;
 use bathbot_util::{fields, AuthorBuilder};
 use twilight_model::channel::message::embed::EmbedField;
 
-use crate::{embeds::attachment, manager::redis::RedisData};
+use crate::{embeds::attachment, manager::redis::osu::CachedUser, util::CachedUserExt};
 
 #[derive(EmbedData)]
 pub struct SnipedEmbed {
@@ -16,11 +16,11 @@ pub struct SnipedEmbed {
 }
 
 impl SnipedEmbed {
-    pub fn new(user: &RedisData<User>, sniper: Vec<SnipedWeek>, snipee: Vec<SnipedWeek>) -> Self {
-        let thumbnail = user.avatar_url().to_owned();
+    pub fn new(user: &CachedUser, sniper: Vec<SnipedWeek>, snipee: Vec<SnipedWeek>) -> Self {
+        let thumbnail = user.avatar_url.as_ref().to_owned();
         let author = user.author_builder();
         let title = "National snipe scores of the last 8 weeks";
-        let username = user.username();
+        let username = user.username.as_str();
 
         if sniper.is_empty() && snipee.is_empty() {
             let description =

--- a/bathbot/src/manager/osu_scores.rs
+++ b/bathbot/src/manager/osu_scores.rs
@@ -1,6 +1,5 @@
 use std::slice;
 
-use bathbot_model::rosu_v2::user::User;
 use eyre::{Result, WrapErr};
 use rosu_v2::{
     model::score::BeatmapUserScore,
@@ -8,10 +7,7 @@ use rosu_v2::{
     OsuResult,
 };
 
-use super::redis::{
-    osu::{UserArgs, UserArgsSlim},
-    RedisData,
-};
+use super::redis::osu::{CachedUser, UserArgs, UserArgsError, UserArgsSlim};
 use crate::core::Context;
 
 #[derive(Clone)]
@@ -229,17 +225,18 @@ impl ScoreArgs {
     pub async fn exec_with_user(
         self,
         user_args: UserArgs,
-    ) -> OsuResult<(RedisData<User>, Vec<Score>)> {
+    ) -> Result<(CachedUser, Vec<Score>), UserArgsError> {
         match user_args {
             UserArgs::Args(args) => {
                 let user_fut = Context::redis().osu_user_from_args(args);
                 let score_fut = self.exec(args);
 
-                tokio::try_join!(user_fut, score_fut)
+                let (user_res, score_res) = tokio::join!(user_fut, score_fut);
+
+                Ok((user_res?, score_res?))
             }
             UserArgs::User { user, mode } => {
-                let args = UserArgsSlim::user_id(user.user_id).mode(mode);
-                let user = RedisData::Original(*user);
+                let args = UserArgsSlim::user_id(user.user_id.to_native()).mode(mode);
                 let scores = self.exec(args).await?;
 
                 Ok((user, scores))

--- a/bathbot/src/manager/redis/osu.rs
+++ b/bathbot/src/manager/redis/osu.rs
@@ -1,31 +1,37 @@
 use std::borrow::Cow;
 
 use bathbot_cache::Cache;
-use bathbot_model::{
-    rkyv_util::time::ArchivedDateTime,
-    rosu_v2::user::{ArchivedUser, ArchivedUserHighestRank, StatsWrapper, User},
-};
-use bathbot_util::{
-    constants::OSU_BASE, numbers::WithComma, osu::flag_url, AuthorBuilder, CowUtils,
-};
-use rkyv::{
-    munge::munge,
-    option::ArchivedOption,
-    rancor::{Panic, ResultExt},
-};
+use bathbot_model::rosu_v2::user::{ArchivedUser, User};
+use bathbot_util::CowUtils;
+use eyre::{Report, WrapErr};
 use rosu_v2::{
-    prelude::{GameMode, OsuError, User as RosuUser},
+    prelude::{GameMode, OsuError, UserExtended},
     request::UserId,
 };
 
-use super::{RedisData, RedisManager, RedisResult};
-use crate::core::{BotMetrics, Context};
+use super::RedisManager;
+use crate::{
+    core::{BotMetrics, Context},
+    util::cached_archive::{serialize_using_arena_and_with, CachedArchive},
+};
+
+pub type CachedUser = CachedArchive<ArchivedUser>;
 
 /// Retrieve an osu user through redis or the osu!api as backup
 pub enum UserArgs {
     Args(UserArgsSlim),
-    User { user: Box<User>, mode: GameMode },
-    Err(OsuError),
+    User { user: CachedUser, mode: GameMode },
+    Err(UserArgsError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UserArgsError {
+    #[error("osu error")]
+    Osu(#[from] OsuError),
+    #[error("serialization error")]
+    Serialization(#[source] Report),
+    #[error("validation error")]
+    Validation(#[source] Report),
 }
 
 impl UserArgs {
@@ -51,42 +57,14 @@ impl UserArgs {
         }
 
         match (Context::osu().user(name).mode(mode).await, alt_name) {
-            (Ok(user), _) => {
-                let user_clone = user.clone();
-
-                tokio::spawn(async move {
-                    Context::osu_user().store(&user_clone, mode).await;
-                    Context::get()
-                        .notify_osutrack_of_user_activity(user_clone.user_id, mode)
-                        .await;
-                });
-
-                Self::User {
-                    user: Box::new(user.into()),
-                    mode,
-                }
-            }
+            (Ok(user), _) => Self::from_user(user, mode),
             (Err(OsuError::NotFound), Some(alt_name)) => {
                 match Context::osu().user(alt_name).mode(mode).await {
-                    Ok(user) => {
-                        let user_clone = user.clone();
-
-                        tokio::spawn(async move {
-                            Context::osu_user().store(&user_clone, mode).await;
-                            Context::get()
-                                .notify_osutrack_of_user_activity(user_clone.user_id, mode)
-                                .await;
-                        });
-
-                        Self::User {
-                            user: Box::new(user.into()),
-                            mode,
-                        }
-                    }
-                    Err(err) => Self::Err(err),
+                    Ok(user) => Self::from_user(user, mode),
+                    Err(err) => Self::Err(UserArgsError::Osu(err)),
                 }
             }
-            (Err(err), _) => Self::Err(err),
+            (Err(err), _) => Self::Err(UserArgsError::Osu(err)),
         }
     }
 
@@ -97,6 +75,30 @@ impl UserArgs {
             Some(name)
         } else {
             None
+        }
+    }
+
+    fn from_user(mut user: UserExtended, mode: GameMode) -> Self {
+        user.mode = mode;
+
+        let archived = match serialize_using_arena_and_with::<_, User>(&user) {
+            Ok(bytes) => match CachedUser::new(bytes) {
+                Ok(archived) => archived,
+                Err(err) => return Self::Err(UserArgsError::Validation(err)),
+            },
+            Err(err) => return Self::Err(UserArgsError::Serialization(Report::new(err))),
+        };
+
+        tokio::spawn(async move {
+            Context::osu_user().store(&user, mode).await;
+            Context::get()
+                .notify_osutrack_of_user_activity(user.user_id, mode)
+                .await;
+        });
+
+        Self::User {
+            user: archived,
+            mode,
         }
     }
 }
@@ -124,13 +126,13 @@ impl UserArgsSlim {
 }
 
 impl TryFrom<UserArgs> for UserArgsSlim {
-    type Error = OsuError;
+    type Error = UserArgsError;
 
     #[inline]
     fn try_from(args: UserArgs) -> Result<Self, Self::Error> {
         match args {
             UserArgs::Args(args) => Ok(args),
-            UserArgs::User { user, mode } => Ok(Self::user_id(user.user_id).mode(mode)),
+            UserArgs::User { user, mode } => Ok(Self::user_id(user.user_id.to_native()).mode(mode)),
             UserArgs::Err(err) => Err(err),
         }
     }
@@ -143,15 +145,15 @@ impl RedisManager {
         format!("osu_user_{user_id}_{}", mode as u8)
     }
 
-    pub async fn osu_user_from_args(self, args: UserArgsSlim) -> RedisResult<User, User, OsuError> {
+    pub async fn osu_user_from_args(self, args: UserArgsSlim) -> Result<CachedUser, UserArgsError> {
         let UserArgsSlim { user_id, mode } = args;
         let key = Self::osu_user_key(user_id, mode);
 
-        let mut conn = match Context::cache().fetch(&key).await {
+        let mut conn = match Context::cache().fetch::<_, User>(&key).await {
             Ok(Ok(user)) => {
                 BotMetrics::inc_redis_hit("osu! user");
 
-                return Ok(RedisData::Archive(user));
+                return CachedUser::new(user.into_bytes()).map_err(UserArgsError::Validation);
             }
             Ok(Err(conn)) => Some(conn),
             Err(err) => {
@@ -163,306 +165,58 @@ impl RedisManager {
 
         let mut user = match Context::osu().user(user_id).mode(mode).await {
             Ok(user) => user,
-            Err(OsuError::NotFound) => {
+            Err(err @ OsuError::NotFound) => {
                 // Remove stats of unknown/restricted users so they don't appear in the
                 // leaderboard
                 if let Err(err) = Context::osu_user().remove_stats_and_scores(user_id).await {
                     warn!(?err, "Failed to remove stats of unknown user");
                 }
 
-                return Err(OsuError::NotFound);
+                return Err(UserArgsError::Osu(err));
             }
-            Err(err) => return Err(err),
+            Err(err) => return Err(UserArgsError::Osu(err)),
         };
 
         user.mode = mode;
-        let user_clone = user.clone();
-        let user = User::from(user);
+
+        let bytes = serialize_using_arena_and_with::<_, User>(&user)
+            .wrap_err_with(|| format!("Failed to serialize key {key}"))
+            .map_err(UserArgsError::Serialization)?;
 
         if let Some(ref mut conn) = conn {
             // Cache users for 10 minutes
-            if let Err(err) = Cache::store(conn, &key, &user, EXPIRE).await {
+            if let Err(err) = Cache::store_raw(conn, &key, bytes.as_slice(), EXPIRE).await {
                 warn!(?err, "Failed to store user");
             }
         }
 
-        drop(conn);
-
         tokio::spawn(async move {
-            Context::osu_user().store(&user_clone, mode).await;
+            Context::osu_user().store(&user, mode).await;
             Context::get()
-                .notify_osutrack_of_user_activity(user_clone.user_id, mode)
+                .notify_osutrack_of_user_activity(user.user_id, mode)
                 .await;
         });
 
-        Ok(RedisData::new(user))
+        CachedUser::new(bytes).map_err(UserArgsError::Validation)
     }
 
-    pub async fn osu_user_from_user(
-        self,
-        mut user: User,
-        mode: GameMode,
-    ) -> RedisResult<User, User, OsuError> {
-        let key = Self::osu_user_key(user.user_id, mode);
-
-        user.mode = mode;
-
-        // Cache users for 10 minutes
-        let store_fut = Context::cache().store_new::<_, _, 64>(&key, &user, EXPIRE);
+    pub async fn osu_user_from_archived(self, user: CachedUser, mode: GameMode) -> CachedUser {
+        let key = Self::osu_user_key(user.user_id.to_native(), mode);
+        let bytes = user.as_bytes();
+        let store_fut = Context::cache().store_new_raw(&key, bytes, EXPIRE);
 
         if let Err(err) = store_fut.await {
-            warn!(?err, "Failed to store user");
+            warn!(?err, "Failed to store key {key}");
         }
 
-        Ok(RedisData::Original(user))
+        user
     }
 
-    pub async fn osu_user(self, args: UserArgs) -> RedisResult<User, User, OsuError> {
+    pub async fn osu_user(self, args: UserArgs) -> Result<CachedUser, UserArgsError> {
         match args {
             UserArgs::Args(args) => self.osu_user_from_args(args).await,
-            UserArgs::User { user, mode } => self.osu_user_from_user(*user, mode).await,
+            UserArgs::User { user, mode } => Ok(self.osu_user_from_archived(user, mode).await),
             UserArgs::Err(err) => Err(err),
-        }
-    }
-}
-
-impl RedisData<User> {
-    pub fn avatar_url(&self) -> &str {
-        match self {
-            RedisData::Original(user) => user.avatar_url.as_ref(),
-            RedisData::Archive(user) => user.avatar_url.as_ref(),
-        }
-    }
-
-    pub fn user_id(&self) -> u32 {
-        match self {
-            RedisData::Original(user) => user.user_id,
-            RedisData::Archive(user) => user.user_id.to_native(),
-        }
-    }
-
-    pub fn username(&self) -> &str {
-        match self {
-            RedisData::Original(user) => user.username.as_str(),
-            RedisData::Archive(user) => user.username.as_str(),
-        }
-    }
-
-    pub fn mode(&self) -> GameMode {
-        match self {
-            RedisData::Original(user) => user.mode,
-            RedisData::Archive(user) => user.mode,
-        }
-    }
-
-    pub fn country_code(&self) -> &str {
-        match self {
-            RedisData::Original(user) => user.country_code.as_str(),
-            RedisData::Archive(user) => user.country_code.as_str(),
-        }
-    }
-
-    pub fn stats(&self) -> StatsWrapper<'_> {
-        let stats_opt = match self {
-            RedisData::Original(user) => user.statistics.as_ref().map(StatsWrapper::Left),
-            RedisData::Archive(user) => user
-                .statistics
-                .as_ref()
-                .map(|stats| {
-                    rkyv::api::deserialize_using::<_, _, Panic>(stats, &mut ()).always_ok()
-                })
-                .map(StatsWrapper::Right),
-        };
-
-        stats_opt.expect("missing statistics")
-    }
-
-    pub fn author_builder(&self) -> AuthorBuilder {
-        match self {
-            RedisData::Original(user) => {
-                let stats = user.statistics.as_ref().expect("missing statistics");
-
-                let text = format!(
-                    "{name}: {pp}pp (#{global} {country}{national})",
-                    name = user.username,
-                    pp = WithComma::new(stats.pp),
-                    global = WithComma::new(stats.global_rank.unwrap_or(0)),
-                    country = user.country_code,
-                    national = stats.country_rank.unwrap_or(0)
-                );
-
-                let url = format!("{OSU_BASE}users/{}/{}", user.user_id, user.mode);
-                let icon = flag_url(&user.country_code);
-
-                AuthorBuilder::new(text).url(url).icon_url(icon)
-            }
-            RedisData::Archive(user) => {
-                let stats = user.statistics.as_ref().expect("missing statistics");
-                let country_code = user.country_code.as_str();
-
-                let text = format!(
-                    "{name}: {pp}pp (#{global} {country_code}{national})",
-                    name = user.username,
-                    pp = WithComma::new(stats.pp.to_native()),
-                    global = WithComma::new(stats.global_rank.to_native()),
-                    national = stats.country_rank
-                );
-
-                let url = format!("{OSU_BASE}users/{}/{}", user.user_id, user.mode);
-                let icon = flag_url(country_code);
-
-                AuthorBuilder::new(text).url(url).icon_url(icon)
-            }
-        }
-    }
-
-    pub fn update(&mut self, user: RosuUser) {
-        match self {
-            RedisData::Original(user_) => {
-                let RosuUser {
-                    avatar_url,
-                    country_code,
-                    last_visit,
-                    user_id,
-                    username,
-                    badges,
-                    follower_count,
-                    graveyard_mapset_count,
-                    guest_mapset_count,
-                    highest_rank,
-                    loved_mapset_count,
-                    monthly_playcounts,
-                    rank_history,
-                    ranked_mapset_count,
-                    replays_watched_counts,
-                    scores_first_count,
-                    statistics,
-                    pending_mapset_count,
-                    medals,
-                    ..
-                } = user;
-
-                user_.avatar_url = avatar_url.into_boxed_str();
-                user_.country_code = country_code;
-                user_.user_id = user_id;
-                user_.username = username;
-
-                if let last_visit @ Some(_) = last_visit {
-                    user_.last_visit = last_visit;
-                }
-
-                if let Some(badges) = badges {
-                    user_.badges = badges;
-                }
-
-                if let Some(follower_count) = follower_count {
-                    user_.follower_count = follower_count;
-                }
-
-                if let Some(graveyard_mapset_count) = graveyard_mapset_count {
-                    user_.graveyard_mapset_count = graveyard_mapset_count;
-                }
-
-                if let Some(guest_mapset_count) = guest_mapset_count {
-                    user_.guest_mapset_count = guest_mapset_count;
-                }
-
-                if let highest_rank @ Some(_) = highest_rank {
-                    user_.highest_rank = highest_rank;
-                }
-
-                if let Some(loved_mapset_count) = loved_mapset_count {
-                    user_.loved_mapset_count = loved_mapset_count;
-                }
-
-                if let Some(monthly_playcounts) = monthly_playcounts {
-                    user_.monthly_playcounts = monthly_playcounts;
-                }
-
-                if let Some(rank_history) = rank_history {
-                    user_.rank_history = rank_history.into_boxed_slice();
-                }
-
-                if let Some(ranked_mapset_count) = ranked_mapset_count {
-                    user_.ranked_mapset_count = ranked_mapset_count;
-                }
-
-                if let Some(replays_watched_counts) = replays_watched_counts {
-                    user_.replays_watched_counts = replays_watched_counts;
-                }
-
-                if let Some(scores_first_count) = scores_first_count {
-                    user_.scores_first_count = scores_first_count;
-                }
-
-                if let Some(pending_mapset_count) = pending_mapset_count {
-                    user_.pending_mapset_count = pending_mapset_count;
-                }
-
-                if let Some(medals) = medals {
-                    user_.medals = medals;
-                }
-
-                if let statistics @ Some(_) = statistics {
-                    user_.statistics = statistics;
-                }
-            }
-            RedisData::Archive(user_) => user_.mutate(|archived| {
-                munge!(let ArchivedUser {
-                    last_visit: last_visit_seal,
-                    highest_rank: highest_rank_seal,
-                    follower_count: follower_count_seal,
-                    graveyard_mapset_count: graveyard_mapset_count_seal,
-                    guest_mapset_count: guest_mapset_count_seal,
-                    loved_mapset_count: loved_mapset_count_seal,
-                    ranked_mapset_count: ranked_mapset_count_seal,
-                    scores_first_count: scores_first_count_seal,
-                    pending_mapset_count: pending_mapset_count_seal,
-                    statistics: statistics_seal,
-                    ..
-                } = archived);
-
-                if let Some(last_visit) = user.last_visit {
-                    if let Some(last_visit_seal) = ArchivedOption::as_seal(last_visit_seal) {
-                        *last_visit_seal.unseal() = ArchivedDateTime::new(last_visit);
-                    }
-                }
-
-                if let Some(stats) = user.statistics {
-                    if let Some(stats_seal) = ArchivedOption::as_seal(statistics_seal) {
-                        // SAFETY: We neither move fields nor write uninitialized bytes
-                        unsafe { *stats_seal.unseal_unchecked() = stats.into() };
-                    }
-                }
-
-                if let Some(highest_rank) = user.highest_rank {
-                    if let Some(highest_rank_seal) = ArchivedOption::as_seal(highest_rank_seal) {
-                        // SAFETY: We neither move fields nor write uninitialized bytes
-                        unsafe {
-                            *highest_rank_seal.unseal_unchecked() = ArchivedUserHighestRank {
-                                rank: highest_rank.rank.into(),
-                                updated_at: ArchivedDateTime::new(highest_rank.updated_at),
-                            }
-                        };
-                    }
-                }
-
-                macro_rules! update_pod {
-                    ( $field:ident: $seal:ident ) => {
-                        if let Some($field) = user.$field {
-                            *$seal.unseal() = $field.into();
-                        }
-                    };
-                }
-
-                update_pod!(follower_count: follower_count_seal);
-                update_pod!(graveyard_mapset_count: graveyard_mapset_count_seal);
-                update_pod!(guest_mapset_count: guest_mapset_count_seal);
-                update_pod!(loved_mapset_count: loved_mapset_count_seal);
-                update_pod!(ranked_mapset_count: ranked_mapset_count_seal);
-                update_pod!(scores_first_count: scores_first_count_seal);
-                update_pod!(pending_mapset_count: pending_mapset_count_seal);
-            }),
         }
     }
 }

--- a/bathbot/src/util/cached_archive.rs
+++ b/bathbot/src/util/cached_archive.rs
@@ -1,0 +1,90 @@
+use std::{marker::PhantomData, ops::Deref};
+
+use eyre::{Report, Result};
+use rkyv::{
+    bytecheck::CheckBytes,
+    rancor::{BoxedError, Strategy},
+    seal::Seal,
+    ser::{allocator::ArenaHandle, Serializer, WriterExt},
+    util::AlignedVec,
+    validation::{archive::ArchiveValidator, Validator},
+    with::With,
+    Archived, Portable, Serialize,
+};
+
+/// Similar to [`bathbot_cache::model::CachedArchive`] but generic over the
+/// *archived* type rather than the original one.
+///
+/// In the future, this type should be used for all cache interactions.
+pub struct CachedArchive<T> {
+    bytes: AlignedVec<8>,
+    phantom: PhantomData<T>,
+}
+
+impl<T> CachedArchive<T>
+where
+    T: Portable + for<'a> CheckBytes<Strategy<Validator<ArchiveValidator<'a>, ()>, BoxedError>>,
+{
+    pub fn new(bytes: AlignedVec<8>) -> Result<Self> {
+        debug_assert!(align_of::<T>() <= 8);
+
+        let slice = bytes.as_slice();
+        let mut validator = Validator::new(ArchiveValidator::new(slice), ());
+        rkyv::api::access_with_context::<T, _, _>(slice, &mut validator).map_err(Report::new)?;
+
+        Ok(Self::new_unchecked(bytes))
+    }
+}
+
+impl<T> CachedArchive<T> {
+    const fn new_unchecked(bytes: AlignedVec<8>) -> Self {
+        Self {
+            bytes,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl<T: Portable> Deref for CachedArchive<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { rkyv::access_unchecked::<T>(self.as_bytes()) }
+    }
+}
+
+impl<T: Portable> CachedArchive<T> {
+    pub fn mutate<F: FnOnce(Seal<'_, T>)>(&mut self, f: F) {
+        f(unsafe { rkyv::api::access_unchecked_mut::<T>(&mut self.bytes) })
+    }
+}
+
+// ----------------------------------------------------------------
+// TODO: the following should probably be refactored somewhere else
+// ----------------------------------------------------------------
+
+type BathbotRedisSerializer<'a> =
+    Strategy<Serializer<AlignedVec<8>, ArenaHandle<'a>, ()>, BoxedError>;
+
+pub fn serialize_using_arena_and_with<T, W>(data: &T) -> Result<AlignedVec<8>, BoxedError>
+where
+    T: ?Sized,
+    With<T, W>: for<'a> Serialize<BathbotRedisSerializer<'a>>,
+{
+    rkyv::util::with_arena(|arena| {
+        let wrap = With::<T, W>::cast(data);
+        let mut serializer = Serializer::new(AlignedVec::new(), arena.acquire(), ());
+        let resolver = wrap.serialize(Strategy::wrap(&mut serializer))?;
+        serializer.align_for::<Archived<With<T, W>>>()?;
+
+        // SAFETY: A proper resolver is being used and the serializer has been
+        // aligned
+        unsafe { serializer.resolve_aligned(wrap, resolver)? };
+
+        Ok(serializer.into_writer())
+    })
+}

--- a/bathbot/src/util/ext/cached_user.rs
+++ b/bathbot/src/util/ext/cached_user.rs
@@ -1,0 +1,104 @@
+use bathbot_model::{
+    rkyv_util::time::ArchivedDateTime,
+    rosu_v2::user::{ArchivedUser, ArchivedUserHighestRank},
+};
+use bathbot_util::{constants::OSU_BASE, numbers::WithComma, osu::flag_url, AuthorBuilder};
+use rkyv::{munge::munge, option::ArchivedOption};
+
+use crate::manager::redis::osu::CachedUser;
+
+pub trait CachedUserExt {
+    fn author_builder(&self) -> AuthorBuilder;
+    fn update(&mut self, user: rosu_v2::model::user::User);
+}
+
+impl CachedUserExt for CachedUser {
+    fn author_builder(&self) -> AuthorBuilder {
+        let stats = self.statistics.as_ref().expect("missing stats");
+        let country_code = self.country_code.as_str();
+
+        let text = format!(
+            "{name}: {pp}pp (#{global} {country_code}{national})",
+            name = self.username,
+            pp = WithComma::new(stats.pp.to_native()),
+            global = WithComma::new(stats.global_rank.to_native()),
+            national = stats.country_rank
+        );
+
+        let url = format!("{OSU_BASE}users/{}/{}", self.user_id, self.mode);
+        let icon = flag_url(country_code);
+
+        AuthorBuilder::new(text).url(url).icon_url(icon)
+    }
+
+    fn update(&mut self, user: rosu_v2::model::user::User) {
+        self.mutate(|seal| {
+            munge!(let ArchivedUser {
+                last_visit: last_visit_seal,
+                highest_rank: highest_rank_seal,
+                follower_count: follower_count_seal,
+                graveyard_mapset_count: graveyard_mapset_count_seal,
+                guest_mapset_count: guest_mapset_count_seal,
+                loved_mapset_count: loved_mapset_count_seal,
+                ranked_mapset_count: ranked_mapset_count_seal,
+                scores_first_count: scores_first_count_seal,
+                pending_mapset_count: pending_mapset_count_seal,
+                statistics: statistics_seal,
+                avatar_url: _,
+                country_code: _,
+                join_date: _,
+                kudosu: _,
+                mode: _,
+                user_id: _,
+                username: _,
+                badges: _,
+                mapping_follower_count: _,
+                monthly_playcounts: _,
+                rank_history: _,
+                replays_watched_counts: _,
+                medals: _,
+            } = seal);
+
+            if let Some(last_visit) = user.last_visit {
+                if let Some(last_visit_seal) = ArchivedOption::as_seal(last_visit_seal) {
+                    *last_visit_seal.unseal() = ArchivedDateTime::new(last_visit);
+                }
+            }
+
+            if let Some(stats) = user.statistics {
+                if let Some(stats_seal) = ArchivedOption::as_seal(statistics_seal) {
+                    // SAFETY: We neither move fields nor write uninitialized bytes
+                    unsafe { *stats_seal.unseal_unchecked() = stats.into() };
+                }
+            }
+
+            if let Some(highest_rank) = user.highest_rank {
+                if let Some(highest_rank_seal) = ArchivedOption::as_seal(highest_rank_seal) {
+                    // SAFETY: We neither move fields nor write uninitialized bytes
+                    unsafe {
+                        *highest_rank_seal.unseal_unchecked() = ArchivedUserHighestRank {
+                            rank: highest_rank.rank.into(),
+                            updated_at: ArchivedDateTime::new(highest_rank.updated_at),
+                        }
+                    };
+                }
+            }
+
+            macro_rules! update_pod {
+                ( $field:ident: $seal:ident ) => {
+                    if let Some($field) = user.$field {
+                        *$seal.unseal() = $field.into();
+                    }
+                };
+            }
+
+            update_pod!(follower_count: follower_count_seal);
+            update_pod!(graveyard_mapset_count: graveyard_mapset_count_seal);
+            update_pod!(guest_mapset_count: guest_mapset_count_seal);
+            update_pod!(loved_mapset_count: loved_mapset_count_seal);
+            update_pod!(ranked_mapset_count: ranked_mapset_count_seal);
+            update_pod!(scores_first_count: scores_first_count_seal);
+            update_pod!(pending_mapset_count: pending_mapset_count_seal);
+        });
+    }
+}

--- a/bathbot/src/util/ext/mod.rs
+++ b/bathbot/src/util/ext/mod.rs
@@ -1,5 +1,6 @@
 pub use self::{
     authored::Authored,
+    cached_user::CachedUserExt,
     channel::ChannelExt,
     component::ComponentExt,
     interaction_command::{InteractionCommandExt, InteractionToken},
@@ -8,6 +9,7 @@ pub use self::{
 };
 
 mod authored;
+mod cached_user;
 mod channel;
 mod component;
 mod interaction_command;

--- a/bathbot/src/util/mod.rs
+++ b/bathbot/src/util/mod.rs
@@ -5,6 +5,7 @@ pub use self::{
     monthly::Monthly,
 };
 
+pub mod cached_archive;
 pub mod interaction;
 pub mod osu;
 pub mod query;


### PR DESCRIPTION
Replaces `CachedArchive<T>` from `bathbot_cache` which is generic over an archivable `T` with a new `CachedArchive<T>` that's generic over an archived type `T` - but only for cached osu users (for now).

This helps avoid the many instances of messy branching caused by the `RedisData` enum. It also prepares in part the usage of [`redlight`](https://github.com/MaxOhn/redlight).

In the future, this new `CachedArchive` should replace `RedisData` entirely.