### PR TITLE
fix: no longer goes to the api endpoint of osekai when clicking profile in medals stats

### DIFF
--- a/bathbot/src/embeds/osu/medal_stats.rs
+++ b/bathbot/src/embeds/osu/medal_stats.rs
@@ -117,7 +117,7 @@ impl MedalStatsEmbed {
         let user_id = user.user_id.to_native();
 
         let author = AuthorBuilder::new(username)
-            .url(format!("https://inex.osekai.net/api/profiles/{user_id}"))
+            .url(format!("https://osekai.net/profiles/?user={user_id}"))
             .icon_url(flag_url(country_code));
 
         let footer = FooterBuilder::new("Check osekai.net for more info");


### PR DESCRIPTION
…le in medals stats