### PR TITLE
fix: Use diffcalc for star rating in /relax top

### DIFF
--- a/bathbot/src/active/impls/relax/top.rs
+++ b/bathbot/src/active/impls/relax/top.rs
@@ -200,6 +200,4 @@ pub enum RelaxTopOrder {
     Pp,
     #[option(name = "Score", value = "score")]
     Score,
-    #[option(name = "Stars", value = "stars")]
-    Stars,
 }

--- a/bathbot/src/active/impls/relax/top.rs
+++ b/bathbot/src/active/impls/relax/top.rs
@@ -122,7 +122,6 @@ impl RelaxTopPagination {
 
             let mods = &score.mods;
             let mut pp_manager = Context::pp(map).mods(mods.clone());
-            let stars = pp_manager.difficulty().await.stars();
             let max_attrs = pp_manager.performance().await;
 
             // NOTE: Make generic versions of formatting functions later on
@@ -143,7 +142,7 @@ impl RelaxTopPagination {
                 map_id = score.beatmap_id,
                 mods = ModsFormatter::new(mods),
                 pp = PpFormatter::new(score_pp, Some(max_pp)),
-                stars = stars,
+                stars = max_attrs.stars(),
                 acc = round(score.accuracy),
                 score = WithComma::new(score.total_score),
                 combo = ComboFormatter::new(score.combo, Some(max_combo)),

--- a/bathbot/src/active/impls/relax/top.rs
+++ b/bathbot/src/active/impls/relax/top.rs
@@ -121,7 +121,9 @@ impl RelaxTopPagination {
             };
 
             let mods = &score.mods;
-            let max_attrs = Context::pp(map).mods(mods.clone()).performance().await;
+            let mut pp_manager = Context::pp(map).mods(mods.clone());
+            let stars = pp_manager.difficulty().await.stars();
+            let max_attrs = pp_manager.performance().await;
 
             // NOTE: Make generic versions of formatting functions later on
             // this is ugly
@@ -141,7 +143,7 @@ impl RelaxTopPagination {
                 map_id = score.beatmap_id,
                 mods = ModsFormatter::new(mods),
                 pp = PpFormatter::new(score_pp, Some(max_pp)),
-                stars = score.beatmap.star_rating_normal,
+                stars = stars,
                 acc = round(score.accuracy),
                 score = WithComma::new(score.total_score),
                 combo = ComboFormatter::new(score.combo, Some(max_combo)),

--- a/bathbot/src/commands/osu/relax/top.rs
+++ b/bathbot/src/commands/osu/relax/top.rs
@@ -119,11 +119,6 @@ pub async fn top(orig: CommandOrigin<'_>, args: RelaxTop<'_>) -> Result<()> {
         RelaxTopOrder::Score => {
             scores.sort_unstable_by(|lhs, rhs| rhs.total_score.cmp(&lhs.total_score))
         }
-        RelaxTopOrder::Stars => scores.sort_unstable_by(|lhs, rhs| {
-            rhs.beatmap
-                .star_rating_normal
-                .total_cmp(&lhs.beatmap.star_rating_normal)
-        }),
     }
 
     let pagination = RelaxTopPagination::builder()


### PR DESCRIPTION
We love testing in production :)

Enables use of diffcalc for `/relax top` as Relaxation Vault does not return star rating with mods applied. Currently done per-page instead of precalculating for all pages at once as Vault's API isn't paginated and I'm slightly worried about having to calculate a thousand scores on top of having to actually retrieve them in the first place

Important caveat - this potentially affects sorting by star rating, but I'm not sure how to fix that without allowing the previous issue to persist, as if you calculate only a portion of scores (e.g. 100 at a time), some might slip through anyway