### PR TITLE
feat: add prefix version for slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "twilight-interactions"
 version = "0.16.1"
-source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#475ac138be35b68a21e11adffbd92eda2af856da"
+source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#c0db4a8f1408f80b44b0a2cecb8b2f6ad6af88f1"
 dependencies = [
  "twilight-interactions-derive",
  "twilight-model",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "twilight-interactions-derive"
 version = "0.16.1"
-source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#475ac138be35b68a21e11adffbd92eda2af856da"
+source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#c0db4a8f1408f80b44b0a2cecb8b2f6ad6af88f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "twilight-interactions"
 version = "0.16.1"
-source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#4c5d2186920b1df761c389db7c23f31580fd976d"
+source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#f24136c6d3912a4a2499e81adab1db853fec355d"
 dependencies = [
  "twilight-interactions-derive",
  "twilight-model",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "twilight-interactions-derive"
 version = "0.16.1"
-source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#4c5d2186920b1df761c389db7c23f31580fd976d"
+source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#f24136c6d3912a4a2499e81adab1db853fec355d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "twilight-interactions"
 version = "0.16.1"
-source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#c0db4a8f1408f80b44b0a2cecb8b2f6ad6af88f1"
+source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#4c5d2186920b1df761c389db7c23f31580fd976d"
 dependencies = [
  "twilight-interactions-derive",
  "twilight-model",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "twilight-interactions-derive"
 version = "0.16.1"
-source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#c0db4a8f1408f80b44b0a2cecb8b2f6ad6af88f1"
+source = "git+https://github.com/MaxOhn/twilight-interactions?branch=with-help-16#4c5d2186920b1df761c389db7c23f31580fd976d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { version = "2.0.11" }
 twilight-gateway = { version = "0.16", default-features = false, features = ["rustls-webpki-roots", "rustls-ring", "twilight-http", "zlib-stock"] }
 twilight-http = { version = "0.16", default-features = false, features = ["rustls-webpki-roots", "rustls-ring"] }
 twilight-interactions = { git = "https://github.com/MaxOhn/twilight-interactions", branch = "with-help-16", default-features = false, features = ["derive"] }
+# twilight-interactions = { path = "../twilight-interactions/twilight-interactions", default-features = false, features = ["derive"] }
 twilight-model = { version = "0.16", default-features = false }
 twilight-standby = { version = "0.16", default-features = false }
 

--- a/bathbot-macros/src/prefix/attrs.rs
+++ b/bathbot-macros/src/prefix/attrs.rs
@@ -1,17 +1,17 @@
-use syn::{Attribute, Error, Ident, LitStr, Meta, MetaList, Result, Token};
+use syn::{Attribute, Error, Ident, Meta, MetaList, Result, Token};
 
 use crate::{
     bucket::Bucket,
     flags::Flags,
-    util::{AsOption, PunctuatedExt},
+    util::{AsOption, LitOrConst, PunctuatedExt},
 };
 
 pub struct CommandAttrs {
-    pub aliases: Box<[LitStr]>,
-    pub desc: Option<LitStr>,
-    pub help: AsOption<LitStr>,
-    pub usage: AsOption<LitStr>,
-    pub examples: Box<[LitStr]>,
+    pub aliases: Box<[LitOrConst]>,
+    pub desc: Option<LitOrConst>,
+    pub help: AsOption<LitOrConst>,
+    pub usage: AsOption<LitOrConst>,
+    pub examples: Box<[LitOrConst]>,
     pub bucket: AsOption<Bucket>,
     pub flags: Flags,
     pub group: Option<Ident>,
@@ -73,11 +73,11 @@ impl CommandAttrs {
     }
 }
 
-fn parse_all(list: &MetaList) -> Result<Vec<LitStr>> {
-    list.parse_args_with(Vec::<LitStr>::parse_separated_nonempty::<Token![,]>)
+fn parse_all(list: &MetaList) -> Result<Vec<LitOrConst>> {
+    list.parse_args_with(Vec::<LitOrConst>::parse_separated_nonempty::<Token![,]>)
 }
 
-fn parse_one(list: &MetaList) -> Result<Option<LitStr>> {
+fn parse_one(list: &MetaList) -> Result<Option<LitOrConst>> {
     let mut list = parse_all(list)?.into_iter();
 
     match (list.next(), list.next()) {

--- a/bathbot-macros/src/slash/attrs.rs
+++ b/bathbot-macros/src/slash/attrs.rs
@@ -1,7 +1,11 @@
 use proc_macro2::Span;
 use syn::{Attribute, Error, LitBool, LitStr, Result};
 
-use crate::{bucket::Bucket, flags::Flags, util::AsOption};
+use crate::{
+    bucket::Bucket,
+    flags::Flags,
+    util::{AsOption, LitOrConst},
+};
 
 pub(super) struct CommandAttrs {
     pub(super) bucket: AsOption<Bucket>,
@@ -25,7 +29,7 @@ impl CommandAttrs {
                     if meta.path.is_ident("name") {
                         name_lit = Some(meta.value()?.parse()?);
                     } else if meta.path.is_ident("desc") | meta.path.is_ident("help") {
-                        let _: LitStr = meta.value()?.parse()?;
+                        let _: LitOrConst = meta.value()?.parse()?;
                     } else if meta.path.is_ident("dm_permission") {
                         let _: LitBool = meta.value()?.parse()?;
                     } else {

--- a/bathbot-util/src/osu.rs
+++ b/bathbot-util/src/osu.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp,
+    fmt::{Display, Formatter, Result as FmtResult},
     iter::{self, Copied, Map},
     slice::Iter,
 };
@@ -433,6 +434,17 @@ pub fn pp_missing(start: f64, goal: f64, pps: impl IntoPpIter) -> (f64, usize) {
 pub enum MapIdType {
     Map(u32),
     Set(u32),
+}
+
+impl Display for MapIdType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let id = match self {
+            MapIdType::Map(id) => id,
+            MapIdType::Set(id) => id,
+        };
+
+        Display::fmt(id, f)
+    }
 }
 
 // Credits to https://github.com/RoanH/osu-BonusPP/blob/master/BonusPP/src/me/roan/bonuspp/BonusPP.java#L202

--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -30,7 +30,6 @@ use crate::{
     active::{
         BuildPage, ComponentResult, IActiveMessage,
         pagination::{Pages, handle_pagination_component},
-        response::ActiveResponse,
     },
     core::Context,
     manager::redis::osu::UserArgs,
@@ -46,7 +45,6 @@ pub struct BookmarksPagination {
     defer_next: bool,
     filtered_maps: Option<bool>,
     confirm_remove: Option<bool>,
-    token: String,
     msg_owner: Id<UserMarker>,
     content: String,
     pages: Pages,
@@ -421,16 +419,6 @@ impl IActiveMessage for BookmarksPagination {
 
     fn until_timeout(&self) -> Option<Duration> {
         (!self.bookmarks.is_empty()).then_some(Duration::from_secs(60))
-    }
-
-    async fn on_timeout(&mut self, _: ActiveResponse) -> Result<()> {
-        Context::interaction()
-            .update_response(&self.token)
-            .components(Some(&[]))
-            .await
-            .wrap_err("Failed to update on bookmark timeout")?;
-
-        Ok(())
     }
 }
 

--- a/bathbot/src/commands/osu/attributes.rs
+++ b/bathbot/src/commands/osu/attributes.rs
@@ -1,4 +1,6 @@
-use bathbot_macros::SlashCommand;
+use std::borrow::Cow;
+
+use bathbot_macros::{SlashCommand, command};
 use bathbot_util::{
     MessageBuilder, matcher,
     osu::{AttributeKind, ModSelection},
@@ -8,8 +10,9 @@ use rosu_v2::{model::mods::GameModsIntermode, prelude::GameMode};
 use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
+    core::commands::{CommandOrigin, prefix::Args},
     embeds::{AttributesEmbed, EmbedData},
-    util::{InteractionCommandExt, interaction::InteractionCommand},
+    util::{ChannelExt, InteractionCommandExt, interaction::InteractionCommand},
 };
 
 #[derive(CommandModel, CreateCommand, SlashCommand)]
@@ -18,45 +21,92 @@ use crate::{
     desc = "Check how mods influence the AR, OD, HP, or CS attributes"
 )]
 #[flags(SKIP_DEFER)]
-pub enum Attributes {
+pub enum Attributes<'a> {
     #[command(name = "ar")]
-    Ar(AttributesAr),
+    Ar(AttributesAr<'a>),
     #[command(name = "cs")]
-    Cs(AttributesCs),
+    Cs(AttributesCs<'a>),
     #[command(name = "hp")]
-    Hp(AttributesHp),
+    Hp(AttributesHp<'a>),
     #[command(name = "od")]
-    Od(AttributesOd),
+    Od(AttributesOd<'a>),
 }
 
+impl<'a> Attributes<'a> {
+    fn args(kind: AttributeKind, mut args: Args<'a>) -> Result<Self, &'static str> {
+        let number: f32 = args
+            .next()
+            .map(str::parse)
+            .and_then(Result::ok)
+            .ok_or("The first argument must be a number")?;
+
+        let mods = args
+            .next()
+            .map(Cow::Borrowed)
+            .ok_or("The second argument must be mods")?;
+
+        let this = match kind {
+            AttributeKind::Ar => Self::Ar(AttributesAr {
+                number: number.clamp(AR_MIN, AR_MAX),
+                mods,
+                clock_rate: None,
+            }),
+            AttributeKind::Cs => Self::Cs(AttributesCs {
+                number: number.clamp(CS_MIN, CS_MAX),
+                mods,
+                clock_rate: None,
+            }),
+            AttributeKind::Hp => Self::Hp(AttributesHp {
+                number: number.clamp(HP_MIN, HP_MAX),
+                mods,
+                clock_rate: None,
+            }),
+            AttributeKind::Od => Self::Od(AttributesOd {
+                number: number.clamp(OD_MIN, OD_MAX),
+                mods,
+                clock_rate: None,
+            }),
+        };
+
+        Ok(this)
+    }
+}
+
+const AR_DESC: &str = "Check how mods influence the approach rate attribute";
+const AR_MIN: f32 = -15.0;
+const AR_MAX: f32 = 13.0;
+
 #[derive(CommandModel, CreateCommand)]
-#[command(
-    name = "ar",
-    desc = "Check how mods influence the approach rate attribute"
-)]
-pub struct AttributesAr {
-    #[command(rename = "value", min_value = -15.0, max_value = 13.0, desc = "Specify an AR value")]
+#[command(name = "ar", desc = AR_DESC)]
+pub struct AttributesAr<'a> {
+    #[command(
+        rename = "value",
+        min_value = AR_MIN = f32,
+        max_value = AR_MAX = f32,
+        desc = "Specify an AR value"
+    )]
     number: f32,
     #[command(
         desc = "Specify mods e.g. hdhr or nm",
         help = "Specify mods either directly or through the explicit `+mod!` / `+mod` syntax, \
         e.g. `hdhr` or `+hdhr!`"
     )]
-    mods: String,
+    mods: Cow<'a, str>,
     #[command(desc = "Specify a custom clock rate that overwrites mods")]
     clock_rate: Option<f32>,
 }
 
+const CS_DESC: &str = "Check how mods influence the circle size attribute";
+const CS_MIN: f32 = 0.0;
+const CS_MAX: f32 = 20.0;
+
 #[derive(CommandModel, CreateCommand)]
-#[command(
-    name = "cs",
-    desc = "Check how mods influence the circle size attribute"
-)]
-pub struct AttributesCs {
+#[command(name = "cs", desc = CS_DESC)]
+pub struct AttributesCs<'a> {
     #[command(
         rename = "value",
-        min_value = 0.0,
-        max_value = 20.0,
+        min_value = CS_MIN = f32,
+        max_value = CS_MAX = f32,
         desc = "Specify a CS value"
     )]
     number: f32,
@@ -65,21 +115,22 @@ pub struct AttributesCs {
         help = "Specify mods either directly or through the explicit `+mod!` / `+mod` syntax, \
         e.g. `hdhr` or `+hdhr!`"
     )]
-    mods: String,
+    mods: Cow<'a, str>,
     #[command(desc = "Specify a custom clock rate that overwrites mods")]
     clock_rate: Option<f32>,
 }
 
+const HP_DESC: &str = "Check how mods influence the drain rate attribute";
+const HP_MIN: f32 = 0.0;
+const HP_MAX: f32 = 20.0;
+
 #[derive(CommandModel, CreateCommand)]
-#[command(
-    name = "hp",
-    desc = "Check how mods influence the drain rate attribute"
-)]
-pub struct AttributesHp {
+#[command(name = "hp", desc = HP_DESC)]
+pub struct AttributesHp<'a> {
     #[command(
         rename = "value",
-        min_value = 0.0,
-        max_value = 20.0,
+        min_value = HP_MIN = f32,
+        max_value = HP_MAX = f32,
         desc = "Specify an HP value"
     )]
     number: f32,
