### PR TITLE
refactor: log suspicion fails

### DIFF
--- a/bathbot/src/active/impls/bookmarks.rs
+++ b/bathbot/src/active/impls/bookmarks.rs
@@ -190,7 +190,7 @@ impl BookmarksPagination {
             let mut max_pp = 0.0;
 
             if let Some(pp_map) = pp_map {
-                let attrs_opt = Context::pp_parsed(pp_map, map.mode)
+                let attrs_opt = Context::pp_parsed(pp_map, map.map_id, map.mode)
                     .lazer(true)
                     .performance()
                     .await;
@@ -262,7 +262,7 @@ impl BookmarksPagination {
             let mut pp_97 = 0.0;
 
             if let Some(pp_map) = pp_map {
-                let attrs_opt = Context::pp_parsed(pp_map, map.mode)
+                let attrs_opt = Context::pp_parsed(pp_map, map.map_id, map.mode)
                     .lazer(true)
                     .performance()
                     .await;

--- a/bathbot/src/active/impls/snipe/difference.rs
+++ b/bathbot/src/active/impls/snipe/difference.rs
@@ -67,7 +67,7 @@ impl IActiveMessage for SnipeDifferencePagination {
                             .await
                             .wrap_err("Failed to get pp map")?;
 
-                        let stars = Context::pp_parsed(&map, GameMode::Osu)
+                        let stars = Context::pp_parsed(&map, score.map_id, GameMode::Osu)
                             .difficulty()
                             .await
                             .map_or(0.0, DifficultyAttributes::stars);

--- a/bathbot/src/commands/osu/cards.rs
+++ b/bathbot/src/commands/osu/cards.rs
@@ -236,7 +236,7 @@ async fn card(orig: CommandOrigin<'_>, args: Card<'_>) -> Result<()> {
                 .await
                 .wrap_err("Failed to get pp map")?;
 
-            let difficulty = Context::pp_parsed(&map, mode)
+            let difficulty = Context::pp_parsed(&map, score.map_id, mode)
                 .lazer(score.set_on_lazer)
                 .mods(score.mods.clone())
                 .difficulty()

--- a/bathbot/src/commands/osu/recent/list.rs
+++ b/bathbot/src/commands/osu/recent/list.rs
@@ -572,7 +572,7 @@ async fn process_scores(
             stars = attrs.stars() as f32;
             max_combo = attrs.max_combo();
 
-            let mut calc = Context::pp_parsed(pp_map, score.mode)
+            let mut calc = Context::pp_parsed(pp_map, score.map_id, score.mode)
                 .mode(score.mode)
                 .mods(score.mods.clone())
                 .lazer(score.set_on_lazer);

--- a/bathbot/src/core/context/manager.rs
+++ b/bathbot/src/core/context/manager.rs
@@ -27,8 +27,8 @@ impl Context {
         PpManager::new(map)
     }
 
-    pub fn pp_parsed(map: &Beatmap, mode: GameMode) -> PpManager<'_> {
-        PpManager::from_parsed(map).mode(mode)
+    pub fn pp_parsed(map: &Beatmap, map_id: u32, mode: GameMode) -> PpManager<'_> {
+        PpManager::from_parsed(map, map_id).mode(mode)
     }
 
     pub fn approx() -> ApproxManager {

--- a/bathbot/src/core/context/mod.rs
+++ b/bathbot/src/core/context/mod.rs
@@ -239,7 +239,14 @@ impl Context {
 
         let ordr = match tokio::time::timeout(Duration::from_secs(20), ordr_fut).await {
             Ok(Ok(ordr)) => Some(Arc::new(ordr)),
-            Ok(Err(err)) => return Err(err),
+            Ok(Err(err)) => {
+                error!(
+                    ?err,
+                    "Failed to create ordr client, initializing without it"
+                );
+
+                None
+            }
             Err(_) => {
                 warn!("o!rdr timed out, initializing without it");
 

--- a/bathbot/src/manager/osu_map.rs
+++ b/bathbot/src/manager/osu_map.rs
@@ -90,7 +90,7 @@ impl MapManager {
         ) -> Result<Option<DifficultyAttributes>> {
             let map = this.pp_map(map_id).await.wrap_err("Failed to get pp map")?;
 
-            let attrs = PpManager::from_parsed(&map)
+            let attrs = PpManager::from_parsed(&map, map_id)
                 .mode(mode)
                 .mods(mods)
                 .difficulty()

--- a/bathbot/src/manager/pp.rs
+++ b/bathbot/src/manager/pp.rs
@@ -17,6 +17,7 @@ use crate::commands::{osu::LeaderboardScore, utility::ScoreEmbedDataRaw};
 #[derive(Clone)]
 pub struct PpManager<'m> {
     map: Cow<'m, Beatmap>,
+    map_id: u32,
     attrs: Option<DifficultyAttributes>,
     mods: Mods,
     state: Option<ScoreState>,
@@ -26,14 +27,15 @@ pub struct PpManager<'m> {
 
 impl<'m> PpManager<'m> {
     pub fn new(map: &'m OsuMap) -> Self {
-        Self::from_parsed(&map.pp_map)
+        Self::from_parsed(&map.pp_map, map.map_id())
     }
 
-    pub fn from_parsed(map: &'m Beatmap) -> Self {
+    pub fn from_parsed(map: &'m Beatmap, map_id: u32) -> Self {
         // Cannot check for suspicion yet because the mode might still change
 
         Self {
             map: Cow::Borrowed(map),
+            map_id,
             attrs: None,
             mods: Mods::default(),
             state: None,
@@ -123,7 +125,16 @@ impl<'m> PpManager<'m> {
             return Some(attrs);
         }
 
-        if self.map.check_suspicion().is_err() {
+        if let Err(reason) = self.map.check_suspicion() {
+            warn!(
+                ?reason,
+                map_id = self.map_id,
+                mods = ?self.mods.inner,
+                clock_rate = self.mods.clock_rate,
+                lazer = self.lazer,
+                "Suspicion check failed",
+            );
+
             return None;
         }
 
@@ -308,7 +319,7 @@ fn stats_to_state(max_combo: u32, mode: GameMode, stats: &ScoreStatistics) -> Sc
 }
 
 /// Mods with an optional custom clock rate.
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Mods {
     pub inner: rosu_pp::GameMods,
     pub clock_rate: Option<f64>,


### PR DESCRIPTION
Closes #1086

Failed suspicion checks will still prevent the command from working which will make flaws in the suspicion heuristic obvious and the added logging should provide sufficient context.