### PR TITLE
hotfix: Relax intergration

### DIFF
--- a/bathbot/src/active/impls/relax/top.rs
+++ b/bathbot/src/active/impls/relax/top.rs
@@ -141,7 +141,7 @@ impl RelaxTopPagination {
                 map_id = score.beatmap_id,
                 mods = ModsFormatter::new(mods),
                 pp = PpFormatter::new(score_pp, Some(max_pp)),
-                stars = score.beatmap.star_rating.unwrap_or_default(),
+                stars = score.beatmap.star_rating_normal,
                 acc = round(score.accuracy),
                 score = WithComma::new(score.total_score),
                 combo = ComboFormatter::new(score.combo, Some(max_combo)),

--- a/bathbot/src/commands/osu/relax/top.rs
+++ b/bathbot/src/commands/osu/relax/top.rs
@@ -65,7 +65,7 @@ pub async fn top(orig: CommandOrigin<'_>, args: RelaxTop<'_>) -> Result<()> {
 
     let relax_api_result = tokio::try_join!(scores_fut, player_fut);
 
-    let (mut scores, player) = match relax_api_result {
+    let (scores, player) = match relax_api_result {
         Ok(v) => v,
         Err(e) => {
             let _ = orig.error("Failed to get a relax player").await;
@@ -74,6 +74,7 @@ pub async fn top(orig: CommandOrigin<'_>, args: RelaxTop<'_>) -> Result<()> {
         }
     };
 
+    let mut scores: Vec<_> = scores.into_iter().filter(|x| x.is_best).collect();
     let map_ids = scores
         .iter()
         .take(5)

--- a/bathbot/src/commands/osu/relax/top.rs
+++ b/bathbot/src/commands/osu/relax/top.rs
@@ -65,7 +65,7 @@ pub async fn top(orig: CommandOrigin<'_>, args: RelaxTop<'_>) -> Result<()> {
 
     let relax_api_result = tokio::try_join!(scores_fut, player_fut);
 
-    let (scores, player) = match relax_api_result {
+    let (mut scores, player) = match relax_api_result {
         Ok(v) => v,
         Err(e) => {
             let _ = orig.error("Failed to get a relax player").await;
@@ -74,7 +74,8 @@ pub async fn top(orig: CommandOrigin<'_>, args: RelaxTop<'_>) -> Result<()> {
         }
     };
 
-    let mut scores: Vec<_> = scores.into_iter().filter(|x| x.is_best).collect();
+    scores.retain(|sc| sc.is_best);
+
     let map_ids = scores
         .iter()
         .take(5)


### PR DESCRIPTION
1. Filter scores by is_best. ~~Collection is done in-place because doing otherwise would require a bit too much refactors for the scope (if even feasible)~~ changed to `Vec::retain`
2. Use the correct field for star rating (I gotta document them later)