### PR TITLE
feat: add support for mods, rates and custom attributes for /map

### DIFF
--- a/bathbot/src/active/impls/map.rs
+++ b/bathbot/src/active/impls/map.rs
@@ -439,7 +439,6 @@ impl IActiveMessage for MapPagination {
         }
 
         if component.data.custom_id.starts_with("pagination") {
-            debug!("Hit pagination");
             return handle_pagination_component(component, self.msg_owner, true, &mut self.pages)
                 .await;
         }
@@ -575,7 +574,6 @@ impl IActiveMessage for MapPagination {
             "map_speed_adjustments" => {
                 self.attrs.clock_rate = parse_attr(&*modal, "map_clock_rate");
                 self.attrs.bpm = parse_attr(modal, "map_bpm");
-                debug!(?self.attrs);
             }
             other => warn!(name = %other, ?modal, "Unknown map modal"),
         }
@@ -627,7 +625,6 @@ fn parse_attr<T: std::str::FromStr + std::fmt::Debug>(
         .find_map(|row| {
             row.components.first().and_then(|component| {
                 (component.custom_id == component_id).then(|| {
-                    debug!("Parsing row {:?}", component.custom_id);
                     component
                         .value
                         .as_deref()
@@ -638,6 +635,5 @@ fn parse_attr<T: std::str::FromStr + std::fmt::Debug>(
             })
         })
         .flatten();
-    debug!("Result: {:?}", result);
     result
 }

--- a/bathbot/src/active/mod.rs
+++ b/bathbot/src/active/mod.rs
@@ -277,7 +277,7 @@ impl ActiveMessages {
 
                             return error!(
                                 name = %modal.data.custom_id,
-                                %err,
+                                ?err,
                                 "Failed to update modal",
                             );
                         }


### PR DESCRIPTION
Closes #816 
Closes #994 

Adds support for clock rate being passed as a parameter on top of adding support for editing CR, mods and attributes using modals a la /simulate. The logic of modals is largely taken from /simulate, however pagination (custom page button specifically) is handled in-line as of now for purposes of readability (and due to me being slightly silly)

<img width="509" height="598" alt="image" src="https://github.com/user-attachments/assets/2d7d3b10-6477-4a22-80a2-b38030bbef43" />

<img width="510" height="599" alt="image" src="https://github.com/user-attachments/assets/3f8b7bbe-ec24-4240-b5f5-ac3c25ae9435" />
