### PR TITLE
Include o!rdr error message and reason in error output

### DIFF
--- a/bathbot/src/active/impls/render/cached.rs
+++ b/bathbot/src/active/impls/render/cached.rs
@@ -194,11 +194,17 @@ impl CachedRender {
                     OrdrError::Response {
                         error:
                             OrdrApiError {
-                                code: Some(code), ..
+                                code: Some(code),
+                                ref message,
+                                reason,
                             },
                         ..
                     } => (
-                        format!("Error code {int} from o!rdr: {code}", int = code.to_u8()),
+                        if let Some(ref reason) = reason {
+                            format!("Error code {int} from o!rdr: {message}\nReason: {reason}", int = code.to_u8())
+                        } else {
+                            format!("Error code {int} from o!rdr: {message}", int = code.to_u8())
+                        },
                         None,
                     ),
                     err => (ORDR_ISSUE.to_owned(), Some(err)),

--- a/bathbot/src/active/impls/single_score.rs
+++ b/bathbot/src/active/impls/single_score.rs
@@ -408,10 +408,18 @@ impl SingleScorePagination {
                     OrdrError::Response {
                         error:
                             OrdrApiError {
-                                code: Some(code), ..
+                                code: Some(code),
+                                ref message,
+                                reason,
                             },
                         ..
-                    } => format!("Error code {int} from o!rdr: {code}", int = code.to_u8()),
+                    } => {
+                        if let Some(ref reason) = reason {
+                            format!("Error code {int} from o!rdr: {message}\nReason: {reason}", int = code.to_u8())
+                        } else {
+                            format!("Error code {int} from o!rdr: {message}", int = code.to_u8())
+                        }
+                    },
                     err => {
                         error!(?err, "Failed to commission render");
 

--- a/bathbot/src/commands/osu/render.rs
+++ b/bathbot/src/commands/osu/render.rs
@@ -193,12 +193,17 @@ async fn render_replay(command: InteractionCommand, replay: RenderReplay) -> Res
                 OrdrError::Response {
                     error:
                         OrdrApiError {
-                            code: Some(code), ..
+                            code: Some(code),
+                            ref message,
+                            reason,
                         },
                     ..
                 } => {
-                    let content =
-                        format!("Error code {int} from o!rdr: {code}", int = code.to_u8());
+                    let content = if let Some(ref reason) = reason {
+                        format!("Error code {int} from o!rdr: {message}\nReason: {reason}", int = code.to_u8())
+                    } else {
+                        format!("Error code {int} from o!rdr: {message}", int = code.to_u8())
+                    };
                     command.error(content).await?;
 
                     Ok(())
@@ -374,11 +379,17 @@ async fn render_score(mut command: InteractionCommand, score: RenderScore) -> Re
         Ok(render) => render,
         Err(OrdrError::Response {
             error: OrdrApiError {
-                code: Some(code), ..
+                code: Some(code),
+                ref message,
+                reason,
             },
             ..
         }) => {
-            let content = format!("Error code {int} from o!rdr: {code}", int = code.to_u8());
+            let content = if let Some(ref reason) = reason {
+                format!("Error code {int} from o!rdr: {message}\nReason: {reason}", int = code.to_u8())
+            } else {
+                format!("Error code {int} from o!rdr: {message}", int = code.to_u8())
+            };
             command.error(content).await?;
 
             return Ok(());


### PR DESCRIPTION
This should close #1120 

Tested locally and seems to display as expected.

<img width="653" height="172" alt="Discord 2026-07-06 16 55 39" src="https://github.com/user-attachments/assets/c5e48dc4-9159-481b-afdc-ccd11f73a708" />
