### PR TITLE
feat: use ordr preset render settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1066,7 +1066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1659,7 +1659,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2901,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "rosu-render"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edf7ac1246417c254ad33011d81c0ef96ba0fddc108413f9c03672ace6fb575"
+checksum = "1346f6d7d57195f2b0a02682f76d15bb1788203caeb2081ef2db4efceb73cb00"
 dependencies = [
  "bytes",
  "fastrand",
@@ -3008,7 +3008,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4512,7 +4512,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/bathbot-util/src/numbers.rs
+++ b/bathbot-util/src/numbers.rs
@@ -155,7 +155,7 @@ impl_with_comma!(@INT: i16 > 1032 -> i32, i32 > 1_000_000_002 -> i64, i64, isize
 impl_with_comma!(@UINT: u16 > 1065 -> u32, u32 > 1_000_000_004 -> u64, u64, usize);
 
 pub fn last_multiple(per_page: usize, total: usize) -> usize {
-    if per_page <= total && total % per_page == 0 {
+    if per_page <= total && total.is_multiple_of(per_page) {
         total - per_page
     } else {
         total - total % per_page

--- a/bathbot/Cargo.toml
+++ b/bathbot/Cargo.toml
@@ -48,7 +48,7 @@ rosu-v2 = { workspace = true }
 rosu-pp-older = { git = "https://github.com/MaxOhn/rosu-pp-older.git", branch = "main" }
 # rosu-pp-older = { path = "../../rosu-pp-older" }
 # rosu-render = { git = "https://github.com/MaxOhn/rosu-render", branch = "main", default-features = false, features = ["rustls-webpki-roots"] }
-rosu-render = { version = "0.4.0", default-features = false, features = ["rustls-webpki-roots"] }
+rosu-render = { version = "0.5.1", default-features = false, features = ["rustls-webpki-roots"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 smallvec = { version = "1.0" }

--- a/bathbot/src/active/impls/render/import.rs
+++ b/bathbot/src/active/impls/render/import.rs
@@ -253,7 +253,7 @@ impl IActiveMessage for SettingsImport {
                     Ok(mut skin_list) => {
                         let skin = skin_list.skins.swap_remove(0);
 
-                        ReplaySettings::new_with_official_skin(options, skin)
+                        ReplaySettings::new_with_official_skin(options, skin, user)
                     }
                     Err(err) => {
                         self.import_result = ImportResult::Err(
@@ -265,7 +265,7 @@ impl IActiveMessage for SettingsImport {
                 }
             }
             RenderSkinOption::Custom { ref id } => match ordr.custom_skin_info(*id).await {
-                Ok(info) => ReplaySettings::new_with_custom_skin(options, info, *id),
+                Ok(info) => ReplaySettings::new_with_custom_skin(options, info, *id, user),
                 Err(err) => {
                     self.import_result = ImportResult::Err(
                         Report::new(err).wrap_err("Failed to request custom skin"),

--- a/bathbot/src/commands/osu/render.rs
+++ b/bathbot/src/commands/osu/render.rs
@@ -72,7 +72,14 @@ pub struct RenderScore {
 }
 
 #[derive(CommandModel, CreateCommand)]
-#[command(name = "settings", desc = "Adjust your o!rdr render settings")]
+#[command(
+    name = "settings",
+    desc = "Adjust your o!rdr render settings",
+    help = "Adjust your o!rdr render settings.\n\
+    Note: You might want to configure your settings on the ordr website and use \
+    that as preset. If a preset on your ordr account is available for your \
+    linked discord account, it will always overwrite your settings here."
+)]
 pub enum RenderSettings {
     #[command(name = "modify")]
     Modify(RenderSettingsModify),
@@ -604,6 +611,8 @@ impl OngoingRender {
                 progress = self.receivers.progress.recv() => {
                     let now = Instant::now();
 
+                    debug!("Got progress: {progress:?}");
+
                     if last_update + INTERVAL > now {
                         continue;
                     }
@@ -613,7 +622,6 @@ impl OngoingRender {
                     let Some(progress) = progress else {
                         return warn!("progress channel was closed");
                     };
-
 
                     self.status.set(RenderStatusInner::Rendering(progress.progress));
                     let builder = self.status.as_message();
@@ -825,7 +833,7 @@ async fn render_settings_default(command: &mut InteractionCommand) -> Result<()>
 
     let owner = command.user_id()?;
     let replay_manager = Context::replay();
-    let settings = ReplaySettings::default();
+    let settings = ReplaySettings::new_default(owner);
 
     if let Err(err) = replay_manager.set_settings(owner, &settings).await {
         let _ = command.error(GENERAL_ISSUE).await;

--- a/bathbot/src/tracking/ordr/mod.rs
+++ b/bathbot/src/tracking/ordr/mod.rs
@@ -88,6 +88,8 @@ impl Ordr {
     }
 
     pub async fn subscribe_render_id(&self, render_id: u32) -> OrdrReceivers {
+        debug!(render_id, "Subscribing");
+
         let (done_tx, done_rx) = mpsc::channel(1);
         let (failed_tx, failed_rx) = mpsc::channel(1);
         let (progress_tx, progress_rx) = mpsc::channel(4);
@@ -110,6 +112,8 @@ impl Ordr {
     }
 
     pub async fn unsubscribe_render_id(&self, render_id: u32) {
+        debug!(render_id, "Unsubscribing");
+
         self.senders.own(RenderId(render_id)).await.remove();
     }
 }


### PR DESCRIPTION
Now always adds the discord user's id into render requests. If they have their discord account linked on ordr and configured settings that are available for verified bots, those settings will always be used instead of the ones configured in Bathbot.