### PR TITLE
fix: add ability to ignore suspicion checks

### DIFF
--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -239,6 +239,7 @@ async fn card(orig: CommandOrigin<'_>, args: Card<'_>) -> Result<()> {
             let difficulty = Context::pp_parsed(&map, mode)
                 .lazer(score.set_on_lazer)
                 .mods(score.mods.clone())
+                .ignore_suspicion_checks()
                 .difficulty()
                 .await
                 .expect("suspicious maps in top scores are a false positive")

--- a/bathbot/src/manager/pp.rs
+++ b/bathbot/src/manager/pp.rs
@@ -20,6 +20,7 @@ pub struct PpManager<'m> {
     attrs: Option<DifficultyAttributes>,
     mods: Mods,
     state: Option<ScoreState>,
+    check_suspicion: bool,
     partial: bool,
     lazer: bool,
 }
@@ -37,6 +38,7 @@ impl<'m> PpManager<'m> {
             attrs: None,
             mods: Mods::default(),
             state: None,
+            check_suspicion: true,
             partial: false,
             lazer: true,
         }
@@ -108,6 +110,13 @@ impl<'m> PpManager<'m> {
         inner(self, score.into())
     }
 
+    /// Disable suspicion checks
+    pub fn ignore_suspicion_checks(mut self) -> Self {
+        self.check_suspicion = false;
+
+        self
+    }
+
     /// Be sure the attributes match the map and difficulty parameters!
     pub fn set_difficulty(&mut self, attrs: DifficultyAttributes) {
         self.attrs = Some(attrs);
@@ -123,7 +132,7 @@ impl<'m> PpManager<'m> {
             }
         }
 
-        if self.map.check_suspicion().is_err() {
+        if self.check_suspicion && self.map.check_suspicion().is_err() {
             return None;
         }
 


### PR DESCRIPTION
Closes #1086

Adds a builder method for PpManager that allows ignoring suspicion checks. The default is still at `true` so this does not require any changes. As a PoC, removed them from /card for #1086, though I cannot reproduce the initial issue (I assume the suspicion check itself was adjusted?)