### PR TITLE
refactor: remove links to full beatmap backgrounds

### DIFF
--- a/bathbot/src/active/impls/bg_game/game.rs
+++ b/bathbot/src/active/impls/bg_game/game.rs
@@ -186,8 +186,7 @@ pub async fn game_loop(
             ContentResult::Title(exact) => {
                 let content = format!(
                     "{} \\:)\n\
-                    Mapset: {OSU_BASE}beatmapsets/{mapset_id}\n\
-                    Full background: https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg",
+                    Mapset: {OSU_BASE}beatmapsets/{mapset_id}",
                     if exact {
                         format!("Gratz {}, you guessed it", msg.author.name)
                     } else {

--- a/bathbot/src/active/impls/bg_game/game_wrapper.rs
+++ b/bathbot/src/active/impls/bg_game/game_wrapper.rs
@@ -76,10 +76,7 @@ impl BackgroundGame {
                         let mapset_id = game_clone.read().await.mapset_id();
 
                         // Send message
-                        let content = format!(
-                            "Mapset: {OSU_BASE}beatmapsets/{mapset_id}\n\
-                            Full background: https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg"
-                        );
+                        let content = format!("Mapset: {OSU_BASE}beatmapsets/{mapset_id}");
 
                         if let Err(err) = channel.plain_message(&content).await {
                             warn!(?err, "Failed to show resolve for bg game restart");
@@ -91,7 +88,6 @@ impl BackgroundGame {
                         // Send message
                         let content = format!(
                             "Mapset: {OSU_BASE}beatmapsets/{mapset_id}\n\
-                            Full background: https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg\n\
                             End of game, see you next time o/"
                         );
 

--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -490,8 +490,7 @@ impl BookmarksPagination {
         let footer = FooterBuilder::new(footer_text).icon_url(format!("{AVATAR_URL}{mapper_id}"));
 
         let mut description = format!(
-            ":musical_note: [Song preview](https://b.ppy.sh/preview/{mapset_id}.mp3) \
-            :frame_photo: [Full background](https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg)",
+            ":musical_note: [Song preview](https://b.ppy.sh/preview/{mapset_id}.mp3)",
             mapset_id = map.mapset_id
         );
 

--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -272,8 +272,7 @@ impl IActiveMessage for MapPagination {
         let image = attachment("map_graph.png");
 
         let mut description = format!(
-            ":musical_note: [Song preview](https://b.ppy.sh/preview/{mapset_id}.mp3) \
-            :frame_photo: [Full background](https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg)",
+            ":musical_note: [Song preview](https://b.ppy.sh/preview/{mapset_id}.mp3)",
             mapset_id = self.mapset.mapset_id
         );
 

--- a/bathbot/src/commands/osu/daily_challenge/today.rs
+++ b/bathbot/src/commands/osu/daily_challenge/today.rs
@@ -139,8 +139,7 @@ impl DailyChallengeDay {
         };
 
         let mut description = format!(
-            "\n:musical_note: [Song preview](https://b.ppy.sh/preview/{mapset_id}.mp3) \
-            :frame_photo: [Full background](https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg)",
+            "\n:musical_note: [Song preview](https://b.ppy.sh/preview/{mapset_id}.mp3)",
             mapset_id = playlist_map.mapset_id.to_native(),
         );
 


### PR DESCRIPTION
As of 29th of October, `https://assets.ppy.sh/beatmaps/{mapset_id}/covers/raw.jpg` is deprecated in favour of `https://assets.ppy.sh/beatmaps/{mapset_id}/covers/fullsize.jpg`. However, from my understanding, usage of fullsize.jpg is either a bannable offense outright or is at least heavily discouraged as one. As of now, all the existing raw.jpg links are 404-ing

This PR removes all existing references to this endpoint