### PR TITLE
feat: added dailychallenge command

### DIFF
--- a/bathbot/src/commands/osu/daily_challenge/mod.rs
+++ b/bathbot/src/commands/osu/daily_challenge/mod.rs
@@ -1,0 +1,35 @@
+use bathbot_macros::{HasName, SlashCommand};
+use eyre::Result;
+use twilight_interactions::command::{CommandModel, CreateCommand};
+use twilight_model::id::{marker::UserMarker, Id};
+
+use crate::util::{interaction::InteractionCommand, InteractionCommandExt};
+
+mod user;
+
+#[derive(CommandModel, CreateCommand, SlashCommand)]
+#[command(name = "dailychallenge", desc = "Daily challenge statistics")]
+pub enum DailyChallenge {
+    #[command(name = "user")]
+    User(DailyChallengeUser),
+}
+
+#[derive(CommandModel, CreateCommand, HasName)]
+#[command(name = "user", desc = "Daily challenge statistics of a user")]
+pub struct DailyChallengeUser {
+    #[command(desc = "Specify a username")]
+    name: Option<String>,
+    #[command(
+        desc = "Specify a linked discord user",
+        help = "Instead of specifying an osu! username with the `name` option, \
+        you can use this option to choose a discord user.\n\
+        Only works on users who have used the `/link` command."
+    )]
+    discord: Option<Id<UserMarker>>,
+}
+
+async fn slash_dailychallenge(mut command: InteractionCommand) -> Result<()> {
+    match DailyChallenge::from_interaction(command.input_data())? {
+        DailyChallenge::User(user) => user::user(command, user).await,
+    }
+}

--- a/bathbot/src/commands/osu/daily_challenge/user.rs
+++ b/bathbot/src/commands/osu/daily_challenge/user.rs
@@ -82,10 +82,12 @@ Best    | {:^daily_len$} | {:^6}
         datetime.day() == OffsetDateTime::now_utc().day()
     });
 
+    let footer = format!("Played today: {}", if played_today { '✅' } else { '❌' });
+
     let embed = EmbedBuilder::new()
         .author(user.author_builder())
         .fields(fields)
-        .footer(FooterBuilder::new(format!("Played today: {played_today}")))
+        .footer(FooterBuilder::new(footer))
         .thumbnail(user.avatar_url.as_ref());
 
     let builder = MessageBuilder::new().embed(embed);

--- a/bathbot/src/commands/osu/daily_challenge/user.rs
+++ b/bathbot/src/commands/osu/daily_challenge/user.rs
@@ -1,0 +1,95 @@
+use bathbot_util::{constants::GENERAL_ISSUE, fields, EmbedBuilder, FooterBuilder, MessageBuilder};
+use eyre::{Report, Result};
+use rkyv::rancor::{Panic, ResultExt};
+use rosu_v2::{error::OsuError, model::GameMode, request::UserId};
+use time::OffsetDateTime;
+
+use super::DailyChallengeUser;
+use crate::{
+    commands::osu::{require_link, user_not_found},
+    core::{commands::CommandOrigin, Context},
+    manager::redis::osu::{UserArgs, UserArgsError},
+    util::{interaction::InteractionCommand, Authored, CachedUserExt, InteractionCommandExt},
+};
+
+pub(super) async fn user(mut command: InteractionCommand, user: DailyChallengeUser) -> Result<()> {
+    let owner = command.user_id()?;
+
+    let orig = CommandOrigin::Interaction {
+        command: &mut command,
+    };
+
+    let user_id = match user_id!(orig, user) {
+        Some(user_id) => user_id,
+        None => match Context::user_config().osu_id(owner).await {
+            Ok(Some(user_id)) => UserId::Id(user_id),
+            Ok(None) => return require_link(&orig).await,
+            Err(err) => {
+                let _ = orig.error(GENERAL_ISSUE).await;
+
+                return Err(err);
+            }
+        },
+    };
+
+    let user_args = UserArgs::rosu_id(&user_id, GameMode::Osu).await;
+
+    let user = match Context::redis().osu_user(user_args).await {
+        Ok(user) => user,
+        Err(UserArgsError::Osu(OsuError::NotFound)) => {
+            let content = user_not_found(user_id).await;
+
+            return orig.error(content).await;
+        }
+        Err(err) => {
+            let _ = orig.error(GENERAL_ISSUE).await;
+            let err = Report::new(err).wrap_err("Failed to get user");
+
+            return Err(err);
+        }
+    };
+
+    let daily = &user.daily_challenge;
+
+    let len_daily_current = daily.daily_streak_current.to_string().len();
+    let len_daily_best = daily.daily_streak_best.to_string().len();
+    let daily_len = "Daily".len().max(len_daily_current).max(len_daily_best);
+
+    let streaks = format!(
+        "```
+Streaks | {:^daily_len$} | Weekly
+--------+-------+-------
+Current | {:^daily_len$} | {:^6}
+Best    | {:^daily_len$} | {:^6}
+```",
+        "Daily",
+        daily.daily_streak_current.to_native(),
+        daily.weekly_streak_current.to_native(),
+        daily.daily_streak_best.to_native(),
+        daily.weekly_streak_best.to_native(),
+    );
+
+    let fields = fields![
+        "Daily challenge statistics", streaks, false;
+        "Top 10%", daily.top_10p_placements.to_string(), true;
+        "Top 50%", daily.top_50p_placements.to_string(), true;
+        "Total", daily.playcount.to_string(), true;
+    ];
+
+    let played_today = daily.last_update.as_ref().is_some_and(|datetime| {
+        let datetime = datetime.try_deserialize::<Panic>().always_ok();
+
+        datetime.day() == OffsetDateTime::now_utc().day()
+    });
+
+    let embed = EmbedBuilder::new()
+        .author(user.author_builder())
+        .fields(fields)
+        .footer(FooterBuilder::new(format!("Played today: {played_today}")))
+        .thumbnail(user.avatar_url.as_ref());
+
+    let builder = MessageBuilder::new().embed(embed);
+    command.update(builder).await?;
+
+    Ok(())
+}

--- a/bathbot/src/commands/osu/mod.rs
+++ b/bathbot/src/commands/osu/mod.rs
@@ -87,6 +87,7 @@ mod bws;
 mod cards;
 mod claim_name;
 mod compare;
+mod daily_challenge;
 mod fix;
 mod graphs;
 mod leaderboard;

--- a/bathbot/src/util/ext/cached_user.rs
+++ b/bathbot/src/util/ext/cached_user.rs
@@ -57,6 +57,7 @@ impl CachedUserExt for CachedUser {
                 rank_history: _,
                 replays_watched_counts: _,
                 medals: _,
+                daily_challenge: _,
             } = seal);
 
             if let Some(last_visit) = user.last_visit {


### PR DESCRIPTION
Closes #798 

A new command is probably worthwhile in the long term rather than displaying all the statistics in the extended user tab of `/profile`. Once data from https://ameobea.me/osutrack/daily-challenge/ is used, there can be more subcommands too.