@@ -88,25 +139,31 @@ pub struct AttributesHp {
         help = "Specify mods either directly or through the explicit `+mod!` / `+mod` syntax, \
         e.g. `hdhr` or `+hdhr!`"
     )]
-    mods: String,
+    mods: Cow<'a, str>,
     #[command(desc = "Specify a custom clock rate that overwrites mods")]
     clock_rate: Option<f32>,
 }
 
+const OD_DESC: &str = "Check how mods influence the overall difficulty attribute";
+const OD_MIN: f32 = -13.33;
+const OD_MAX: f32 = 13.33;
+
 #[derive(CommandModel, CreateCommand)]
-#[command(
-    name = "od",
-    desc = "Check how mods influence the overall difficulty attribute"
-)]
-pub struct AttributesOd {
-    #[command(rename = "value", min_value = -13.33, max_value = 13.33, desc = "Specify an OD value")]
+#[command(name = "od", desc = OD_DESC)]
+pub struct AttributesOd<'a> {
+    #[command(
+        rename = "value",
+        min_value = OD_MIN = f32,
+        max_value = OD_MAX = f32,
+        desc = "Specify an OD value"
+    )]
     number: f32,
     #[command(
         desc = "Specify mods e.g. hdhr or nm",
         help = "Specify mods either directly or through the explicit `+mod!` / `+mod` syntax, \
         e.g. `hdhr` or `+hdhr!`"
     )]
-    mods: String,
+    mods: Cow<'a, str>,
     #[command(desc = "Specify a custom clock rate that overwrites mods")]
     clock_rate: Option<f32>,
 }
