### PR TITLE
perf: archive `Box<str>` as `ArchivedString`

### DIFF
--- a/bathbot-model/src/huismetbenen.rs
+++ b/bathbot-model/src/huismetbenen.rs
@@ -6,7 +6,7 @@ use std::{
 
 use bathbot_util::{CowUtils, osu::ModSelection};
 use rkyv::{
-    Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize, boxed::ArchivedBox,
+    Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize, string::ArchivedString,
 };
 use rosu_v2::prelude::{CountryCode, GameMode, GameMods, GameModsIntermode, Username};
 use serde::{
@@ -27,7 +27,10 @@ use time::{
 use twilight_interactions::command::{CommandOption, CreateOption};
 
 use super::deser;
-use crate::KittenRoleplayCountries;
+use crate::{
+    KittenRoleplayCountries,
+    rkyv_util::{DerefAsString, MapBoxedSlice},
+};
 
 pub struct SnipeScoreParams {
     pub user_id: u32,
@@ -404,6 +407,7 @@ impl<'de> Deserialize<'de> for SnipeScore {
 
 #[derive(Debug, Archive, RkyvDeserialize, RkyvSerialize)]
 pub struct SnipeCountries {
+    #[rkyv(with = MapBoxedSlice<DerefAsString>)]
     country_codes: Box<[Box<str>]>,
 }
 
@@ -437,7 +441,7 @@ impl SnipeCountries {
 impl ArchivedSnipeCountries {
     pub fn contains(&self, country_code: &str) -> bool {
         self.country_codes
-            .binary_search_by_key(&country_code, ArchivedBox::as_ref)
+            .binary_search_by_key(&country_code, ArchivedString::as_str)
             .is_ok()
     }
 }

--- a/bathbot-model/src/osekai.rs
+++ b/bathbot-model/src/osekai.rs
@@ -208,9 +208,12 @@ pub struct OsekaiMedal {
     #[serde(rename = "Frequency", with = "deser::option_f32_string")]
     #[rkyv(with = NicheInto<NaN>)]
     pub rarity: Option<f32>,
+    #[rkyv(with = DerefAsString)]
     pub name: Box<str>,
     #[serde(rename = "Link")]
+    #[rkyv(with = DerefAsString)]
     icon_url_suffix: Box<str>,
+    #[rkyv(with = DerefAsString)]
     pub description: Box<str>,
     #[serde(rename = "Gamemode", deserialize_with = "maybe_osekai_mode")]
     #[rkyv(with = NicheInto<GameModeNiche>)]
@@ -591,6 +594,7 @@ fn maybe_osekai_mode<'de, D: Deserializer<'de>>(d: D) -> Result<Option<GameMode>
 #[derive(Archive, Debug, RkyvDeserialize, Serialize)]
 #[rkyv(as = ArchivedOsekaiRankingEntry<T>)]
 pub struct OsekaiRankingEntry<T: Archive> {
+    #[rkyv(with = DerefAsString)]
     pub country: Box<str>,
     #[rkyv(with = DerefAsString)]
     pub country_code: CountryCode,
@@ -605,7 +609,7 @@ pub struct OsekaiRankingEntry<T: Archive> {
 #[bytecheck(crate = rkyv::bytecheck)]
 #[repr(C)]
 pub struct ArchivedOsekaiRankingEntry<T: Archive> {
-    pub country: <Box<str> as Archive>::Archived,
+    pub country: ArchivedString,
     pub country_code: ArchivedString,
     pub rank: Archived<u32>,
     pub user_id: Archived<u32>,
@@ -786,14 +790,17 @@ pub struct OsekaiUserEntry {
     #[serde(rename = "countrycode")]
     #[rkyv(with = DerefAsString)]
     pub country_code: CountryCode,
+    #[rkyv(with = DerefAsString)]
     pub country: Box<str>,
     #[rkyv(with = DerefAsString)]
     pub username: Username,
     #[serde(rename = "medalCount", with = "deser::u32_string")]
     pub medal_count: u32,
     #[serde(rename = "rarestmedal")]
+    #[rkyv(with = DerefAsString)]
     pub rarest_medal: Box<str>,
     #[serde(rename = "link")]
+    #[rkyv(with = DerefAsString)]
     pub rarest_icon_url: Box<str>,
     #[serde(rename = "userid", with = "deser::u32_string")]
     pub user_id: u32,
@@ -806,11 +813,14 @@ pub struct OsekaiRarityEntry {
     #[serde(with = "deser::u32_string")]
     pub rank: u32,
     #[serde(rename = "link")]
+    #[rkyv(with = DerefAsString)]
     pub icon_url: Box<str>,
     #[serde(rename = "medalname")]
+    #[rkyv(with = DerefAsString)]
     pub medal_name: Box<str>,
     #[serde(rename = "medalid", with = "deser::u32_string")]
     pub medal_id: u32,
+    #[rkyv(with = DerefAsString)]
     pub description: Box<str>,
     #[serde(rename = "possessionRate", with = "deser::f32_string")]
     pub possession_percent: f32,
@@ -824,10 +834,13 @@ pub struct OsekaiBadge {
     #[serde(with = "deser::date")]
     #[rkyv(with = DateRkyv)]
     pub awarded_at: Date,
+    #[rkyv(with = DerefAsString)]
     pub description: Box<str>,
     #[serde(rename = "id", with = "deser::u32_string")]
     pub badge_id: u32,
+    #[rkyv(with = DerefAsString)]
     pub image_url: Box<str>,
+    #[rkyv(with = DerefAsString)]
     pub name: Box<str>,
     #[serde(deserialize_with = "string_of_vec_of_u32s")]
     pub users: Vec<u32>,

--- a/bathbot-model/src/osu_stats.rs
+++ b/bathbot-model/src/osu_stats.rs
@@ -21,7 +21,10 @@ use twilight_interactions::command::{CommandOption, CreateOption};
 use super::deser;
 use crate::{
     deser::ModeAsSeed,
-    rkyv_util::time::{DateRkyv, DateTimeRkyv},
+    rkyv_util::{
+        DerefAsString,
+        time::{DateRkyv, DateTimeRkyv},
+    },
     rosu_v2::grade::GradeRkyv,
 };
 
@@ -655,9 +658,13 @@ pub struct OsuStatsBestScoreMap {
     pub map_id: u32,
     #[serde(rename = "beatmapSetId")]
     pub mapset_id: u32,
+    #[rkyv(with = DerefAsString)]
     pub artist: Box<str>,
+    #[rkyv(with = DerefAsString)]
     pub title: Box<str>,
+    #[rkyv(with = DerefAsString)]
     pub version: Box<str>,
+    #[rkyv(with = DerefAsString)]
     pub creator: Box<str>,
     #[serde(rename = "maxCombo")]
     pub max_combo: u32,
@@ -668,5 +675,6 @@ pub struct OsuStatsBestScoreUser {
     #[serde(rename = "userId")]
     pub user_id: u32,
     #[serde(rename = "userName")]
+    #[rkyv(with = DerefAsString)]
     pub username: Box<str>,
 }

--- a/bathbot-model/src/rkyv_util/map_boxed_slice.rs
+++ b/bathbot-model/src/rkyv_util/map_boxed_slice.rs
@@ -1,0 +1,36 @@
+use std::marker::PhantomData;
+
+use rkyv::{
+    Place,
+    rancor::Fallible,
+    ser::{Allocator, Writer},
+    vec::{ArchivedVec, VecResolver},
+    with::{ArchiveWith, SerializeWith, With},
+};
+
+/// Basically [`rkyv::with::Map`] but for `Box<[T]>`
+pub struct MapBoxedSlice<T>(PhantomData<T>);
+
+impl<A, O> ArchiveWith<Box<[O]>> for MapBoxedSlice<A>
+where
+    A: ArchiveWith<O>,
+{
+    type Archived = ArchivedVec<<A as ArchiveWith<O>>::Archived>;
+    type Resolver = VecResolver;
+
+    #[inline]
+    fn resolve_with(field: &Box<[O]>, resolver: Self::Resolver, out: Place<Self::Archived>) {
+        ArchivedVec::resolve_from_len(field.len(), resolver, out);
+    }
+}
+
+impl<S, A, O> SerializeWith<Box<[O]>, S> for MapBoxedSlice<A>
+where
+    S: Fallible + Allocator + Writer + ?Sized,
+    A: ArchiveWith<O> + SerializeWith<O, S>,
+{
+    #[inline]
+    fn serialize_with(field: &Box<[O]>, s: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedVec::serialize_from_iter::<With<O, A>, _, _>(field.iter().map(With::cast), s)
+    }
+}

--- a/bathbot-model/src/rkyv_util/mod.rs
+++ b/bathbot-model/src/rkyv_util/mod.rs
@@ -2,6 +2,7 @@ mod as_non_zero;
 mod bitflags;
 mod deref_as_box;
 mod deref_as_string;
+mod map_boxed_slice;
 mod map_unwrap_or_default;
 mod niche_deref_as_box;
 mod str_as_string;
@@ -11,7 +12,7 @@ pub mod time;
 
 pub use self::{
     as_non_zero::AsNonZero, bitflags::BitflagsRkyv, deref_as_box::DerefAsBox,
-    deref_as_string::DerefAsString, map_unwrap_or_default::MapUnwrapOrDefault,
-    niche_deref_as_box::NicheDerefAsBox, str_as_string::StrAsString,
-    unwrap_or_default::UnwrapOrDefault,
+    deref_as_string::DerefAsString, map_boxed_slice::MapBoxedSlice,
+    map_unwrap_or_default::MapUnwrapOrDefault, niche_deref_as_box::NicheDerefAsBox,
+    str_as_string::StrAsString, unwrap_or_default::UnwrapOrDefault,
 };


### PR DESCRIPTION
`ArchivedBox` always archives as pointer indirection whereas `ArchivedString` archives strings that are no longer than 8 bytes inline.