### PR TITLE
fix: check beatmap suspicion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "rosu-pp"
 version = "3.0.0"
-source = "git+https://github.com/MaxOhn/rosu-pp?branch=main#37ebd0ddf8a0646da2692d84872055286e80c5c7"
+source = "git+https://github.com/MaxOhn/rosu-pp?branch=main#a7cdc5df16d71ba7cd4c577e8ea80c0649f88c9c"
 dependencies = [
  "rosu-map",
  "rosu-mods",

--- a/bathbot/src/active/impls/higherlower/score_pp.rs
+++ b/bathbot/src/active/impls/higherlower/score_pp.rs
@@ -94,7 +94,8 @@ impl ScorePp {
         let map = map_res.wrap_err("Failed to get beatmap")?;
 
         let max_combo = match attrs_res {
-            Ok(attrs) => Some(attrs.max_combo()),
+            Ok(Some(attrs)) => Some(attrs.max_combo()),
+            Ok(None) => None,
             Err(err) => {
                 warn!(?err, "Failed to get difficulty attributes");
 

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -104,15 +104,25 @@ impl OsuStatsScoresPagination {
 
                 let pp = match score.pp {
                     Some(pp) => pp,
-                    None => calc.score(&score).performance().await.pp() as f32,
+                    None => match calc.score(&score).performance().await {
+                        Some(attrs) => attrs.pp() as f32,
+                        None => 0.0,
+                    },
                 };
 
-                let max_pp =
-                    if score.grade.eq_letter(Grade::X) && mode != GameMode::Mania && pp > 0.0 {
-                        pp
-                    } else {
-                        attrs.pp() as f32
-                    };
+                let mut max_pp = 0.0;
+                let mut stars = 0.0;
+                let mut max_combo = 0;
+
+                if let Some(attrs) = attrs {
+                    max_pp = attrs.pp() as f32;
+                    stars = attrs.stars() as f32;
+                    max_combo = attrs.max_combo() as u32;
+                }
+
+                if score.grade.eq_letter(Grade::X) && mode != GameMode::Mania && pp > 0.0 {
+                    max_pp = pp;
+                }
 
                 let rank = score.position;
 
@@ -145,8 +155,8 @@ impl OsuStatsScoresPagination {
                     map,
                     rank,
                     max_pp,
-                    stars: attrs.stars() as f32,
-                    max_combo: attrs.max_combo(),
+                    stars,
+                    max_combo,
                 };
 
                 self.entries.insert(i, entry);

--- a/bathbot/src/active/impls/osustats/scores.rs
+++ b/bathbot/src/active/impls/osustats/scores.rs
@@ -117,7 +117,7 @@ impl OsuStatsScoresPagination {
                 if let Some(attrs) = attrs {
                     max_pp = attrs.pp() as f32;
                     stars = attrs.stars() as f32;
-                    max_combo = attrs.max_combo() as u32;
+                    max_combo = attrs.max_combo();
                 }
 
                 if score.grade.eq_letter(Grade::X) && mode != GameMode::Mania && pp > 0.0 {

--- a/bathbot/src/active/impls/relax/top.rs
+++ b/bathbot/src/active/impls/relax/top.rs
@@ -121,16 +121,23 @@ impl RelaxTopPagination {
             };
 
             let mods = &score.mods;
-            let mut pp_manager = Context::pp(map).mods(mods.clone());
-            let max_attrs = pp_manager.performance().await;
+            let max_attrs = Context::pp(map).mods(mods.to_owned()).performance().await;
+
+            let score_pp = score.pp.map(|pp| pp as f32);
+            let count_miss = score.count_miss;
+
+            let mut max_pp = 0.0;
+            let mut stars = 0.0;
+            let mut max_combo = 0;
+
+            if let Some(max_attrs) = max_attrs {
+                max_pp = max_attrs.pp() as f32;
+                stars = max_attrs.stars() as f32;
+                max_combo = max_attrs.max_combo();
+            }
 
             // NOTE: Make generic versions of formatting functions later on
             // this is ugly
-            let score_pp = score.pp.map(|pp| pp as f32);
-            let max_pp = max_attrs.pp() as f32;
-            let max_combo = max_attrs.max_combo();
-            let count_miss = score.count_miss;
-
             let _ = writeln!(
                 description,
                 "**#{idx} [{title} [{version}]]({OSU_BASE}b/{map_id}) +{mods}**\n\
@@ -142,7 +149,6 @@ impl RelaxTopPagination {
                 map_id = score.beatmap_id,
                 mods = ModsFormatter::new(mods),
                 pp = PpFormatter::new(score_pp, Some(max_pp)),
-                stars = max_attrs.stars(),
                 acc = round(score.accuracy),
                 score = WithComma::new(score.total_score),
                 combo = ComboFormatter::new(score.combo, Some(max_combo)),

--- a/bathbot/src/active/impls/simulate/state.rs
+++ b/bathbot/src/active/impls/simulate/state.rs
@@ -30,6 +30,10 @@ impl ScoreState {
 
                 let (large_tick_hit, slider_tail_hit) = map
                     .and_then(|map| {
+                        if map.check_suspicion().is_err() {
+                            return None;
+                        }
+
                         Difficulty::new()
                             .calculate_for_mode::<rosu_pp::osu::Osu>(map)
                             .ok()

--- a/bathbot/src/active/impls/simulate/top_old.rs
+++ b/bathbot/src/active/impls/simulate/top_old.rs
@@ -405,7 +405,16 @@ impl TopOldVersion {
         components
     }
 
-    pub(super) fn generate_hitresults(self, map: &Beatmap, data: &SimulateData) -> ScoreState {
+    /// Returns `None` if the map is too suspicious.
+    pub(super) fn generate_hitresults(
+        self,
+        map: &Beatmap,
+        data: &SimulateData,
+    ) -> Option<ScoreState> {
+        if map.check_suspicion().is_err() {
+            return None;
+        }
+
         let mut calc = Performance::new(map).lazer(data.set_on_lazer);
 
         if let Some(acc) = data.acc {
@@ -448,7 +457,7 @@ impl TopOldVersion {
 
         let state = calc.generate_state();
 
-        match self {
+        let state = match self {
             Self::Osu(_) => ScoreState::Osu(OsuScoreState {
                 max_combo: state.max_combo,
                 n300: state.n300,
@@ -481,7 +490,9 @@ impl TopOldVersion {
                 n50: state.n50,
                 misses: state.misses,
             }),
-        }
+        };
+
+        Some(state)
     }
 }
 

--- a/bathbot/src/active/impls/snipe/difference.rs
+++ b/bathbot/src/active/impls/snipe/difference.rs
@@ -12,6 +12,7 @@ use bathbot_util::{
 };
 use eyre::{Result, WrapErr};
 use futures::future::BoxFuture;
+use rosu_pp::any::DifficultyAttributes;
 use rosu_v2::prelude::GameMode;
 use twilight_model::{
     channel::message::Component,
@@ -96,7 +97,7 @@ impl SnipeDifferencePagination {
                         let stars = Context::pp_parsed(&map, GameMode::Osu)
                             .difficulty()
                             .await
-                            .stars();
+                            .map_or(0.0, DifficultyAttributes::stars);
 
                         *e.insert(stars as f32)
                     }

--- a/bathbot/src/active/impls/snipe/player_list.rs
+++ b/bathbot/src/active/impls/snipe/player_list.rs
@@ -149,8 +149,15 @@ impl SnipePlayerListPagination {
                 .mods(mods.clone().into_owned())
                 .performance()
                 .await;
-            let max_pp = max_attrs.pp() as f32;
-            let max_combo = max_attrs.max_combo();
+
+            let mut max_pp = 0.0;
+            let mut max_combo = 0;
+
+            if let Some(max_attrs) = max_attrs {
+                max_pp = max_attrs.pp() as f32;
+                max_combo = max_attrs.max_combo();
+            }
+
             let count_miss = score.count_miss.unwrap_or(0);
 
             let _ = write!(

--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -172,6 +172,7 @@ async fn slash_card(mut command: InteractionCommand) -> Result<()> {
                 .mods(score.mods.clone())
                 .difficulty()
                 .await
+                .expect("suspicious maps in top scores are a false positive")
                 .to_owned();
 
             let attrs = RequiredAttributes {

--- a/bathbot/src/commands/osu/fix.rs
+++ b/bathbot/src/commands/osu/fix.rs
@@ -386,7 +386,10 @@ async fn request_by_map(
             let pp_fut = async {
                 match score.pp {
                     Some(pp) => pp,
-                    None => Context::pp(&map).score(&score).performance().await.pp() as f32,
+                    None => match Context::pp(&map).score(&score).performance().await {
+                        Some(attrs) => attrs.pp() as f32,
+                        None => 0.0,
+                    },
                 }
             };
 
@@ -508,7 +511,10 @@ async fn request_by_score(
 
     let pp = match score.pp {
         Some(pp) => pp,
-        None => Context::pp(&map).score(&score).performance().await.pp() as f32,
+        None => match Context::pp(&map).score(&score).performance().await {
+            Some(attrs) => attrs.pp() as f32,
+            None => 0.0,
+        },
     };
 
     let score = ScoreSlim::new(score, pp);

--- a/bathbot/src/commands/osu/leaderboard.rs
+++ b/bathbot/src/commands/osu/leaderboard.rs
@@ -487,8 +487,13 @@ async fn leaderboard(orig: CommandOrigin<'_>, args: LeaderboardArgs<'_>) -> Resu
         format!("I found {amount} scores on the map's leaderboard")
     };
 
-    let stars = attrs.stars() as f32;
-    let max_combo = attrs.max_combo();
+    let mut stars = 0.0;
+    let mut max_combo = 0;
+
+    if let Some(attrs) = attrs {
+        stars = attrs.stars() as f32;
+        max_combo = attrs.max_combo();
+    }
 
     args.sort.sort(&mut scores, &map, score_data).await;
     args.sort.push_content(&mut content);
@@ -634,9 +639,16 @@ impl LeaderboardScore {
             .mods(self.mods.clone())
             .lazer(self.set_on_lazer);
 
-        let attrs = calc.performance().await;
-        let max_pp = attrs.pp() as f32;
-        let pp = calc.score(&*self).performance().await.pp() as f32;
+        let mut max_pp = 0.0;
+        let mut pp = 0.0;
+
+        if let Some(max_attrs) = calc.performance().await {
+            max_pp = max_attrs.pp() as f32;
+
+            if let Some(attrs) = calc.score(&*self).performance().await {
+                pp = attrs.pp() as f32;
+            }
+        }
 
         *self.pps.insert(PpData { pp, max: max_pp })
     }

--- a/bathbot/src/commands/osu/map.rs
+++ b/bathbot/src/commands/osu/map.rs
@@ -402,6 +402,10 @@ struct GraphStrains {
 const NEW_STRAIN_COUNT: usize = 200;
 
 fn strain_values(map: &PpMap, mods: GameMods) -> Result<GraphStrains> {
+    if map.check_suspicion().is_err() {
+        bail!("skip strain calculation because map is too suspicious");
+    }
+
     let mut strains = Difficulty::new().mods(mods).strains(map);
     let section_len = strains.section_len();
 
@@ -475,8 +479,8 @@ async fn get_cover(url: &str) -> Result<DynamicImage> {
 }
 
 pub async fn map_strain_graph(map: &PpMap, mods: GameMods, cover_url: &str) -> Result<Vec<u8>> {
-    let cover_res = get_cover(cover_url).await;
     let strains = strain_values(map, mods)?;
+    let cover_res = get_cover(cover_url).await;
 
     let last_timestamp = ((NEW_STRAIN_COUNT - 2) as f64
         * strains.strains.section_len()

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -495,7 +495,7 @@ async fn process_scores(
         if let Some(attrs) = attrs {
             max_pp = attrs.pp() as f32;
             stars = attrs.stars() as f32;
-            max_combo = attrs.max_combo() as u32;
+            max_combo = attrs.max_combo();
         }
 
         if score.grade.eq_letter(Grade::X) && mode != GameMode::Mania && pp > 0.0 {

--- a/bathbot/src/commands/osu/osustats/globals.rs
+++ b/bathbot/src/commands/osu/osustats/globals.rs
@@ -482,14 +482,25 @@ async fn process_scores(
 
         let pp = match score.pp {
             Some(pp) => pp,
-            None => calc.score(&score).performance().await.pp() as f32,
+            None => match calc.score(&score).performance().await {
+                Some(attrs) => attrs.pp() as f32,
+                None => 0.0,
+            },
         };
 
-        let max_pp = if score.grade.eq_letter(Grade::X) && mode != GameMode::Mania && pp > 0.0 {
-            pp
-        } else {
-            attrs.pp() as f32
-        };
+        let mut max_pp = 0.0;
+        let mut stars = 0.0;
+        let mut max_combo = 0;
+
+        if let Some(attrs) = attrs {
+            max_pp = attrs.pp() as f32;
+            stars = attrs.stars() as f32;
+            max_combo = attrs.max_combo() as u32;
+        }
+
+        if score.grade.eq_letter(Grade::X) && mode != GameMode::Mania && pp > 0.0 {
+            max_pp = pp;
+        }
 
         let rank = score.position;
 
@@ -522,8 +533,8 @@ async fn process_scores(
             map,
             rank,
             max_pp,
-            stars: attrs.stars() as f32,
-            max_combo: attrs.max_combo(),
+            stars,
+            max_combo,
         };
 
         entries.insert(i, entry);

--- a/bathbot/src/commands/osu/recent/fix.rs
+++ b/bathbot/src/commands/osu/recent/fix.rs
@@ -151,7 +151,10 @@ pub(super) async fn fix(orig: CommandOrigin<'_>, args: RecentFix) -> Result<()> 
 
     let pp = match score.pp {
         Some(pp) => pp,
-        None => Context::pp(&map).score(&score).performance().await.pp() as f32,
+        None => match Context::pp(&map).score(&score).performance().await {
+            Some(attrs) => attrs.pp() as f32,
+            None => 0.0,
+        },
     };
 
     let score = ScoreSlim::new(score, pp);

--- a/bathbot/src/commands/osu/recent/leaderboard.rs
+++ b/bathbot/src/commands/osu/recent/leaderboard.rs
@@ -365,8 +365,13 @@ pub(super) async fn leaderboard(
         format!("I found {amount} scores on the map's leaderboard")
     };
 
-    let stars = attrs.stars() as f32;
-    let max_combo = attrs.max_combo();
+    let mut stars = 0.0;
+    let mut max_combo = 0;
+
+    if let Some(attrs) = attrs {
+        stars = attrs.stars() as f32;
+        max_combo = attrs.max_combo();
+    }
 
     let order = args.sort.unwrap_or_default();
     order.sort(&mut scores, &map, score_data).await;

--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -581,12 +581,18 @@ async fn process_scores(
             .filter(|_| score.grade.eq_letter(Grade::X) && score.mode != GameMode::Mania)
         {
             Some(pp) => pp,
-            None => calc.performance().await.pp() as f32,
+            None => match calc.performance().await {
+                Some(attrs) => attrs.pp() as f32,
+                None => 0.0,
+            },
         };
 
         let pp = match score.pp {
             Some(pp) => pp,
-            None => calc.score(&score).performance().await.pp() as f32,
+            None => match calc.score(&score).performance().await {
+                Some(attrs) => attrs.pp() as f32,
+                None => 0.0,
+            },
         };
 
         let map_id = score.map_id;

--- a/bathbot/src/commands/osu/simulate/mod.rs
+++ b/bathbot/src/commands/osu/simulate/mod.rs
@@ -121,7 +121,10 @@ async fn simulate(orig: CommandOrigin<'_>, mut args: SimulateArgs) -> Result<()>
     };
 
     let max_combo = match map {
-        SimulateMap::Full(ref map) => Context::pp(map).difficulty().await.max_combo(),
+        SimulateMap::Full(ref map) => match Context::pp(map).difficulty().await {
+            Some(attrs) => attrs.max_combo(),
+            None => 0,
+        },
         SimulateMap::Attached(ref map) => map.max_combo,
     };
 

--- a/bathbot/src/commands/osu/simulate/parsed_map.rs
+++ b/bathbot/src/commands/osu/simulate/parsed_map.rs
@@ -51,7 +51,11 @@ impl AttachedSimulateMap {
             let _ = pp_map.convert_mut((mode as u8).into(), &Default::default());
         }
 
-        let max_combo = Difficulty::new().calculate(&pp_map).max_combo();
+        let max_combo = if pp_map.check_suspicion().is_ok() {
+            Difficulty::new().calculate(&pp_map).max_combo()
+        } else {
+            0
+        };
 
         Ok(Some(Self {
             pp_map,

--- a/bathbot/src/commands/osu/top/if_.rs
+++ b/bathbot/src/commands/osu/top/if_.rs
@@ -568,19 +568,33 @@ async fn process_scores(
         let old_pp = score.pp.unwrap_or(0.0);
 
         let new_pp = if changed {
-            calc.score(&score).performance().await.pp() as f32
+            if let Some(attrs) = calc.score(&score).performance().await {
+                attrs.pp() as f32
+            } else {
+                0.0
+            }
         } else {
             old_pp
         };
+
+        let mut stars = 0.0;
+        let mut max_pp = 0.0;
+        let mut max_combo = 0;
+
+        if let Some(attrs) = attrs {
+            stars = attrs.stars() as f32;
+            max_pp = attrs.pp() as f32;
+            max_combo = attrs.max_combo();
+        }
 
         let entry = TopIfEntry {
             original_idx: i,
             score: ScoreSlim::new(score, new_pp),
             old_pp,
             map,
-            stars: attrs.stars() as f32,
-            max_pp: attrs.pp() as f32,
-            max_combo: attrs.max_combo(),
+            stars,
+            max_pp,
+            max_combo,
         };
 
         entries.push(entry);

--- a/bathbot/src/commands/utility/embed_builder.rs
+++ b/bathbot/src/commands/utility/embed_builder.rs
@@ -299,7 +299,10 @@ impl ScoreEmbedDataWrap {
 
         let pp = match score.pp {
             Some(pp) => pp,
-            None => calc.score(&score).performance().await.pp() as f32,
+            None => match calc.score(&score).performance().await {
+                Some(attrs) => attrs.pp() as f32,
+                None => 0.0,
+            },
         };
 
         let score = ScoreSlim::new(score, pp);
@@ -448,7 +451,10 @@ impl ScoreEmbedDataHalf {
 
         let pp = match score.pp {
             Some(pp) => pp,
-            None => calc.score(&score).performance().await.pp() as f32,
+            None => match calc.score(&score).performance().await {
+                Some(attrs) => attrs.pp() as f32,
+                None => 0.0,
+            },
         };
 
         let has_replay = score.has_replay;
@@ -807,7 +813,10 @@ impl ScoreEmbedDataRaw {
 
         let pp = match self.pp {
             Some(pp) => pp,
-            None => calc.score(&self).performance().await.pp() as f32,
+            None => match calc.score(&self).performance().await {
+                Some(attrs) => attrs.pp() as f32,
+                None => 0.0,
+            },
         };
 
         let score = ScoreSlim {
@@ -943,14 +952,18 @@ impl<'m> PpAttrs<'m> {
             .mods(mods.to_owned())
             .lazer(lazer);
 
-        let attrs = calc.performance().await;
+        let mut max_pp = 0.0;
+        let mut stars = 0.0;
+        let mut max_combo = 0;
 
-        let max_pp = pp
-            .filter(|_| grade.eq_letter(Grade::X) && mode != GameMode::Mania)
-            .unwrap_or(attrs.pp() as f32);
+        if let Some(attrs) = calc.performance().await {
+            max_pp = pp
+                .filter(|_| grade.eq_letter(Grade::X) && mode != GameMode::Mania)
+                .unwrap_or(attrs.pp() as f32);
 
-        let stars = attrs.stars() as f32;
-        let max_combo = attrs.max_combo();
+            stars = attrs.stars() as f32;
+            max_combo = attrs.max_combo();
+        }
 
         Self {
             calc,

--- a/bathbot/src/embeds/osu/player_snipe_stats.rs
+++ b/bathbot/src/embeds/osu/player_snipe_stats.rs
@@ -65,14 +65,22 @@ impl PlayerSnipeStatsEmbed {
             if let Some((oldest_score, oldest_map)) = oldest {
                 let mut calc = Context::pp(oldest_map).mods(oldest_score.mods.clone());
 
-                let attrs = calc.performance().await;
-                let stars = attrs.stars() as f32;
-                let max_pp = attrs.pp() as f32;
-                let max_combo = attrs.max_combo();
+                let mut stars = 0.0;
+                let mut max_pp = 0.0;
+                let mut max_combo = 0;
+
+                if let Some(attrs) = calc.performance().await {
+                    stars = attrs.stars() as f32;
+                    max_pp = attrs.pp() as f32;
+                    max_combo = attrs.max_combo();
+                }
 
                 let pp = match oldest_score.pp {
                     Some(pp) => pp,
-                    None => calc.score(oldest_score).performance().await.pp() as f32,
+                    None => match calc.score(oldest_score).performance().await {
+                        Some(attrs) => attrs.pp() as f32,
+                        None => 0.0,
+                    },
                 };
 
                 // TODO: update formatting

--- a/bathbot/src/manager/osu_map.rs
+++ b/bathbot/src/manager/osu_map.rs
@@ -70,18 +70,19 @@ impl MapManager {
         Ok(pp_map)
     }
 
+    /// Returns `Ok(None)` if the map is too suspicious.
     pub async fn difficulty(
         self,
         map_id: u32,
         mode: GameMode,
         mods: impl Into<Mods>,
-    ) -> Result<DifficultyAttributes> {
+    ) -> Result<Option<DifficultyAttributes>> {
         async fn inner(
             this: MapManager,
             map_id: u32,
             mode: GameMode,
             mods: Mods,
-        ) -> Result<DifficultyAttributes> {
+        ) -> Result<Option<DifficultyAttributes>> {
             let map = this.pp_map(map_id).await.wrap_err("Failed to get pp map")?;
 
             let attrs = PpManager::from_parsed(&map)
@@ -89,7 +90,7 @@ impl MapManager {
                 .mods(mods)
                 .difficulty()
                 .await
-                .to_owned();
+                .cloned();
 
             Ok(attrs)
         }

--- a/bathbot/src/util/osu.rs
+++ b/bathbot/src/util/osu.rs
@@ -448,13 +448,14 @@ pub struct IfFc {
 }
 
 impl IfFc {
+    /// Returns `None` if the score is an FC or if the map is too suspicious.
     pub async fn new(score: &ScoreSlim, map: &OsuMap) -> Option<Self> {
         let mut calc = Context::pp(map)
             .mods(score.mods.clone())
             .mode(score.mode)
             .lazer(score.set_on_lazer);
 
-        let attrs = calc.difficulty().await;
+        let attrs = calc.difficulty().await?;
 
         if score.is_fc(score.mode, attrs.max_combo()) {
             return None;


### PR DESCRIPTION
Calculating difficulty or performance attributes is now almost always prefaced with a suspicion check as introduced here https://github.com/MaxOhn/rosu-pp/pull/56 to prevent calculations on malicious maps.