@@ -114,7 +171,79 @@ pub struct AttributesOd {
 async fn slash_attributes(mut command: InteractionCommand) -> Result<()> {
     let attrs = Attributes::from_interaction(command.input_data())?;
 
-    let (kind, value, mods, clock_rate) = match attrs {
+    attributes((&mut command).into(), attrs).await
+}
+
+#[command]
+#[desc(AR_DESC)]
+#[usage("[number] [mods]")]
+#[examples("8.5 +dt")]
+#[aliases("approachrate")]
+#[group(AllModes)]
+async fn prefix_ar(msg: &Message, args: Args<'_>) -> Result<()> {
+    match Attributes::args(AttributeKind::Ar, args) {
+        Ok(args) => attributes(msg.into(), args).await,
+        Err(err) => {
+            msg.error(err).await?;
+
+            Ok(())
+        }
+    }
+}
+
+#[command]
+#[desc(CS_DESC)]
+#[usage("[number] [mods]")]
+#[examples("4 +hr")]
+#[aliases("circlesize")]
+#[group(AllModes)]
+async fn prefix_cs(msg: &Message, args: Args<'_>) -> Result<()> {
+    match Attributes::args(AttributeKind::Cs, args) {
+        Ok(args) => attributes(msg.into(), args).await,
+        Err(err) => {
+            msg.error(err).await?;
+
+            Ok(())
+        }
+    }
+}
+
+#[command]
+#[desc(HP_DESC)]
+#[usage("[number] [mods]")]
+#[examples("2 +dthr")]
+#[aliases("dr", "drainrate")]
+#[group(AllModes)]
+async fn prefix_hp(msg: &Message, args: Args<'_>) -> Result<()> {
+    match Attributes::args(AttributeKind::Hp, args) {
+        Ok(args) => attributes(msg.into(), args).await,
+        Err(err) => {
+            msg.error(err).await?;
+
+            Ok(())
+        }
+    }
+}
+
+#[command]
+#[desc(OD_DESC)]
+#[usage("[number] [mods]")]
+#[examples("5 +hddt")]
+#[aliases("overalldifficulty")]
+#[group(AllModes)]
+async fn prefix_od(msg: &Message, args: Args<'_>) -> Result<()> {
+    match Attributes::args(AttributeKind::Od, args) {
+        Ok(args) => attributes(msg.into(), args).await,
+        Err(err) => {
+            msg.error(err).await?;
+
+            Ok(())
+        }
+    }
+}
+
+async fn attributes(orig: CommandOrigin<'_>, args: Attributes<'_>) -> Result<()> {
+    let (kind, value, mods, clock_rate) = match args {
         Attributes::Ar(args) => (AttributeKind::Ar, args.number, args.mods, args.clock_rate),
         Attributes::Cs(args) => (AttributeKind::Cs, args.number, args.mods, args.clock_rate),
         Attributes::Hp(args) => (AttributeKind::Hp, args.number, args.mods, args.clock_rate),
@@ -129,13 +258,13 @@ async fn slash_attributes(mut command: InteractionCommand) -> Result<()> {
             None => {
                 let content =
                     "Failed to parse mods. Be sure to specify a valid mod combination e.g. `hrdt`.";
-                command.error_callback(content).await?;
+                orig.error_callback(content).await?;
 
                 return Ok(());
             }
             Some(ModSelection::Exclude { .. }) => {
                 let content = "Excluding mods does not work for this command";
-                command.error_callback(content).await?;
+                orig.error_callback(content).await?;
 
                 return Ok(());
             }
@@ -154,14 +283,14 @@ async fn slash_attributes(mut command: InteractionCommand) -> Result<()> {
     if !valid_mods {
         let content = "Looks like either some of these mods are incompatible with each other \
             or those mods don't fit to any gamemode.";
-        command.error_callback(content).await?;
+        orig.error_callback(content).await?;
 
         return Ok(());
     }
 
     let embed = AttributesEmbed::new(kind, value, mods, clock_rate).build();
     let builder = MessageBuilder::new().embed(embed);
-    command.callback(builder, false).await?;
+    orig.callback(builder).await?;
 
     Ok(())
 }

--- a/bathbot/src/commands/osu/bookmarks/message.rs
+++ b/bathbot/src/commands/osu/bookmarks/message.rs
@@ -155,7 +155,6 @@ async fn bookmark_map(mut command: InteractionCommand) -> Result<()> {
         .origin(origin)
         .cached_entries(HashMap::default())
         .defer_next(false)
-        .token(command.token.clone())
         .content(content)
         .msg_owner(user_id)
         .build();

--- a/bathbot/src/commands/osu/bookmarks/slash.rs
+++ b/bathbot/src/commands/osu/bookmarks/slash.rs
@@ -109,7 +109,7 @@ async fn bookmarks(orig: CommandOrigin<'_>, args: Bookmarks<'_>) -> Result<()> {
     let mut bookmarks = match Context::bookmarks().get(owner).await {
         Ok(bookmarks) => bookmarks,
         Err(err) => {
-            let _ = orig.error(GENERAL_ISSUE).await?;
+            let _ = orig.error(GENERAL_ISSUE).await;
 
             return Err(err);
         }

--- a/bathbot/src/commands/osu/graphs/bpm.rs
+++ b/bathbot/src/commands/osu/graphs/bpm.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cell::RefCell, ops::ControlFlow, rc::Rc, time::Duration};
+use std::{borrow::Cow, cell::RefCell, rc::Rc, time::Duration};
 
 use bathbot_macros::command;
 use bathbot_util::{matcher, osu::MapIdType};
@@ -7,26 +7,26 @@ use plotters::{
     chart::ChartBuilder,
     prelude::{DrawingArea, Rectangle},
     series::LineSeries,
-    style::{BLACK, Color, FontDesc, RGBColor, WHITE},
+    style::{Color, FontDesc, RGBColor, BLACK, WHITE},
 };
 use plotters_backend::{FontFamily, FontStyle};
 use plotters_skia::SkiaBackend;
 use rosu_pp::{
-    Beatmap,
     model::{
         control_point::TimingPoint,
         hit_object::{HitObjectKind, HoldNote, Spinner},
     },
+    Beatmap,
 };
 use rosu_v2::prelude::GameMods;
-use skia_safe::{EncodedImageFormat, surfaces};
+use skia_safe::{surfaces, EncodedImageFormat};
 use twilight_model::{channel::Message, guild::Permissions};
 
-use super::{BitMapElement, H, W, get_map_cover};
+use super::{get_map_cover, BitMapElement, Graph, H, W};
 use crate::{
-    commands::osu::{GraphMapBpm, graphs::GRAPH_BPM_DESC},
-    core::commands::{CommandOrigin, prefix::Args},
-    util::{ChannelExt, osu::MapOrScore},
+    commands::osu::{graphs::GRAPH_BPM_DESC, GraphMapBpm},
+    core::commands::{prefix::Args, CommandOrigin},
+    util::{osu::MapOrScore, ChannelExt},
 };
 
 impl<'m> GraphMapBpm<'m> {
@@ -85,15 +85,7 @@ async fn prefix_graphbpm(msg: &Message, args: Args<'_>, perms: Option<Permission
 
     let orig = CommandOrigin::from_msg(msg, perms);
 
-    match super::map_bpm(&orig, args).await {
-        Ok(ControlFlow::Continue(map)) => {
-            orig.create_message(map.into()).await?;
-
-            Ok(())
-        }
-        Ok(ControlFlow::Break(())) => Ok(()),
-        Err(err) => Err(err.wrap_err("Failed to create map bpm graph")),
-    }
+    super::graph(orig, Graph::MapBpm(args)).await
 }
 
 pub async fn map_bpm_graph(map: &Beatmap, mods: GameMods, cover_url: &str) -> Result<Vec<u8>> {

--- a/bathbot/src/commands/osu/graphs/bpm.rs
+++ b/bathbot/src/commands/osu/graphs/bpm.rs
@@ -7,26 +7,26 @@ use plotters::{
     chart::ChartBuilder,
     prelude::{DrawingArea, Rectangle},
     series::LineSeries,
-    style::{Color, FontDesc, RGBColor, BLACK, WHITE},
+    style::{BLACK, Color, FontDesc, RGBColor, WHITE},
 };
 use plotters_backend::{FontFamily, FontStyle};
 use plotters_skia::SkiaBackend;
 use rosu_pp::{
+    Beatmap,
     model::{
         control_point::TimingPoint,
         hit_object::{HitObjectKind, HoldNote, Spinner},
     },
-    Beatmap,
 };
 use rosu_v2::prelude::GameMods;
-use skia_safe::{surfaces, EncodedImageFormat};
+use skia_safe::{EncodedImageFormat, surfaces};
 use twilight_model::{channel::Message, guild::Permissions};
 
-use super::{get_map_cover, BitMapElement, Graph, H, W};
+use super::{BitMapElement, Graph, H, W, get_map_cover};
 use crate::{
-    commands::osu::{graphs::GRAPH_BPM_DESC, GraphMapBpm},
-    core::commands::{prefix::Args, CommandOrigin},
-    util::{osu::MapOrScore, ChannelExt},
+    commands::osu::{GraphMapBpm, graphs::GRAPH_BPM_DESC},
+    core::commands::{CommandOrigin, prefix::Args},
+    util::{ChannelExt, osu::MapOrScore},
 };
 
 impl<'m> GraphMapBpm<'m> {

--- a/bathbot/src/commands/osu/graphs/map_strains.rs
+++ b/bathbot/src/commands/osu/graphs/map_strains.rs
@@ -3,27 +3,26 @@ use std::{borrow::Cow, cell::RefCell, mem, rc::Rc, time::Duration};
 use bathbot_macros::command;
 use bathbot_model::command_fields::GameModeOption;
 use bathbot_util::{matcher, osu::MapIdType};
-use enterpolation::{linear::Linear, Curve};
+use enterpolation::{Curve, linear::Linear};
 use eyre::{ContextCompat, Result, WrapErr};
 use plotters::{
-    coord::{types::RangedCoordf64, Shift},
+    coord::{Shift, types::RangedCoordf64},
     prelude::*,
 };
 use plotters_skia::SkiaBackend;
 use rosu_pp::{
-    any::Strains, catch::CatchStrains, mania::ManiaStrains, osu::OsuStrains, taiko::TaikoStrains,
-    Beatmap, Difficulty,
+    Beatmap, Difficulty, any::Strains, catch::CatchStrains, mania::ManiaStrains, osu::OsuStrains,
+    taiko::TaikoStrains,
 };
 use rosu_v2::prelude::GameMods;
-use skia_safe::{surfaces, BlendMode, EncodedImageFormat};
+use skia_safe::{BlendMode, EncodedImageFormat, surfaces};
 use twilight_model::{channel::Message, guild::Permissions};
 
+use super::{BitMapElement, Graph, GraphMapStrains, get_map_cover};
 use crate::{
-    core::commands::{prefix::Args, CommandOrigin},
-    util::{osu::MapOrScore, ChannelExt},
+    core::commands::{CommandOrigin, prefix::Args},
+    util::{ChannelExt, osu::MapOrScore},
 };
-
-use super::{get_map_cover, BitMapElement, Graph, GraphMapStrains};
 
 impl<'m> GraphMapStrains<'m> {
     async fn args(

--- a/bathbot/src/commands/osu/graphs/map_strains.rs
+++ b/bathbot/src/commands/osu/graphs/map_strains.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cell::RefCell, mem, ops::ControlFlow, rc::Rc, time::Duration};
+use std::{borrow::Cow, cell::RefCell, mem, rc::Rc, time::Duration};
 
 use bathbot_macros::command;
 use bathbot_model::command_fields::GameModeOption;
@@ -23,7 +23,7 @@ use crate::{
     util::{osu::MapOrScore, ChannelExt},
 };
 
-use super::{get_map_cover, BitMapElement, GraphMapStrains};
+use super::{get_map_cover, BitMapElement, Graph, GraphMapStrains};
 
 impl<'m> GraphMapStrains<'m> {
     async fn args(
@@ -79,7 +79,9 @@ async fn prefix_graphstrains(
     perms: Option<Permissions>,
 ) -> Result<()> {
     match GraphMapStrains::args(None, msg, args).await {
-        Ok(args) => process_graphstrains(CommandOrigin::from_msg(msg, perms), args).await,
+        Ok(args) => {
+            super::graph(CommandOrigin::from_msg(msg, perms), Graph::MapStrains(args)).await
+        }
         Err(content) => {
             msg.error(content).await?;
 
@@ -100,7 +102,9 @@ async fn prefix_graphstrainstaiko(
     perms: Option<Permissions>,
 ) -> Result<()> {
     match GraphMapStrains::args(Some(GameModeOption::Taiko), msg, args).await {
-        Ok(args) => process_graphstrains(CommandOrigin::from_msg(msg, perms), args).await,
+        Ok(args) => {
+            super::graph(CommandOrigin::from_msg(msg, perms), Graph::MapStrains(args)).await
+        }
         Err(content) => {
             msg.error(content).await?;
 
@@ -121,7 +125,9 @@ async fn prefix_graphstrainsctb(
     perms: Option<Permissions>,
 ) -> Result<()> {
     match GraphMapStrains::args(Some(GameModeOption::Catch), msg, args).await {
-        Ok(args) => process_graphstrains(CommandOrigin::from_msg(msg, perms), args).await,
+        Ok(args) => {
+            super::graph(CommandOrigin::from_msg(msg, perms), Graph::MapStrains(args)).await
+        }
         Err(content) => {
             msg.error(content).await?;
 
@@ -142,24 +148,14 @@ async fn prefix_graphstrainsmania(
     perms: Option<Permissions>,
 ) -> Result<()> {
     match GraphMapStrains::args(Some(GameModeOption::Mania), msg, args).await {
-        Ok(args) => process_graphstrains(CommandOrigin::from_msg(msg, perms), args).await,
+        Ok(args) => {
+            super::graph(CommandOrigin::from_msg(msg, perms), Graph::MapStrains(args)).await
+        }
         Err(content) => {
             msg.error(content).await?;
 
             Ok(())
         }
-    }
-}
-
-async fn process_graphstrains(orig: CommandOrigin<'_>, args: GraphMapStrains<'_>) -> Result<()> {
-    match super::map_strains(&orig, args).await {
-        Ok(ControlFlow::Continue(map)) => {
-            orig.create_message(map.into()).await?;
-
-            Ok(())
-        }
-        Ok(ControlFlow::Break(())) => Ok(()),
-        Err(err) => Err(err.wrap_err("Failed to create map bpm graph")),
     }
 }
 

--- a/bathbot/src/commands/osu/graphs/medals.rs
+++ b/bathbot/src/commands/osu/graphs/medals.rs
@@ -1,6 +1,6 @@
 use bathbot_macros::command;
 use bathbot_model::rosu_v2::user::MedalCompactRkyv;
-use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
+use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE, matcher};
 use eyre::{Report, Result};
 use rkyv::{
     rancor::{Panic, ResultExt},
@@ -13,8 +13,8 @@ use super::{Graph, GraphMedals, H, W};
 use crate::{
     commands::osu::{graphs::GRAPH_MEDALS_DESC, medals::stats as medals_stats, user_not_found},
     core::{
-        commands::{prefix::Args, CommandOrigin},
         Context,
+        commands::{CommandOrigin, prefix::Args},
     },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };

--- a/bathbot/src/commands/osu/graphs/medals.rs
+++ b/bathbot/src/commands/osu/graphs/medals.rs
@@ -1,18 +1,56 @@
+use bathbot_macros::command;
 use bathbot_model::rosu_v2::user::MedalCompactRkyv;
-use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE};
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
 use eyre::{Report, Result};
 use rkyv::{
     rancor::{Panic, ResultExt},
     with::{Map, With},
 };
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
+use twilight_model::guild::Permissions;
 
-use super::{H, W};
+use super::{Graph, GraphMedals, H, W};
 use crate::{
-    commands::osu::{medals::stats as medals_stats, user_not_found},
-    core::{Context, commands::CommandOrigin},
+    commands::osu::{graphs::GRAPH_MEDALS_DESC, medals::stats as medals_stats, user_not_found},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        Context,
+    },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
+
+impl<'m> GraphMedals<'m> {
+    fn args(args: Args<'m>) -> Self {
+        let mut name = None;
+        let mut discord = None;
+
+        for arg in args {
+            if let Some(id) = matcher::get_mention_user(arg) {
+                discord = Some(id);
+            } else {
+                name = Some(arg.into());
+            }
+        }
+
+        Self { name, discord }
+    }
+}
+
+#[command]
+#[desc(GRAPH_MEDALS_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(AllModes)]
+async fn prefix_graphmedals(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphMedals::args(args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Medals(args)).await
+}
 
 pub async fn medals_graph(
     orig: &CommandOrigin<'_>,

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -1,17 +1,16 @@
 use std::{borrow::Cow, iter, ops::ControlFlow};
 
-use bathbot_macros::{command, HasMods, HasName, SlashCommand};
+use bathbot_macros::{HasMods, HasName, SlashCommand, command};
 use bathbot_model::{
-    command_fields::{GameModeOption, ShowHideOption, TimezoneOption},
     Countries,
+    command_fields::{GameModeOption, ShowHideOption, TimezoneOption},
 };
 use bathbot_psql::model::configs::ScoreData;
 use bathbot_util::{
-    attachment,
+    AuthorBuilder, CowUtils, EmbedBuilder, FooterBuilder, MessageBuilder, attachment,
     constants::{GENERAL_ISSUE, OSU_BASE},
     matcher,
     osu::{MapIdType, ModSelection, ModsResult},
-    AuthorBuilder, CowUtils, EmbedBuilder, FooterBuilder, MessageBuilder,
 };
 use eyre::{Report, Result, WrapErr};
 use image::{DynamicImage, GenericImageView, RgbaImage};
@@ -25,8 +24,8 @@ use rosu_v2::{
 use time::UtcOffset;
 use twilight_interactions::command::{CommandModel, CommandOption, CreateCommand, CreateOption};
 use twilight_model::id::{
-    marker::{ChannelMarker, UserMarker},
     Id,
+    marker::{ChannelMarker, UserMarker},
 };
 
 pub use self::map_strains::map_strains_graph;
@@ -34,7 +33,7 @@ use self::{
     bpm::map_bpm_graph,
     medals::medals_graph,
     osutrack::osutrack_graph,
-    playcount_replays::{playcount_replays_graph, ProfileGraphFlags},
+    playcount_replays::{ProfileGraphFlags, playcount_replays_graph},
     rank::rank_graph,
     score_rank::score_rank_graph,
     snipe_count::snipe_count_graph,
@@ -43,15 +42,15 @@ use self::{
     top_index::top_graph_index,
     top_time::{top_graph_time_day, top_graph_time_hour},
 };
-use super::{require_link, user_not_found, SnipeGameMode, UserIdResult};
+use super::{SnipeGameMode, UserIdResult, require_link, user_not_found};
 use crate::{
     commands::osu::{HasMods, HasName as HasNameTrait},
-    core::{commands::CommandOrigin, Context},
+    core::{Context, commands::CommandOrigin},
     manager::{
-        redis::osu::{CachedUser, UserArgs, UserArgsError},
         MapError, OsuMap,
+        redis::osu::{CachedUser, UserArgs, UserArgsError},
     },
-    util::{interaction::InteractionCommand, CachedUserExt, InteractionCommandExt},
+    util::{CachedUserExt, InteractionCommandExt, interaction::InteractionCommand},
 };
 
 mod bpm;

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -79,7 +79,7 @@ pub enum Graph<'a> {
     #[command(name = "osutrack")]
     OsuTrack(GraphOsuTrack),
     #[command(name = "playcount_replays")]
-    PlaycountReplays(GraphPlaycountReplays),
+    PlaycountReplays(GraphPlaycountReplays<'a>),
     #[command(name = "rank")]
     Rank(GraphRank),
     #[command(name = "score_rank")]
@@ -271,14 +271,13 @@ pub struct GraphOsuTrackGrades {
     discord: Option<Id<UserMarker>>,
 }
 
+const GRAPH_PLAYCOUNT_DESC: &str = "Display a user's playcount and replays watched over time";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(
-    name = "playcount_replays",
-    desc = "Display a user's playcount and replays watched over time"
-)]
-pub struct GraphPlaycountReplays {
+#[command( name = "playcount_replays", desc = GRAPH_PLAYCOUNT_DESC)]
+pub struct GraphPlaycountReplays<'a> {
     #[command(desc = "Specify a username")]
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     #[command(
         desc = "Specify a linked discord user",
         help = "Instead of specifying an osu! username with the `name` option, \

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -85,9 +85,9 @@ pub enum Graph<'a> {
     #[command(name = "score_rank")]
     ScoreRank(GraphScoreRank<'a>),
     #[command(name = "sniped")]
-    Sniped(GraphSniped),
+    Sniped(GraphSniped<'a>),
     #[command(name = "snipe_count")]
-    SnipeCount(GraphSnipeCount),
+    SnipeCount(GraphSnipeCount<'a>),
     #[command(name = "top")]
     Top(GraphTop),
 }
@@ -337,13 +337,15 @@ pub struct GraphScoreRank<'a> {
     discord: Option<Id<UserMarker>>,
 }
 
+const GRAPH_SNIPED_DESC: &str = "Display sniped users of the past 8 weeks";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(name = "sniped", desc = "Display sniped users of the past 8 weeks")]
-pub struct GraphSniped {
+#[command(name = "sniped", desc = GRAPH_SNIPED_DESC)]
+pub struct GraphSniped<'a> {
     #[command(desc = "Specify a gamemode")]
     mode: Option<SnipeGameMode>,
     #[command(desc = "Specify a username")]
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     #[command(
         desc = "Specify a linked discord user",
         help = "Instead of specifying an osu! username with the `name` option, \
@@ -353,16 +355,15 @@ pub struct GraphSniped {
     discord: Option<Id<UserMarker>>,
 }
 
+const GRAPH_SNIPE_COUNT_DESC: &str = "Display how a user's national #1 count progressed";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(
-    name = "snipe_count",
-    desc = "Display how a user's national #1 count progressed"
-)]
-pub struct GraphSnipeCount {
+#[command(name = "snipe_count", desc = GRAPH_SNIPE_COUNT_DESC)]
+pub struct GraphSnipeCount<'a> {
     #[command(desc = "Specify a gamemode")]
     mode: Option<SnipeGameMode>,
     #[command(desc = "Specify a username")]
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     #[command(
         desc = "Specify a linked discord user",
         help = "Instead of specifying an osu! username with the `name` option, \

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -81,9 +81,9 @@ pub enum Graph<'a> {
     #[command(name = "playcount_replays")]
     PlaycountReplays(GraphPlaycountReplays<'a>),
     #[command(name = "rank")]
-    Rank(GraphRank),
+    Rank(GraphRank<'a>),
     #[command(name = "score_rank")]
-    ScoreRank(GraphScoreRank),
+    ScoreRank(GraphScoreRank<'a>),
     #[command(name = "sniped")]
     Sniped(GraphSniped),
     #[command(name = "snipe_count")]
@@ -293,13 +293,15 @@ pub struct GraphPlaycountReplays<'a> {
     badges: Option<ShowHideOption>,
 }
 
+const GRAPH_RANK_DESC: &str = "Display a user's rank progression over time";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(name = "rank", desc = "Display a user's rank progression over time")]
-pub struct GraphRank {
+#[command(name = "rank", desc = GRAPH_RANK_DESC)]
+pub struct GraphRank<'a> {
     #[command(desc = "Specify a gamemode")]
     mode: Option<GameModeOption>,
     #[command(desc = "Specify a username")]
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     #[command(desc = "From this many days ago", min_value = 0, max_value = 90)]
     from: Option<u8>,
     #[command(desc = "Until this many days ago", min_value = 0, max_value = 90)]
@@ -313,16 +315,15 @@ pub struct GraphRank {
     discord: Option<Id<UserMarker>>,
 }
 
+const GRAPH_SCORE_RANK_DESC: &str = "Display a user's score rank progression over time";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(
-    name = "score_rank",
-    desc = "Display a user's score rank progression over time"
-)]
-pub struct GraphScoreRank {
+#[command(name = "score_rank", desc = GRAPH_SCORE_RANK_DESC)]
+pub struct GraphScoreRank<'a> {
     #[command(desc = "Specify a gamemode")]
     mode: Option<GameModeOption>,
     #[command(desc = "Specify a username")]
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     #[command(desc = "From this many days ago", min_value = 0, max_value = 90)]
     from: Option<u8>,
     #[command(desc = "Until this many days ago", min_value = 0, max_value = 90)]

--- a/bathbot/src/commands/osu/graphs/mod.rs
+++ b/bathbot/src/commands/osu/graphs/mod.rs
@@ -75,7 +75,7 @@ pub enum Graph<'a> {
     #[command(name = "strains")]
     MapStrains(GraphMapStrains<'a>),
     #[command(name = "medals")]
-    Medals(GraphMedals),
+    Medals(GraphMedals<'a>),
     #[command(name = "osutrack")]
     OsuTrack(GraphOsuTrack),
     #[command(name = "playcount_replays")]
@@ -130,11 +130,13 @@ pub struct GraphMapStrains<'a> {
     mode: Option<GameModeOption>,
 }
 
+const GRAPH_MEDALS_DESC: &str = "Display a user's medal progress over time";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(name = "medals", desc = "Display a user's medal progress over time")]
-pub struct GraphMedals {
+#[command(name = "medals", desc = GRAPH_MEDALS_DESC)]
+pub struct GraphMedals<'a> {
     #[command(desc = "Specify a username")]
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     #[command(
         desc = "Specify a linked discord user",
         help = "Instead of specifying an osu! username with the `name` option, \

--- a/bathbot/src/commands/osu/graphs/playcount_replays.rs
+++ b/bathbot/src/commands/osu/graphs/playcount_replays.rs
@@ -2,20 +2,20 @@ use std::iter;
 
 use bathbot_macros::command;
 use bathbot_model::rosu_v2::user::MonthlyCountRkyv;
-use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
+use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE, matcher};
 use bitflags::bitflags;
 use bytes::Bytes;
 use eyre::{ContextCompat, Report, Result, WrapErr};
-use futures::{stream::FuturesUnordered, TryStreamExt};
+use futures::{TryStreamExt, stream::FuturesUnordered};
 use image::imageops::FilterType::Lanczos3;
 use plotters::{
-    coord::{types::RangedCoordi32, Shift},
+    coord::{Shift, types::RangedCoordi32},
     prelude::{
         Cartesian2d, ChartBuilder, ChartContext, Circle, DrawingArea, IntoDrawingArea, PathElement,
         SeriesLabelPosition,
     },
     series::AreaSeries,
-    style::{Color, RGBColor, BLACK, WHITE},
+    style::{BLACK, Color, RGBColor, WHITE},
 };
 use plotters_backend::FontStyle;
 use plotters_skia::SkiaBackend;
@@ -28,7 +28,7 @@ use rosu_v2::{
     prelude::{MonthlyCount, OsuError},
     request::UserId,
 };
-use skia_safe::{surfaces, EncodedImageFormat, Surface};
+use skia_safe::{EncodedImageFormat, Surface, surfaces};
 use time::{Date, Month, OffsetDateTime};
 use twilight_model::guild::Permissions;
 
@@ -36,8 +36,8 @@ use super::{BitMapElement, Graph, GraphPlaycountReplays, H, W};
 use crate::{
     commands::osu::{graphs::GRAPH_PLAYCOUNT_DESC, user_not_found},
     core::{
-        commands::{prefix::Args, CommandOrigin},
         Context,
+        commands::{CommandOrigin, prefix::Args},
     },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
     util::Monthly,

--- a/bathbot/src/commands/osu/graphs/rank.rs
+++ b/bathbot/src/commands/osu/graphs/rank.rs
@@ -1,25 +1,117 @@
 use std::iter;
 
-use bathbot_util::{constants::GENERAL_ISSUE, numbers::WithComma};
+use bathbot_macros::command;
+use bathbot_model::command_fields::GameModeOption;
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, numbers::WithComma};
 use eyre::{ContextCompat, Report, Result, WrapErr};
 use plotters::{
     prelude::{ChartBuilder, Circle, IntoDrawingArea, SeriesLabelPosition},
     series::AreaSeries,
-    style::{BLACK, Color, GREEN, RED, RGBColor, ShapeStyle, WHITE},
+    style::{Color, RGBColor, ShapeStyle, BLACK, GREEN, RED, WHITE},
 };
 use plotters_backend::FontStyle;
 use plotters_skia::SkiaBackend;
 use rosu_v2::{prelude::OsuError, request::UserId};
-use skia_safe::{EncodedImageFormat, surfaces};
+use skia_safe::{surfaces, EncodedImageFormat};
+use twilight_model::guild::Permissions;
 
 use crate::{
     commands::osu::{
-        graphs::{H, W},
+        graphs::{GRAPH_RANK_DESC, H, W},
         user_not_found,
     },
-    core::{Context, commands::CommandOrigin},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        Context,
+    },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
+
+use super::{Graph, GraphRank};
+
+impl<'m> GraphRank<'m> {
+    fn args(mode: Option<GameModeOption>, args: Args<'m>) -> Self {
+        let mut name = None;
+        let mut discord = None;
+
+        for arg in args {
+            if let Some(id) = matcher::get_mention_user(arg) {
+                discord = Some(id);
+            } else {
+                name = Some(arg.into());
+            }
+        }
+
+        Self {
+            mode,
+            name,
+            discord,
+            from: None,
+            until: None,
+        }
+    }
+}
+
+#[command]
+#[desc(GRAPH_RANK_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Osu)]
+async fn prefix_graphrank(msg: &Message, args: Args<'_>, perms: Option<Permissions>) -> Result<()> {
+    let args = GraphRank::args(None, args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Rank(args)).await
+}
+
+#[command]
+#[desc(GRAPH_RANK_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Taiko)]
+async fn prefix_graphranktaiko(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphRank::args(Some(GameModeOption::Taiko), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Rank(args)).await
+}
+
+#[command]
+#[desc(GRAPH_RANK_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[aliases("graphrankcatch")]
+#[group(Catch)]
+async fn prefix_graphrankctb(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphRank::args(Some(GameModeOption::Catch), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Rank(args)).await
+}
+
+#[command]
+#[desc(GRAPH_RANK_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Mania)]
+async fn prefix_graphrankmania(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphRank::args(Some(GameModeOption::Mania), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Rank(args)).await
+}
 
 pub async fn rank_graph(
     orig: &CommandOrigin<'_>,

--- a/bathbot/src/commands/osu/graphs/rank.rs
+++ b/bathbot/src/commands/osu/graphs/rank.rs
@@ -7,27 +7,26 @@ use eyre::{ContextCompat, Report, Result, WrapErr};
 use plotters::{
     prelude::{ChartBuilder, Circle, IntoDrawingArea, SeriesLabelPosition},
     series::AreaSeries,
-    style::{Color, RGBColor, ShapeStyle, BLACK, GREEN, RED, WHITE},
+    style::{BLACK, Color, GREEN, RED, RGBColor, ShapeStyle, WHITE},
 };
 use plotters_backend::FontStyle;
 use plotters_skia::SkiaBackend;
 use rosu_v2::{prelude::OsuError, request::UserId};
-use skia_safe::{surfaces, EncodedImageFormat};
+use skia_safe::{EncodedImageFormat, surfaces};
 use twilight_model::guild::Permissions;
 
+use super::{Graph, GraphRank};
 use crate::{
     commands::osu::{
         graphs::{GRAPH_RANK_DESC, H, W},
         user_not_found,
     },
     core::{
-        commands::{prefix::Args, CommandOrigin},
         Context,
+        commands::{CommandOrigin, prefix::Args},
     },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
-
-use super::{Graph, GraphRank};
 
 impl<'m> GraphRank<'m> {
     fn args(mode: Option<GameModeOption>, args: Args<'m>) -> Self {

--- a/bathbot/src/commands/osu/graphs/score_rank.rs
+++ b/bathbot/src/commands/osu/graphs/score_rank.rs
@@ -1,34 +1,33 @@
 use std::iter;
 
 use bathbot_macros::command;
-use bathbot_model::{command_fields::GameModeOption, RespektiveUser};
-use bathbot_util::{constants::GENERAL_ISSUE, matcher, numbers::WithComma, AuthorBuilder};
+use bathbot_model::{RespektiveUser, command_fields::GameModeOption};
+use bathbot_util::{AuthorBuilder, constants::GENERAL_ISSUE, matcher, numbers::WithComma};
 use eyre::{ContextCompat, Report, Result, WrapErr};
 use plotters::{
     prelude::{ChartBuilder, Circle, IntoDrawingArea, SeriesLabelPosition},
     series::AreaSeries,
-    style::{Color, RGBColor, ShapeStyle, BLACK, GREEN, RED, WHITE},
+    style::{BLACK, Color, GREEN, RED, RGBColor, ShapeStyle, WHITE},
 };
 use plotters_backend::FontStyle;
 use plotters_skia::SkiaBackend;
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
-use skia_safe::{surfaces, EncodedImageFormat};
+use skia_safe::{EncodedImageFormat, surfaces};
 use time::OffsetDateTime;
 use twilight_model::guild::Permissions;
 
+use super::{Graph, GraphScoreRank};
 use crate::{
     commands::osu::{
         graphs::{GRAPH_SCORE_RANK_DESC, H, W},
         rank, user_not_found,
     },
     core::{
-        commands::{prefix::Args, CommandOrigin},
         Context,
+        commands::{CommandOrigin, prefix::Args},
     },
     manager::redis::osu::{UserArgs, UserArgsError},
 };
-
-use super::{Graph, GraphScoreRank};
 
 impl<'m> GraphScoreRank<'m> {
     fn args(mode: Option<GameModeOption>, args: Args<'m>) -> Self {

--- a/bathbot/src/commands/osu/graphs/score_rank.rs
+++ b/bathbot/src/commands/osu/graphs/score_rank.rs
@@ -88,7 +88,7 @@ async fn prefix_graphscoreranktaiko(
 #[desc(GRAPH_SCORE_RANK_DESC)]
 #[usage("[username]")]
 #[examples("peppy")]
-#[aliases("graphrankcatch")]
+#[aliases("graphscorerankcatch")]
 #[group(Catch)]
 async fn prefix_graphscorerankctb(
     msg: &Message,

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -1,13 +1,90 @@
-use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE};
+use bathbot_macros::command;
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
+use twilight_model::guild::Permissions;
 
-use super::{H, W};
+use super::{Graph, GraphSnipeCount, H, W};
 use crate::{
-    commands::osu::{player_snipe_stats, user_not_found},
-    core::{Context, commands::CommandOrigin},
+    commands::osu::{
+        graphs::GRAPH_SNIPE_COUNT_DESC, player_snipe_stats, user_not_found, SnipeGameMode,
+    },
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        Context,
+    },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
+
+impl<'m> GraphSnipeCount<'m> {
+    fn args(mode: Option<SnipeGameMode>, args: Args<'m>) -> Self {
+        let mut name = None;
+        let mut discord = None;
+
+        for arg in args {
+            if let Some(id) = matcher::get_mention_user(arg) {
+                discord = Some(id);
+            } else {
+                name = Some(arg.into());
+            }
+        }
+
+        Self {
+            mode,
+            name,
+            discord,
+        }
+    }
+}
+
+#[command]
+#[desc(GRAPH_SNIPE_COUNT_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Osu)]
+async fn prefix_graphsnipecount(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphSnipeCount::args(None, args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::SnipeCount(args)).await
+}
+
+#[command]
+#[desc(GRAPH_SNIPE_COUNT_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[aliases("graphsnipecountcatch")]
+#[group(Catch)]
+async fn prefix_graphsnipecountctb(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphSnipeCount::args(Some(SnipeGameMode::Catch), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::SnipeCount(args)).await
+}
+
+#[command]
+#[desc(GRAPH_SNIPE_COUNT_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Mania)]
+async fn prefix_graphsnipecountmania(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphSnipeCount::args(Some(SnipeGameMode::Mania), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::SnipeCount(args)).await
+}
 
 pub async fn snipe_count_graph(
     orig: &CommandOrigin<'_>,

--- a/bathbot/src/commands/osu/graphs/snipe_count.rs
+++ b/bathbot/src/commands/osu/graphs/snipe_count.rs
@@ -1,5 +1,5 @@
 use bathbot_macros::command;
-use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
+use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE, matcher};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use twilight_model::guild::Permissions;
@@ -7,11 +7,11 @@ use twilight_model::guild::Permissions;
 use super::{Graph, GraphSnipeCount, H, W};
 use crate::{
     commands::osu::{
-        graphs::GRAPH_SNIPE_COUNT_DESC, player_snipe_stats, user_not_found, SnipeGameMode,
+        SnipeGameMode, graphs::GRAPH_SNIPE_COUNT_DESC, player_snipe_stats, user_not_found,
     },
     core::{
-        commands::{prefix::Args, CommandOrigin},
         Context,
+        commands::{CommandOrigin, prefix::Args},
     },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -1,13 +1,88 @@
-use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE};
+use bathbot_macros::command;
+use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
+use twilight_model::guild::Permissions;
 
-use super::{H, W};
+use super::{Graph, GraphSniped, H, W};
 use crate::{
-    commands::osu::{sniped, user_not_found},
-    core::{Context, commands::CommandOrigin},
+    commands::osu::{graphs::GRAPH_SNIPED_DESC, sniped, user_not_found, SnipeGameMode},
+    core::{
+        commands::{prefix::Args, CommandOrigin},
+        Context,
+    },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };
+
+impl<'m> GraphSniped<'m> {
+    fn args(mode: Option<SnipeGameMode>, args: Args<'m>) -> Self {
+        let mut name = None;
+        let mut discord = None;
+
+        for arg in args {
+            if let Some(id) = matcher::get_mention_user(arg) {
+                discord = Some(id);
+            } else {
+                name = Some(arg.into());
+            }
+        }
+
+        Self {
+            mode,
+            name,
+            discord,
+        }
+    }
+}
+
+#[command]
+#[desc(GRAPH_SNIPED_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Osu)]
+async fn prefix_graphsniped(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphSniped::args(None, args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Sniped(args)).await
+}
+
+#[command]
+#[desc(GRAPH_SNIPED_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[aliases("graphsnipedcatch")]
+#[group(Catch)]
+async fn prefix_graphsnipedctb(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphSniped::args(Some(SnipeGameMode::Catch), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Sniped(args)).await
+}
+
+#[command]
+#[desc(GRAPH_SNIPED_DESC)]
+#[usage("[username]")]
+#[examples("peppy")]
+#[group(Mania)]
+async fn prefix_graphsnipedmania(
+    msg: &Message,
+    args: Args<'_>,
+    perms: Option<Permissions>,
+) -> Result<()> {
+    let args = GraphSniped::args(Some(SnipeGameMode::Mania), args);
+    let orig = CommandOrigin::from_msg(msg, perms);
+
+    super::graph(orig, Graph::Sniped(args)).await
+}
 
 pub async fn sniped_graph(
     orig: &CommandOrigin<'_>,

--- a/bathbot/src/commands/osu/graphs/sniped.rs
+++ b/bathbot/src/commands/osu/graphs/sniped.rs
@@ -1,15 +1,15 @@
 use bathbot_macros::command;
-use bathbot_util::{constants::GENERAL_ISSUE, matcher, MessageBuilder};
+use bathbot_util::{MessageBuilder, constants::GENERAL_ISSUE, matcher};
 use eyre::{Report, Result};
 use rosu_v2::{model::GameMode, prelude::OsuError, request::UserId};
 use twilight_model::guild::Permissions;
 
 use super::{Graph, GraphSniped, H, W};
 use crate::{
-    commands::osu::{graphs::GRAPH_SNIPED_DESC, sniped, user_not_found, SnipeGameMode},
+    commands::osu::{SnipeGameMode, graphs::GRAPH_SNIPED_DESC, sniped, user_not_found},
     core::{
-        commands::{prefix::Args, CommandOrigin},
         Context,
+        commands::{CommandOrigin, prefix::Args},
     },
     manager::redis::osu::{CachedUser, UserArgs, UserArgsError},
 };

--- a/bathbot/src/commands/osu/match_live.rs
+++ b/bathbot/src/commands/osu/match_live.rs
@@ -70,7 +70,7 @@ async fn slash_matchlive(mut command: InteractionCommand) -> Result<()> {
 )]
 #[usage("[match url / match id]")]
 #[examples("58320988", "https://osu.ppy.sh/community/matches/58320988")]
-#[alias("ml", "mla", "matchliveadd", "mlt", "matchlivetrack")]
+#[alias("mla", "matchliveadd", "mlt", "matchlivetrack")]
 #[bucket(MatchLive)]
 #[flags(AUTHORITY)]
 #[group(AllModes)]

--- a/bathbot/src/commands/osu/medals/mod.rs
+++ b/bathbot/src/commands/osu/medals/mod.rs
@@ -148,8 +148,10 @@ struct MedalInfo_<'a> {
     name: AutocompleteValue<Cow<'a, str>>,
 }
 
+const MEDAL_LIST_DESC: &str = "List all achieved medals of a user";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(name = "list", desc = "List all achieved medals of a user")]
+#[command(name = "list", desc = MEDAL_LIST_DESC)]
 pub struct MedalList<'a> {
     #[command(desc = "Specify a username")]
     name: Option<Cow<'a, str>>,
@@ -168,23 +170,17 @@ pub struct MedalList<'a> {
     discord: Option<Id<UserMarker>>,
 }
 
-#[derive(CommandOption, CreateOption)]
+#[derive(CommandOption, CreateOption, Default)]
 pub enum MedalListOrder {
     #[option(name = "Alphabetically", value = "alphabet")]
     Alphabet,
     #[option(name = "Date", value = "date")]
+    #[default]
     Date,
     #[option(name = "Medal ID", value = "medal_id")]
     MedalId,
     #[option(name = "Rarity", value = "rarity")]
     Rarity,
-}
-
-impl Default for MedalListOrder {
-    #[inline]
-    fn default() -> Self {
-        Self::Date
-    }
 }
 
 #[derive(CommandModel, CreateCommand, Default, HasName)]

--- a/bathbot/src/commands/osu/relax/mod.rs
+++ b/bathbot/src/commands/osu/relax/mod.rs
@@ -33,12 +33,12 @@ pub enum Relax<'a> {
     Top(RelaxTop<'a>),
 }
 
+const RX_PROFILE_DESC: &str = "Show user's relax profile";
+const RX_PROFILE_HELP: &str =
+    "Show user's relax profile, as provided by [Relaxation Vault](https://rx.stanr.info/)";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(
-    name = "profile",
-    desc = "Show user's relax profile",
-    help = "Show user's relax profile, as provided by [Relaxation Vault](https://rx.stanr.info/)"
-)]
+#[command(name = "profile", desc = RX_PROFILE_DESC, help = RX_PROFILE_HELP)]
 pub struct RelaxProfile<'a> {
     #[command(desc = "Specify a username")]
     name: Option<Cow<'a, str>>,
@@ -51,12 +51,12 @@ pub struct RelaxProfile<'a> {
     discord: Option<Id<UserMarker>>,
 }
 
+const RX_TOP_DESC: &str = "Show user's relax top plays";
+const RX_TOP_HELP: &str =
+    "Show user's relax top plays, as provided by [Relaxation Vault](https://rx.stanr.info/)";
+
 #[derive(CommandModel, CreateCommand, HasName)]
-#[command(
-    name = "top",
-    desc = "Show user's relax top plays",
-    help = "Show user's relax top plays, as provided by [Relaxation Vault](https://rx.stanr.info/)"
-)]
+#[command(name = "top", desc = RX_TOP_DESC, help = RX_TOP_HELP)]
 pub struct RelaxTop<'a> {
     #[command(desc = "Specify a username")]
     name: Option<Cow<'a, str>>,


### PR DESCRIPTION
Closes #955 

Prefix versions generally don't offer many arguments which is fine because users can use the slash commands for more detailed usage.

Not all slash commands got a prefix version. Some because they rely on ephemerality, other because they rely on too many arguments, and others because they were just too annoying.