### PR TITLE
fix: add a top length check to /whatif

### DIFF
--- a/bathbot/src/commands/osu/whatif.rs
+++ b/bathbot/src/commands/osu/whatif.rs
@@ -235,7 +235,7 @@ async fn whatif(orig: CommandOrigin<'_>, args: WhatIf<'_>) -> Result<()> {
         };
 
         WhatIfData::NoScores { count, rank }
-    } else if pp < scores.last().and_then(|s| s.pp).unwrap_or(0.0) {
+    } else if scores.len() == 200 && pp < scores.last().and_then(|s| s.pp).unwrap_or(0.0) {
         WhatIfData::NonTop200
     } else {
         let mut pps = scores.extract_pp();


### PR DESCRIPTION
Closes #1071

Simple one - adds a direct length == 200 check to the whatif command to allows users with incomplete tops to use the command. Doubt there is a better way to handle this.

The only issue is if the top length is ever expanded again, this will break, which is mildly concerning but should be a very quick patch, so let's hope for some peace :D